### PR TITLE
fix(desktop): repair history and shortcut behavior, refresh Rust dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,7 @@ cargo run -- preview onboarding
 cargo run -- preview transcription-picker --language zh --model-state installed
 ./scripts/capture-preview.sh /tmp/hex-preview.png settings
 ./scripts/capture-preview.sh /tmp/hex-model-missing.png settings --model-missing
+./scripts/capture-preview.sh /tmp/hex-history-retention.png history --open-history-retention
 ./scripts/capture-preview.sh /tmp/hex-modes.png modes
 ./scripts/capture-preview.sh /tmp/hex-modes-collapsed.png modes --collapse-mode-processing
 ./scripts/capture-preview.sh /tmp/hex-modes-picker.png modes --collapse-mode-processing --open-transformation-picker

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1085,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1095,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1107,14 +1107,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2050,7 +2050,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2292,7 +2292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2458,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "finl_unicode"
@@ -3923,7 +3923,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4175,9 +4175,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -4569,7 +4569,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4747,7 +4747,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5994,7 +5994,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6400,9 +6400,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6412,9 +6412,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6595,7 +6595,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6762,9 +6762,9 @@ dependencies = [
 
 [[package]]
 name = "screencapturekit"
-version = "8.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c549b1b0bc1ae3a536a88e3097d394234657402191e6867a3215bd897d43b9fd"
+checksum = "9ddaa8d6b16a2762c9a97c9a6297f04cb8ded0487e5ef02dc98b4e2bee3a26c7"
 dependencies = [
  "apple-cf",
  "apple-metal",
@@ -6827,9 +6827,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -6837,22 +6837,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6877,9 +6877,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
@@ -7139,7 +7139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7197,7 +7197,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7495,6 +7495,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7617,7 +7628,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7650,7 +7661,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8174,9 +8185,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
+checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -8190,7 +8201,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8246,7 +8257,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8541,7 +8552,7 @@ dependencies = [
  "dirs 6.0.0",
  "ed25519-dalek",
  "fs2",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "gpui",
  "gpui-symbols",
  "gtk",
@@ -8560,7 +8571,7 @@ dependencies = [
  "regex",
  "rodio",
  "rubato",
- "screencapturekit 8.0.0",
+ "screencapturekit 8.0.1",
  "semver",
  "serde",
  "serde_json",
@@ -8854,7 +8865,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ctrlc = "3.5.2"
 crossterm = "0.29.0"
 dirs = "6.0.0"
 fs2 = "0.4.3"
-getrandom = "0.3.4"
+getrandom = "0.4.3"
 hound = "3.5.1"
 libc = "0.2.177"
 libloading = "0.9.0"
@@ -57,7 +57,7 @@ objc2-foundation = "0.3.2"
 objc2-quartz-core = { version = "0.3.2", features = ["CALayer"] }
 objc2-service-management = { version = "0.3.2", features = ["SMAppService"] }
 raw-window-handle = "0.6.2"
-screencapturekit = { version = "=8.0.0", features = ["macos_15_0"] }
+screencapturekit = { version = "=8.0.1", features = ["macos_15_0"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 base64 = "0.22.1"

--- a/docs/releases/2.1.0.md
+++ b/docs/releases/2.1.0.md
@@ -10,6 +10,11 @@ there is no automatic migration or preference import.
   HEX downloads during setup.
 - A missing dictation model now shows a prominent notice with a model-picker
   action, including after onboarding, instead of leaving the shortcut unexplained.
+- History retention uses explicit choices rather than cycling through shorter
+  windows that could delete entries on the way to the desired setting.
+- Shortcut side changes reject conflicting bindings, and key-based dictation
+  shortcuts preserve spacing between consecutive dictations.
+- Onboarding blocks clicks on the controls behind it.
 - New installations default to NVIDIA Parakeet Unified English 0.6B. Existing
   explicitly selected transcription models remain unchanged.
 - Existing Rust settings and selected models remain unchanged. Swift settings,

--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -13,7 +13,7 @@ use gpui::{
     KeyDownEvent, Modifiers as GpuiModifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent,
     MouseMoveEvent, PathPromptOptions, Pixels, Point, Render, ScrollHandle, SharedString,
     Subscription, Timer, TitlebarOptions, Window, WindowBounds, WindowHandle, WindowOptions,
-    actions, div, img, prelude::*, px, relative, rgb, rgba, size,
+    actions, deferred, div, img, prelude::*, px, relative, rgb, rgba, size,
 };
 
 use crate::app_settings::{
@@ -250,6 +250,7 @@ pub struct AppWindowPreview {
     pub opencode_unavailable: bool,
     pub permissions_missing: bool,
     pub model_missing: bool,
+    pub open_history_retention: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -822,6 +823,7 @@ pub struct AppWindow {
     selected_history: Option<u64>,
     history_error: Option<String>,
     history_clear_armed: bool,
+    history_retention_open: bool,
     history_copied: Option<u64>,
 }
 
@@ -1262,6 +1264,9 @@ impl AppWindow {
             selected_history: None,
             history_error: None,
             history_clear_armed: false,
+            history_retention_open: preview
+                .as_ref()
+                .is_some_and(|preview| preview.open_history_retention),
             history_copied: None,
         };
         if !window.preview {
@@ -1307,6 +1312,7 @@ impl AppWindow {
     fn select_pane(&mut self, pane: Pane, cx: &mut Context<Self>) {
         self.pane = pane;
         self.mode_context_menu = None;
+        self.history_retention_open = false;
         match pane {
             Pane::HudLab => self.apply_hud_lab(),
             Pane::Meetings => self.reload_meetings(),
@@ -1967,16 +1973,49 @@ impl AppWindow {
         let search = div().w(px(220.0)).child(self.history_search.entity.clone());
         let retention_control = header_button(format!("Keep: {}", retention.label()))
             .id("history-retention")
-            .on_click(cx.listener(move |this, _, _, cx| {
-                let all = HistoryRetention::ALL;
-                let index = all
-                    .iter()
-                    .position(|choice| *choice == this.settings.history_retention)
-                    .unwrap_or(0);
-                let next = all[(index + 1) % all.len()];
-                this.set_history_retention(next, cx);
-            }))
-            .into_any_element();
+            .on_click(cx.listener(|this, _, _, cx| {
+                this.history_retention_open = true;
+                cx.notify();
+            }));
+        let retention_control = div().relative().child(retention_control).when(
+            self.history_retention_open,
+            |control| {
+                control.child(deferred(
+                    div()
+                        .id("history-retention-menu")
+                        .absolute()
+                        .top(px(36.0))
+                        .right_0()
+                        .w(px(160.0))
+                        .p_1()
+                        .rounded_md()
+                        .border_1()
+                        .border_color(rgb(LINE))
+                        .bg(rgb(SURFACE))
+                        .occlude()
+                        .on_mouse_down_out(cx.listener(|this, _, _, cx| {
+                            this.history_retention_open = false;
+                            cx.notify();
+                        }))
+                        .children(HistoryRetention::ALL.into_iter().enumerate().map(
+                            |(index, choice)| {
+                                compact_button(choice.label())
+                                    .id(("history-retention-choice", index))
+                                    .w_full()
+                                    .when(choice == retention, |item| {
+                                        item.bg(rgb(SURFACE_SELECTED))
+                                    })
+                                    .on_click(cx.listener(move |this, _, _, cx| {
+                                        cx.stop_propagation();
+                                        this.history_retention_open = false;
+                                        this.set_history_retention(choice, cx);
+                                        cx.notify();
+                                    }))
+                            },
+                        )),
+                ))
+            },
+        );
         let clear = header_button(if self.history_clear_armed {
             "Really clear all?"
         } else {
@@ -2532,6 +2571,7 @@ impl AppWindow {
                         .into_iter()
                         .enumerate()
                         .map(|(index, (label, side))| {
+                            let candidate = hotkey_side_binding(&self.settings, kind, side);
                             segmented_item(selected == side)
                                 .id(("hotkey-side", hotkey_kind_index(kind) * 3 + index))
                                 .w(px(side_widths[index]))
@@ -2540,12 +2580,18 @@ impl AppWindow {
                                 .justify_center()
                                 .bg(rgba(0x00000000))
                                 .text_size(px(9.0))
+                                .when(candidate.is_none(), |item| item.opacity(0.35))
                                 .child(label)
                                 .on_click(cx.listener(move |this, _, _, cx| {
+                                    let Some(candidate) =
+                                        hotkey_side_binding(&this.settings, kind, side)
+                                    else {
+                                        return;
+                                    };
                                     let Some(binding) = this.hotkey_binding_mut(kind) else {
                                         return;
                                     };
-                                    set_standalone_modifier_side(binding, side);
+                                    *binding = candidate;
                                     this.hotkey_side_selection_springs[hotkey_kind_index(kind)]
                                         .set_target(index as f32);
                                     this.save_settings(cx);
@@ -2706,24 +2752,7 @@ impl AppWindow {
             HotkeyCaptureState::Listening { kind, .. } => kind,
             HotkeyCaptureState::Idle | HotkeyCaptureState::Saved { .. } => return,
         };
-        let mut others = match kind {
-            HotkeyKind::Dictation => vec![self.settings.edit_hotkey.clone()],
-            HotkeyKind::Edit => vec![self.settings.dictation_hotkey.clone()],
-            HotkeyKind::PasteLast => vec![
-                self.settings.dictation_hotkey.clone(),
-                self.settings.edit_hotkey.clone(),
-            ],
-        };
-        if kind != HotkeyKind::PasteLast
-            && let Some(paste) = &self.settings.paste_last_hotkey
-        {
-            others.push(paste.clone());
-        }
-        if crate::DEVELOPER_FEATURES_ENABLED {
-            others.push(HotkeyBinding::paste_meeting_default());
-        }
-        let conflicts = crate::app_settings::hotkey_conflicts(&binding, others);
-        if conflicts {
+        if hotkey_binding_conflicts(&self.settings, kind, &binding) {
             self.set_hotkey_capture_message("Already in use", cx);
             return;
         }
@@ -2793,9 +2822,6 @@ impl AppWindow {
                             .flex_none()
                             .text_size(px(14.0))
                             .text_color(rgb(MUTED))
-                            .hover(|button| {
-                                button.bg(rgb(SURFACE_HOVER)).text_color(rgb(TEXT_SOFT))
-                            })
                             .on_click(cx.listener(move |this, _, _, cx| {
                                 this.mode_inputs_mut(selection).replacements.remove(index);
                                 this.mode_settings_mut(selection).replacements.remove(index);
@@ -3621,6 +3647,7 @@ impl AppWindow {
 
         div()
             .id("setup-backdrop")
+            .occlude()
             .absolute()
             .top_0()
             .left_0()
@@ -7179,6 +7206,12 @@ impl Render for AppWindow {
         window_frame()
             .track_focus(&self.window_focus)
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, _, cx| {
+                if event.keystroke.key == "escape" && this.history_retention_open {
+                    this.history_retention_open = false;
+                    cx.stop_propagation();
+                    cx.notify();
+                    return;
+                }
                 if event.keystroke.key == "escape" && this.mode_context_menu.take().is_some() {
                     cx.stop_propagation();
                     cx.notify();
@@ -7401,6 +7434,46 @@ fn set_standalone_modifier_side(binding: &mut HotkeyBinding, side: ModifierSide)
     } else if binding.modifiers.command.is_some() {
         binding.modifiers.command = Some(side);
     }
+}
+
+fn hotkey_binding_conflicts(
+    settings: &AppSettings,
+    kind: HotkeyKind,
+    binding: &HotkeyBinding,
+) -> bool {
+    let mut others = match kind {
+        HotkeyKind::Dictation => vec![settings.edit_hotkey.clone()],
+        HotkeyKind::Edit => vec![settings.dictation_hotkey.clone()],
+        HotkeyKind::PasteLast => vec![
+            settings.dictation_hotkey.clone(),
+            settings.edit_hotkey.clone(),
+        ],
+    };
+    if kind != HotkeyKind::PasteLast
+        && let Some(paste) = &settings.paste_last_hotkey
+    {
+        others.push(paste.clone());
+    }
+    if crate::DEVELOPER_FEATURES_ENABLED {
+        others.push(HotkeyBinding::paste_meeting_default());
+    }
+    crate::app_settings::hotkey_conflicts(binding, others)
+}
+
+fn hotkey_side_binding(
+    settings: &AppSettings,
+    kind: HotkeyKind,
+    side: ModifierSide,
+) -> Option<HotkeyBinding> {
+    let mut binding = match kind {
+        HotkeyKind::Dictation => &settings.dictation_hotkey,
+        HotkeyKind::Edit => &settings.edit_hotkey,
+        HotkeyKind::PasteLast => settings.paste_last_hotkey.as_ref()?,
+    }
+    .clone();
+    standalone_modifier_side(&binding)?;
+    set_standalone_modifier_side(&mut binding, side);
+    (!hotkey_binding_conflicts(settings, kind, &binding)).then_some(binding)
 }
 
 fn hotkey_control_width(active: bool, idle_width: f32, animated_width: f32) -> f32 {
@@ -7992,8 +8065,11 @@ const fn permission_warning_id(kind: PermissionKind) -> &'static str {
 }
 
 fn hotkey_modifiers(modifiers: GpuiModifiers) -> HotkeyModifiers {
-    let physical =
-        crate::app_settings::modifiers_from_flags(crate::suppression::physical_modifier_flags());
+    hotkey_modifiers_with_flags(modifiers, crate::suppression::physical_modifier_flags())
+}
+
+fn hotkey_modifiers_with_flags(modifiers: GpuiModifiers, flags: u64) -> HotkeyModifiers {
+    let physical = crate::app_settings::modifiers_from_flags(flags);
     if !physical.is_empty() {
         return physical;
     }
@@ -8392,6 +8468,40 @@ mod tests {
     }
 
     #[test]
+    fn shortcut_side_changes_reject_overlap_without_changing_the_saved_binding() {
+        let mut settings = AppSettings::default();
+        settings.dictation_hotkey.modifiers.option = Some(ModifierSide::Left);
+        settings.edit_hotkey = HotkeyBinding {
+            modifiers: HotkeyModifiers {
+                option: Some(ModifierSide::Right),
+                ..Default::default()
+            },
+            key: None,
+        };
+        let original = settings.dictation_hotkey.clone();
+
+        assert!(
+            hotkey_side_binding(&settings, HotkeyKind::Dictation, ModifierSide::Right).is_none()
+        );
+        assert!(
+            hotkey_side_binding(&settings, HotkeyKind::Dictation, ModifierSide::Either).is_none()
+        );
+        assert_eq!(settings.dictation_hotkey, original);
+        assert_eq!(
+            hotkey_side_binding(&settings, HotkeyKind::Dictation, ModifierSide::Left),
+            Some(original)
+        );
+
+        settings.edit_hotkey = HotkeyBinding::edit_default();
+        let candidate =
+            hotkey_side_binding(&settings, HotkeyKind::Dictation, ModifierSide::Right).unwrap();
+        assert_eq!(
+            standalone_modifier_side(&candidate),
+            Some(ModifierSide::Right)
+        );
+    }
+
+    #[test]
     fn side_selection_only_changes_a_standalone_modifier() {
         let mut standalone = HotkeyBinding {
             modifiers: HotkeyModifiers {
@@ -8447,10 +8557,13 @@ mod tests {
 
     #[test]
     fn hotkey_capture_preserves_the_function_modifier() {
-        let modifiers = hotkey_modifiers(GpuiModifiers {
-            function: true,
-            ..Default::default()
-        });
+        let modifiers = hotkey_modifiers_with_flags(
+            GpuiModifiers {
+                function: true,
+                ..Default::default()
+            },
+            0,
+        );
 
         assert!(modifiers.function);
         assert_eq!(modifiers.count(), 1);

--- a/src/history.rs
+++ b/src/history.rs
@@ -499,6 +499,28 @@ mod tests {
     }
 
     #[test]
+    fn choosing_week_retention_from_month_keeps_entries_newer_than_a_week() {
+        let day_ms = 24 * 60 * 60 * 1_000;
+        let now = 30 * day_ms;
+        let path = temp_path("month-to-week");
+        let mut store = HistoryStore::open(path, HistoryRetention::Month, 0);
+        store
+            .record(draft("twenty days old"), now - 20 * day_ms)
+            .unwrap();
+        store
+            .record(draft("two days old"), now - 2 * day_ms)
+            .unwrap();
+
+        store.set_retention(HistoryRetention::Week, now).unwrap();
+
+        let texts: Vec<_> = store
+            .entries()
+            .map(|entry| entry.final_text.as_str())
+            .collect();
+        assert_eq!(texts, ["two days old"]);
+    }
+
+    #[test]
     fn off_records_nothing_but_preserves_existing_entries() {
         let path = temp_path("off");
         let mut store = HistoryStore::open(path, HistoryRetention::Week, 1_000);

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,9 @@ enum Command {
         /// Show the selected dictation model as missing without changing local files.
         #[arg(long)]
         model_missing: bool,
+        /// Open the explicit history retention choices in the History preview.
+        #[arg(long)]
+        open_history_retention: bool,
     },
     /// Listen and transcribe until interrupted.
     Listen {
@@ -440,6 +443,7 @@ fn main() -> Result<()> {
             opencode_unavailable,
             permissions_missing,
             model_missing,
+            open_history_retention,
         } => {
             if matches!(target, AppPreviewTarget::DictationHud) {
                 return meeting_watcher::run(&SHUTDOWN, false, None, true);
@@ -484,6 +488,7 @@ fn main() -> Result<()> {
                     opencode_unavailable,
                     permissions_missing,
                     model_missing,
+                    open_history_retention,
                 },
             )
         }

--- a/src/recognition.rs
+++ b/src/recognition.rs
@@ -2228,6 +2228,9 @@ mod tests {
             },
         );
 
+        dictation.suspend();
+        edit.suspend();
+
         // Option down: plain dictation starts, no Voice Action gesture yet.
         let event = InputEvent::Flags(OPTION);
         let edit_action = edit.process(event, now);

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -175,6 +175,17 @@ impl InputActivity {
     pub fn invalidate(&self) {
         self.0.fetch_add(1, Ordering::AcqRel);
     }
+
+    fn observe(&self, input: InputEvent, suppressed: bool) {
+        if !suppressed
+            && matches!(
+                input,
+                InputEvent::Key { down: true, .. } | InputEvent::MouseDown
+            )
+        {
+            self.invalidate();
+        }
+    }
 }
 
 impl InputMonitor {
@@ -443,13 +454,8 @@ unsafe extern "C" fn event_callback(
     };
     // SAFETY: CoreGraphics supplied a valid event to this callback.
     let capture_at = CaptureInstant::from_mach_ticks(unsafe { CGEventGetTimestamp(event) });
-    if matches!(
-        input,
-        InputEvent::Key { down: true, .. } | InputEvent::MouseDown
-    ) {
-        context.activity.invalidate();
-    }
     if crate::app_settings::hotkey_capture_active() {
+        context.activity.observe(input, false);
         context
             .shortcut_suppression
             .lock()
@@ -468,6 +474,7 @@ unsafe extern "C" fn event_callback(
             delivered,
             context.escape_cancels.load(Ordering::Acquire),
         ) || suppression.process_all(input, crate::app_settings::runtime_hotkeys(), delivered);
+    context.activity.observe(input, suppress);
     if suppress { ptr::null_mut() } else { event }
 }
 
@@ -977,6 +984,51 @@ mod tests {
         RuntimeHotkey {
             modifiers: crate::app_settings::modifiers_from_flags(FUNCTION),
             key_code: None,
+        }
+    }
+
+    #[test]
+    fn consumed_dictation_keys_preserve_continuation_but_typing_and_clicks_do_not() {
+        for flags in [NO_FLAGS, SHIFT_KEY_MASK] {
+            let activity = InputActivity::default();
+            let mut suppression = ShortcutSuppression::default();
+            let binding = RuntimeHotkey {
+                modifiers: crate::app_settings::modifiers_from_flags(flags),
+                key_code: Some(96),
+            };
+            let revision = activity.revision();
+            for down in [true, true, false] {
+                let input = InputEvent::Key {
+                    code: 96,
+                    down,
+                    flags,
+                };
+                let suppressed = suppression.process(input, 47, binding, true);
+                assert!(suppressed);
+                activity.observe(input, suppressed);
+            }
+            assert_eq!(activity.revision(), revision);
+
+            let typed = InputEvent::Key {
+                code: 0,
+                down: true,
+                flags: NO_FLAGS,
+            };
+            activity.observe(typed, suppression.process(typed, 47, binding, true));
+            assert_eq!(activity.revision(), revision + 1);
+            activity.observe(InputEvent::MouseDown, false);
+            assert_eq!(activity.revision(), revision + 2);
+
+            let undelivered = InputEvent::Key {
+                code: 96,
+                down: true,
+                flags,
+            };
+            activity.observe(
+                undelivered,
+                suppression.process(undelivered, 47, binding, false),
+            );
+            assert_eq!(activity.revision(), revision + 3);
         }
     }
 


### PR DESCRIPTION
## Why

Changing History from 30 days to 7 days currently cycles through a 24-hour setting, deleting entries before the user reaches the intended choice. Key-based dictation shortcuts also count as ordinary typing, breaking continuation spacing between consecutive dictations.

A practical audit found three additional desktop usability bugs and several compatible dependency updates. The fixes and dependency changes are separate commits for review.

## What Changes

| Before | After |
| --- | --- |
| Retention changes immediately while cycling through every choice | A menu applies only the selected retention window; Escape/outside clicks dismiss it |
| Correction rows panic in debug builds because hover styling is registered twice | Correction controls use the shared button's hover styling |
| Left/Either/Right controls accept conflicts that shortcut capture rejects | Both paths use the same conflict checks; conflicting side choices are disabled |
| Onboarding's dimmed background allows clicks into underlying controls | The setup backdrop occludes underlying hit targets |
| Consumed function-key/chord shortcuts invalidate paste continuation | Consumed shortcuts preserve continuation; real typing and mouse clicks still invalidate it |

Two existing tests now start from deterministic modifier state rather than depending on keys held at the developer's keyboard. The History menu has an isolated `preview history --open-history-retention` fixture.

### Dependencies

| Direct dependency | Previous resolved version | Updated version |
| --- | --- | --- |
| cc | 1.2.67 | 1.4.4 |
| clap | 4.6.1 | 4.6.6 |
| libc | 0.2.186 | 0.2.189 |
| regex | 1.13.0 | 1.13.1 |
| serde | 1.0.228 | 1.0.229 |
| serde_json | 1.0.150 | 1.0.151 |
| tray-icon | 0.24.1 | 0.24.2 |
| getrandom | 0.3.4 | 0.4.3 |
| screencapturekit | 8.0.0 | 8.0.1 |

The getrandom migration preserves the existing `fill` call. ScreenCaptureKit's patch fixes a Swift target-name collision without changing its Rust source API. Supporting lockfile dependencies are updated with these packages.

## Demo

Visual evidence is pending: macOS Screen Recording permission is unavailable, so window screenshots could not be captured. Debug and release preview windows were confirmed visible and remained running for Modes, History with the retention menu open, onboarding, and Settings. These are render/launch checks, not a completed visual or click-through review.

## Scope

This covers desktop usability and targeted dependency maintenance, not a blanket upgrade to every newest major version. Audio-engine and graphics migrations remain separate. CPAL stays pinned in the lockfile pending review of its new CoreAudio error callbacks against HEX's capture-recovery policy. This does not publish an app or SDK release.

## Verification

```sh
CMAKE=/opt/homebrew/lib/python3.10/site-packages/cmake/data/bin/cmake cargo test --locked --bin voice-control
CMAKE=/opt/homebrew/lib/python3.10/site-packages/cmake/data/bin/cmake cargo clippy --locked --all-targets --all-features -- -D warnings
CMAKE=/opt/homebrew/lib/python3.10/site-packages/cmake/data/bin/cmake cargo build --locked --bin voice-control
CMAKE=/opt/homebrew/lib/python3.10/site-packages/cmake/data/bin/cmake cargo build --locked --release --bin voice-control
cargo fmt --all --check
git diff --check
```

- 334 tests passed; 8 ignored. New coverage exercises retention cutoffs, conflicting side candidates, and consumed versus ordinary input activity.
- Clippy, debug/release builds, formatting, and diff checks passed. Release retains the existing unused `call_developer` warning.
- The previously failing debug Modes preview now opens without the duplicate-hover panic.
- Native Linux, physical dictation, meeting capture, and full UI interaction testing were not performed in this pass.
