### PR TITLE
feat: add a Nix flake for the Linux beta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /target
+/result
+/result-*
 /.venv
 /logs
 /perf/transcription-corpus

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,7 +349,9 @@ rustup default stable
 
 For a source install, run `scripts/install-linux.sh`, then `hex model install`.
 The installer owns the user-local version layout, desktop entry, and autostart
-entry; only that managed layout participates in automatic updates.
+entry; only that managed layout participates in automatic updates. A Nix
+flake packages the same Linux binary; it does not participate in app-managed
+updates.
 
 Automatic microphone selection follows the compiled preference order in
 `src/config.rs`, then falls back to the macOS default. A saved microphone takes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@ On macOS:
 ```
 
 Linux dependencies and installation are documented in
-[`docs/linux.md`](docs/linux.md).
+[`docs/linux.md`](docs/linux.md). On Nix, `nix develop` provides the native
+build inputs used by the flake.
 
 ## Validate Changes
 

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ Diagnostics are stored at:
 The Linux beta targets x86_64 Arch Linux on i3/X11. It supports local hotkey
 dictation, automatic paste, shortcut rebinding, a tray app, and user-local
 updates. It does not support voice commands, meetings, native Wayland, or a
-package-manager install.
+package-manager install. A Nix flake packages the same X11 binary.
 
 See the [Linux installation guide](docs/linux.md) for the verified user-local
-installer, source-build fallback, requirements, and limitations.
+installer, source-build fallback, Nix flake, requirements, and limitations.
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ override shipped behavior.
 ## User Guides
 
 - [`../README.md`](../README.md): install and use HEX on macOS.
-- [`linux.md`](linux.md): install the supported Linux X11 beta from source.
+- [`linux.md`](linux.md): install the supported Linux X11 beta from source or Nix.
 - [`../ios/README.md`](../ios/README.md): build and test the iOS prototype.
 
 ## Engineering Reference

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -5,7 +5,8 @@ X11. Audio uses ALSA, including PipeWire systems with ALSA compatibility.
 Inference uses Vulkan when available and can fall back to the CPU.
 
 The beta does not support voice commands, application or browser context,
-meetings, native Wayland, or package-manager installation.
+meetings, native Wayland, or package-manager installation. A Nix flake
+packages the same X11 binary for `nix build` / `nix run`.
 
 ## Install A Published Build
 
@@ -58,6 +59,22 @@ cd hex
 
 Do not run the installer as root. It installs a user-local binary, desktop
 launcher, and autostart entry.
+
+## Install With Nix
+
+The flake packages the Linux X11 beta. It does not change the desktop
+contract. The Nix package is not the user-local managed layout, so HEX does
+not apply its signed in-app updater.
+
+```sh
+nix build
+nix run . -- model install
+nix run . -- app
+```
+
+`nix develop` provides the native build inputs. Optional NixOS and Home
+Manager modules are `hex.nixosModules.hex` and `hex.homeManagerModules.hex`.
+After install, run `hex model install` once, then `hex app`.
 
 ## Dictate
 

--- a/docs/plans/linux.md
+++ b/docs/plans/linux.md
@@ -118,9 +118,11 @@ daemon.
 
 ### 6. Add Distribution Channels Deliberately
 
-The app-managed updater owns only the user-local direct-install layout. A future
-Arch package must leave updates to the package manager. Add architectures,
-distros, or package formats one validated channel at a time.
+The app-managed updater owns only the user-local direct-install layout. A
+future Arch package must leave updates to the package manager. The Nix flake
+is a source package of the same X11 beta and does not participate in
+app-managed updates. Add architectures, distros, or package formats one
+validated channel at a time.
 
 ## Preserve The Portable Core
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "HEX local-first voice dictation";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      hex = pkgs.callPackage ./nix/package.nix { };
+    in
+    {
+      packages.${system} = {
+        inherit hex;
+        default = hex;
+      };
+
+      overlays.default = final: _prev: {
+        hex = final.callPackage ./nix/package.nix { };
+      };
+
+      nixosModules.hex = {
+        imports = [ ./nix/module.nix ];
+        programs.hex.package = nixpkgs.lib.mkDefault self.packages.${system}.hex;
+      };
+      nixosModules.default = self.nixosModules.hex;
+
+      homeManagerModules.hex = {
+        imports = [ ./nix/hm-module.nix ];
+        programs.hex.package = nixpkgs.lib.mkDefault self.packages.${system}.hex;
+      };
+      homeManagerModules.default = self.homeManagerModules.hex;
+
+      devShells.${system}.default = pkgs.mkShell {
+        inputsFrom = [ hex ];
+        packages = with pkgs; [
+          rustc
+          cargo
+          rust-analyzer
+          rustfmt
+          clippy
+        ];
+      };
+
+      formatter.${system} = pkgs.nixfmt;
+    };
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -19,24 +19,24 @@ in
     autostart = lib.mkOption {
       type = lib.types.bool;
       default = false;
-      description = "Start HEX hidden in the tray when the graphical session starts.";
+      description = "Start HEX with the graphical session.";
     };
   };
 
   config = lib.mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    xdg.configFile."autostart/HEX.desktop" = lib.mkIf cfg.autostart {
-      text = ''
-        [Desktop Entry]
-        Type=Application
-        Name=HEX
-        Comment=Local voice dictation
-        Exec=${lib.getExe cfg.package} app --hidden
-        Icon=audio-input-microphone
-        Terminal=false
-        X-GNOME-Autostart-enabled=true
-      '';
+    systemd.user.services.hex = lib.mkIf cfg.autostart {
+      Unit = {
+        Description = "HEX local voice dictation";
+        After = [ "graphical-session.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+      Service = {
+        ExecStart = "${lib.getExe cfg.package} app --hidden";
+        Restart = "on-failure";
+      };
+      Install.WantedBy = [ "graphical-session.target" ];
     };
   };
 }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,42 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.hex;
+in
+{
+  options.programs.hex = {
+    enable = lib.mkEnableOption "HEX local voice dictation";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "HEX package to install.";
+    };
+
+    autostart = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Start HEX hidden in the tray when the graphical session starts.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    xdg.configFile."autostart/HEX.desktop" = lib.mkIf cfg.autostart {
+      text = ''
+        [Desktop Entry]
+        Type=Application
+        Name=HEX
+        Comment=Local voice dictation
+        Exec=${lib.getExe cfg.package} app --hidden
+        Icon=audio-input-microphone
+        Terminal=false
+        X-GNOME-Autostart-enabled=true
+      '';
+    };
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,23 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.programs.hex;
+in
+{
+  options.programs.hex = {
+    enable = lib.mkEnableOption "HEX local voice dictation";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "HEX package to install.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -10,15 +10,19 @@
   spirv-headers,
   openblas,
   gtk3,
+  gtk-layer-shell,
   libayatana-appindicator,
   alsa-lib,
   alsa-plugins,
   pipewire,
   openssl,
   libxkbcommon,
+  wayland,
   fontconfig,
   freetype,
   curl,
+  wl-clipboard,
+  wtype,
   wrapGAppsHook3,
   autoAddDriverRunpath,
   makeWrapper,
@@ -80,10 +84,12 @@ rustPlatform.buildRustPackage {
     spirv-headers
     openblas
     gtk3
+    gtk-layer-shell
     libayatana-appindicator
     alsa-lib
     openssl
     libxkbcommon
+    wayland
     fontconfig
     freetype
     libx11
@@ -113,11 +119,18 @@ rustPlatform.buildRustPackage {
 
   preFixup = ''
     gappsWrapperArgs+=(
-      --prefix PATH : ${lib.makeBinPath [ curl ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          curl
+          wl-clipboard
+          wtype
+        ]
+      }
       --prefix LD_LIBRARY_PATH : ${
         lib.makeLibraryPath [
           vulkan-loader
           libayatana-appindicator
+          gtk-layer-shell
           openblas
           alsa-lib
         ]

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,141 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  cmake,
+  python3,
+  shaderc,
+  vulkan-headers,
+  vulkan-loader,
+  spirv-headers,
+  openblas,
+  gtk3,
+  libayatana-appindicator,
+  alsa-lib,
+  alsa-plugins,
+  pipewire,
+  openssl,
+  libxkbcommon,
+  fontconfig,
+  freetype,
+  curl,
+  wrapGAppsHook3,
+  autoAddDriverRunpath,
+  makeWrapper,
+  symlinkJoin,
+  libx11,
+  libxcb,
+  libxcursor,
+  libxrandr,
+  libxi,
+}:
+
+let
+  alsaPluginDir = symlinkJoin {
+    name = "hex-alsa-plugins";
+    paths = [
+      "${pipewire}/lib/alsa-lib"
+      "${alsa-plugins}/lib/alsa-lib"
+    ];
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "hex";
+  version = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).package.version;
+
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../Cargo.toml
+      ../Cargo.lock
+      ../build.rs
+      ../src
+      ../native
+      ../resources
+      ../assets
+      ../packaging
+    ];
+  };
+
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+    outputHashes = {
+      "transcribe-rs-0.3.11" = "sha256-MJJiug3LfbKsuHcL2+LJk95+j5kk/MWzb5ihdBlHLmE=";
+    };
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    python3
+    shaderc
+    wrapGAppsHook3
+    autoAddDriverRunpath
+    makeWrapper
+  ];
+
+  buildInputs = [
+    vulkan-headers
+    vulkan-loader
+    spirv-headers
+    openblas
+    gtk3
+    libayatana-appindicator
+    alsa-lib
+    openssl
+    libxkbcommon
+    fontconfig
+    freetype
+    libx11
+    libxcb
+    libxcursor
+    libxrandr
+    libxi
+  ];
+
+  dontUseCmakeConfigure = true;
+  doCheck = false;
+
+  env = {
+    OPENSSL_NO_VENDOR = "1";
+    BLA_VENDOR = "OpenBLAS";
+    # build.rs emits -lopenblas before transcribe-cpp-sys, so GNU ld drops
+    # cblas_sgemm. Append the library after the static archives.
+    RUSTFLAGS = "-C link-arg=-lopenblas";
+  };
+
+  postInstall = ''
+    mv $out/bin/voice-control $out/bin/hex
+    install -Dm644 ${../packaging/hex.desktop} $out/share/applications/hex.desktop
+    substituteInPlace $out/share/applications/hex.desktop \
+      --replace-fail '@HEX_BIN@' "$out/bin/hex"
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [ curl ]}
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          vulkan-loader
+          libayatana-appindicator
+          openblas
+          alsa-lib
+        ]
+      }
+      --set ALSA_PLUGIN_DIR ${alsaPluginDir}
+    )
+  '';
+
+  meta = {
+    description = "Local-first voice dictation (Linux beta)";
+    longDescription = ''
+      HEX transcribes speech locally and pastes at the current focus.
+      This package is not the user-local managed layout, so HEX does not
+      apply its signed in-app updater.
+    '';
+    homepage = "https://github.com/anomalyco/hex";
+    license = lib.licenses.mit;
+    mainProgram = "hex";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Adds a proper nix flake + home-manager module.

Helped me with building and debugging #28.

Feel free to ignore, but this is a nice way to package the app and also provide a system service via systemd.