### PR TITLE
fix(release): use the approved personal signing identity for Hex 2.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,11 +359,15 @@ precedence while available; override everything with `--device`. The app bundle
 build requires Xcode 26 for Icon Composer compilation and a Developer ID signing
 identity. `scripts/release-app.sh` prepares a notarized and stapled DMG plus its
 signed Sparkle appcast; run `scripts/release-app.sh publish` only after validating
-the prepared artifact. The Anomaly app is named `Hex`, packaged as `Hex.app`,
-with bundle identifier `ly.anoma.Hex` and executable `hex`. Signing requires an
-explicit Anomaly `VOICE_CONTROL_TEAM_ID` and `HEX_NOTARY_PROFILE`; the main app
-build and release scripts must not default to the personal signing team.
+the prepared artifact. The Rust app is named `Hex`, packaged as `Hex.app`,
+with bundle identifier `com.kitlangton.hex2` and executable `hex`. Kit has approved
+his personal Developer ID signing team `QC99C9JE59` for this app. Signing requires
+an explicit `VOICE_CONTROL_TEAM_ID` and matching `HEX_NOTARY_PROFILE`; the build
+and release scripts verify the selected team rather than assuming an Anomaly team.
 `scripts/validate-app.sh` checks this identity before preparation and publication.
+The manual DMG contains `Hex.app`; the signed Sparkle ZIP preserves `HEX.app`
+as its archive root so existing Rust 2.0.x installations can discover the update
+despite the new bundle ID. Both artifacts contain the same signed, stapled app.
 There is no Swift migration: never import Swift preferences or data, adopt its
 bundle identifier, publish Rust artifacts to its S3 feed, or automatically quit,
 delete, or replace the Swift app. Prefer a website-only informational item in
@@ -371,7 +375,7 @@ the legacy Sparkle feed, with no enclosure, pointing to the new app for manual
 installation and fresh setup. Publish it only after the new artifact is live. See
 `docs/plans/swift-app-handoff.md`. The Rust data root remains unchanged, but the
 new app identity requires fresh macOS permission grants. Validate signed
-distribution with the Anomaly team before publishing an app update.
+distribution with the selected signing team before publishing an app update.
 
 `SMAppService` is meaningful only from a signed app installed in
 `/Applications`. When replacing a local bundle outside Finder during a login-item

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,9 +41,9 @@ Keep Swift and Rust separate. Prefer the old app's existing Sparkle update windo
 with a website-only informational item to install the new app manually, with no
 data import or automatic replacement.
 Follow [`docs/plans/swift-app-handoff.md`](docs/plans/swift-app-handoff.md).
-The new app uses Anomaly identity `ly.anoma.Hex`, display name `Hex`, and filename
-`Hex.app`, while retaining the Rust `voice-control` data root. Configure the
-Anomaly signing team and validate the new identity before release. The legacy
+The new app uses identity `com.kitlangton.hex2`, display name `Hex`, and filename
+`Hex.app`, while retaining the Rust `voice-control` data root. Use Kit's approved
+Developer ID signing team and validate the new identity before release. The legacy
 S3 feed must never install a Rust payload. Publish
 the updated Rust artifact first, then the separately validated legacy feed notice.
 No Swift rebuild should be necessary for the notice.

--- a/app/Info.plist
+++ b/app/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleExecutable</key>
   <string>hex</string>
   <key>CFBundleIdentifier</key>
-  <string>ly.anoma.Hex</string>
+  <string>com.kitlangton.hex2</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleIconFile</key>

--- a/docs/plans/swift-app-handoff.md
+++ b/docs/plans/swift-app-handoff.md
@@ -14,15 +14,15 @@ offer a download link; downloading and installing remains an explicit user actio
 
 ## Separate Identities
 
-The Anomaly app is called **Hex**, packaged as **Hex.app**, with
-bundle identifier `ly.anoma.Hex` and executable `hex`. Its Application Support
+The Rust app is called **Hex**, packaged as **Hex.app**, with
+bundle identifier `com.kitlangton.hex2` and executable `hex`. Its Application Support
 root remains `voice-control`. The supported platform remains Apple silicon with
 macOS 15 or newer. The new bundle identity requires fresh macOS permission grants;
 changing the display name alone does not change signing ownership.
 
-Configure an Anomaly Developer ID Application certificate and explicitly provide
-its `VOICE_CONTROL_TEAM_ID` and matching `HEX_NOTARY_PROFILE` before release.
-The main app build and release scripts no longer default to personal credentials.
+Kit's personal Developer ID Application certificate (team `QC99C9JE59`) is approved
+for this app. Explicitly provide `VOICE_CONTROL_TEAM_ID` and the matching
+`HEX_NOTARY_PROFILE` before release; an Anomaly signing account is not required.
 
 Swift retains its own bundle identity, sandbox data, and S3 update feed. Intel
 and macOS 14 users can continue using Swift without an incompatible-install nag.
@@ -36,19 +36,23 @@ two global hotkey listeners.
 
 ## Legacy Notice
 
+Swift 0.8.5/build 92 already ships a dismissible link to the Rust app. This Rust
+release does not publish another Swift build or change its S3 feed. The optional
+feed-only notice below remains a separate future action.
+
 Prefer a [website-only Sparkle update](https://sparkle-project.org/documentation/publishing/#downloading-from-a-web-site),
-not a custom Swift popup or bridge build. The shipping `v0.8.4` source pins
+not another custom Swift popup or bridge build. The shipping `v0.8.5` source pins
 Sparkle 2.9.4, which supports both the informational item and platform gates.
 
 After the new signed app and download page are live, add one item to the existing
 Swift S3 appcast while preserving every existing release and artifact:
 
 - `link`: `https://github.com/anomalyco/hex`, the public download page.
-- `sparkle:version`: reserve 92 if still unused; it must exceed installed build 91.
+- `sparkle:version`: reserve 93 if still unused; it must exceed installed build 92.
 - `sparkle:shortVersionString`: the advertised new release, initially 2.1.0.
 - `sparkle:minimumSystemVersion`: 15.0.0.
 - `sparkle:hardwareRequirements`: arm64.
-- `sparkle:minimumUpdateVersion`: 91.
+- `sparkle:minimumUpdateVersion`: 92.
 - Embedded release notes explain separate installation, new permissions and
   model setup, no settings/history transfer, and the same-name app-file collision.
 - Omit `enclosure` entirely, including delta enclosures. Without a download URL,
@@ -63,7 +67,7 @@ one-time custom modal, and appcast text cannot rename the standard buttons.
 OS and architecture gates work without an enclosure in Sparkle 2.9.4. Older
 Sparkle versions may ignore the architecture/minimum-update gates; unsupported
 users may still reach an informational page, but never an automatic install.
-Keep requirements explicit on that page and retain Swift build 91 for compatible
+Keep requirements explicit on that page and retain Swift build 92 for compatible
 legacy updates. Do not mark the notice critical or redirect the old feed.
 
 Before publication, verify the actual distributed Swift bundle, automatic and
@@ -75,7 +79,11 @@ and these behaviors are validated.
 
 Prepare and publish Rust through `scripts/release-app.sh`, with identity checks
 from `scripts/validate-app.sh`. Publish immutable artifacts before the R2 feed.
-Validate the signed Anomaly identity and installation behavior before publishing.
+The manual DMG contains `Hex.app`; the Sparkle ZIP keeps the old Rust `HEX.app`
+archive name. Sparkle 2.9.4 uses case-sensitive filenames or matching bundle IDs
+to discover an update, so changing both at once would hide the update payload
+from 2.0.x installations. Both artifacts contain the same signed, stapled app.
+Validate the approved signing identity and installation behavior before publishing.
 Do not assume permissions or login-item registrations survive the identity change.
 
 Publish the legacy informational feed item independently after the new artifact

--- a/docs/releases/2.1.0.md
+++ b/docs/releases/2.1.0.md
@@ -1,7 +1,8 @@
 ## HEX 2.1.0
 
 Hex 2.1 updates the native Rust app for Apple-silicon Macs running macOS 15 or
-newer. The app is named Hex and uses the new Anomaly identity `ly.anoma.Hex`.
+newer. The app is named Hex and uses the new Rust identity `com.kitlangton.hex2`,
+signed with Kit Langton's Developer ID.
 macOS permissions must be granted for the new identity; Rust data stays in place.
 Users of the original Swift app install the new app manually and complete setup;
 there is no automatic migration or preference import.
@@ -37,4 +38,4 @@ there is no automatic migration or preference import.
   beam and glow.
 - The development installer refuses to replace another app with the same name.
 
-Intel Macs and Macs running macOS 14 remain on HEX 0.8.4.
+Intel Macs and Macs running macOS 14 can continue using the legacy Swift Hex 0.8.5.

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -2,7 +2,7 @@
 set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-team_id=${VOICE_CONTROL_TEAM_ID:?Set VOICE_CONTROL_TEAM_ID to the Anomaly Apple Developer Team ID}
+team_id=${VOICE_CONTROL_TEAM_ID:?Set VOICE_CONTROL_TEAM_ID to the Apple Developer signing team}
 identity=${VOICE_CONTROL_CODESIGN_IDENTITY:-}
 if [ -z "$identity" ]; then
   identity=$(security find-identity -v -p codesigning | sed -n "s/.*\"\(Developer ID Application:.*($team_id)\)\"/\1/p" | head -1)
@@ -24,14 +24,15 @@ sparkle_dir=$("$root/scripts/setup-sparkle.sh")
 version=${HEX_VERSION:-$(cargo metadata --no-deps --format-version 1 --manifest-path "$root/Cargo.toml" | jq -r '.packages[0].version')}
 build_number=${HEX_BUILD_NUMBER:-$(printf '%s\n' "$version" | awk -F. '{ print ($1 * 10000) + ($2 * 100) + $3 }')}
 bundle_name=Hex.app
-bundle_id=ly.anoma.Hex
+bundle_id=com.kitlangton.hex2
 executable_name=hex
 
 bundle="$root/target/app/$bundle_name"
 executable="$bundle/Contents/MacOS/$executable_name"
 frameworks="$bundle/Contents/Frameworks"
 
-cargo build --release --manifest-path "$root/Cargo.toml"
+export MACOSX_DEPLOYMENT_TARGET=15.0
+cargo build --locked --release --manifest-path "$root/Cargo.toml"
 rm -rf "$bundle"
 mkdir -p "$bundle/Contents/MacOS" "$bundle/Contents/Resources" "$frameworks"
 cp "$root/target/release/voice-control" "$executable"

--- a/scripts/install-app.sh
+++ b/scripts/install-app.sh
@@ -29,8 +29,8 @@ stop_bundle() {
 mkdir -p "$install_dir"
 if [ -e "$installed_bundle" ] || [ -L "$installed_bundle" ]; then
   existing_id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$installed_bundle/Contents/Info.plist" 2>/dev/null || true)
-  if [ "$existing_id" != ly.anoma.Hex ]; then
-    echo "Refusing to replace $installed_bundle: it is not the Anomaly Hex app. Install the new app manually." >&2
+  if [ "$existing_id" != com.kitlangton.hex2 ]; then
+    echo "Refusing to replace $installed_bundle: it is not the Rust Hex app. Install the new app manually." >&2
     exit 1
   fi
 fi

--- a/scripts/release-app.sh
+++ b/scripts/release-app.sh
@@ -2,17 +2,18 @@
 set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-team_id=${VOICE_CONTROL_TEAM_ID:?Set VOICE_CONTROL_TEAM_ID to the Anomaly Apple Developer Team ID}
+team_id=${VOICE_CONTROL_TEAM_ID:?Set VOICE_CONTROL_TEAM_ID to the Apple Developer signing team}
 mode=${1:-prepare}
 version=${HEX_VERSION:-$(cargo metadata --no-deps --format-version 1 --manifest-path "$root/Cargo.toml" | jq -r '.packages[0].version')}
 build_number=${HEX_BUILD_NUMBER:-$(printf '%s\n' "$version" | awk -F. '{ print ($1 * 10000) + ($2 * 100) + $3 }')}
-notary_profile=${HEX_NOTARY_PROFILE:?Set HEX_NOTARY_PROFILE to the Anomaly notarization profile}
+notary_profile=${HEX_NOTARY_PROFILE:?Set HEX_NOTARY_PROFILE to the matching notarization profile}
 bucket=${HEX_RELEASE_BUCKET:-hex-releases}
 base_url=${HEX_RELEASE_BASE_URL:-https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev}
 release_notes=${HEX_RELEASE_NOTES:-$root/docs/releases/$version.md}
 dist="$root/dist"
 updates="$dist/updates"
 artifact="HEX-$version-arm64.dmg"
+update_artifact="HEX-$version-arm64.zip"
 latest_artifact="HEX-latest-arm64.dmg"
 identity=${VOICE_CONTROL_CODESIGN_IDENTITY:-}
 
@@ -44,27 +45,36 @@ if [ -z "$published_build" ] || [ "$build_number" -le "$published_build" ]; then
 fi
 
 if [ "$mode" = "publish" ]; then
-  if [ ! -f "$dist/$artifact" ] || [ ! -f "$updates/appcast.xml" ]; then
+  if [ ! -f "$dist/$artifact" ] || [ ! -f "$dist/$update_artifact" ] || [ ! -f "$updates/appcast.xml" ]; then
     echo "Prepare and validate version $version before publishing it." >&2
     exit 1
   fi
-  if ! grep -Fq "$base_url/releases/$artifact" "$updates/appcast.xml" \
+  if ! grep -Fq "$base_url/releases/$update_artifact" "$updates/appcast.xml" \
     || ! grep -Fq 'sparkle:edSignature=' "$updates/appcast.xml"; then
-    echo "The prepared appcast does not contain a signed $artifact update." >&2
+    echo "The prepared appcast does not contain a signed $update_artifact update." >&2
     exit 1
   fi
   xcrun stapler validate "$dist/$artifact"
   spctl --assess --type open --context context:primary-signature --verbose=2 "$dist/$artifact"
-  mountpoint=$(mktemp -d "${TMPDIR:-/tmp}/hex-release-validation.XXXXXX")
-  trap 'hdiutil detach -quiet "$mountpoint" 2>/dev/null || true; rmdir "$mountpoint" 2>/dev/null || true' EXIT HUP INT TERM
+  verification=$(mktemp -d "${TMPDIR:-/tmp}/hex-release-validation.XXXXXX")
+  mountpoint="$verification/dmg"
+  mkdir -p "$mountpoint" "$verification/update"
+  trap 'hdiutil detach -quiet "$mountpoint" 2>/dev/null || true; rm -rf "$verification"' EXIT HUP INT TERM
   hdiutil attach -quiet -nobrowse -readonly -mountpoint "$mountpoint" "$dist/$artifact"
   "$root/scripts/validate-app.sh" "$mountpoint/Hex.app" Hex.app "$version" "$build_number" >/dev/null
+  /usr/bin/ditto -x -k "$dist/$update_artifact" "$verification/update"
+  "$root/scripts/validate-app.sh" "$verification/update/HEX.app" HEX.app "$version" "$build_number" >/dev/null
+  xcrun stapler validate "$verification/update/HEX.app"
+  diff -qr "$mountpoint/Hex.app" "$verification/update/HEX.app"
   hdiutil detach -quiet "$mountpoint"
-  rmdir "$mountpoint"
+  rm -rf "$verification"
   trap - EXIT HUP INT TERM
   wrangler r2 object put "$bucket/releases/$artifact" --remote \
     --file "$dist/$artifact" \
     --content-type application/x-apple-diskimage
+  wrangler r2 object put "$bucket/releases/$update_artifact" --remote \
+    --file "$dist/$update_artifact" \
+    --content-type application/zip
   wrangler r2 object put "$bucket/releases/$latest_artifact" --remote \
     --file "$dist/$artifact" \
     --content-type application/x-apple-diskimage
@@ -72,6 +82,7 @@ if [ "$mode" = "publish" ]; then
     --file "$updates/appcast.xml" \
     --content-type application/xml
   curl --fail --silent --show-error "$base_url/releases/$artifact" -o /dev/null
+  curl --fail --silent --show-error "$base_url/releases/$update_artifact" -o /dev/null
   curl --fail --silent --show-error "$base_url/releases/$latest_artifact" -o /dev/null
   curl --fail --silent --show-error "$base_url/appcast.xml" -o /dev/null
   echo "$base_url/releases/$artifact"
@@ -93,9 +104,9 @@ if [ -z "$identity" ]; then
   echo "No Developer ID signing identity found for team $team_id." >&2
   exit 1
 fi
-rm -rf "$dist/staging" "$updates"
-rm -f "$dist/HEX-$version.zip" "$dist/$artifact"
-mkdir -p "$dist/staging" "$updates"
+rm -rf "$dist/staging" "$dist/update-staging" "$updates"
+rm -f "$dist/HEX-$version.zip" "$dist/$artifact" "$dist/$update_artifact"
+mkdir -p "$dist/staging" "$dist/update-staging" "$updates"
 
 # Notarize the app first so its ticket can be stapled inside the distributable DMG.
 /usr/bin/ditto -c -k --sequesterRsrc --keepParent "$bundle" "$dist/HEX-$version.zip"
@@ -112,7 +123,11 @@ xcrun stapler staple "$dist/$artifact"
 xcrun stapler validate "$dist/$artifact"
 spctl --assess --type open --context context:primary-signature --verbose=2 "$dist/$artifact"
 
-cp "$dist/$artifact" "$updates/$artifact"
+# Sparkle 2.9.4 discovers updates by exact app filename or matching bundle ID.
+# Retain the old Rust archive name so 2.0.x can find the new bundle identity.
+/usr/bin/ditto "$bundle" "$dist/update-staging/HEX.app"
+/usr/bin/ditto -c -k --sequesterRsrc --keepParent "$dist/update-staging/HEX.app" "$dist/$update_artifact"
+cp "$dist/$update_artifact" "$updates/$update_artifact"
 cp "$release_notes" "$updates/HEX-$version-arm64.md"
 curl --fail --silent --show-error "$base_url/appcast.xml" -o "$updates/appcast.xml" || rm -f "$updates/appcast.xml"
 sparkle_dir=$("$root/scripts/setup-sparkle.sh")
@@ -126,7 +141,7 @@ security find-generic-password \
   --maximum-deltas 0 \
   --maximum-versions 5 \
   "$updates"
-grep -Fq "$base_url/releases/$artifact" "$updates/appcast.xml"
+grep -Fq "$base_url/releases/$update_artifact" "$updates/appcast.xml"
 grep -Fq 'sparkle:edSignature=' "$updates/appcast.xml"
 
 echo "$dist/$artifact"

--- a/scripts/test-app-identity.sh
+++ b/scripts/test-app-identity.sh
@@ -10,7 +10,7 @@ mkdir -p "$bundle/Contents"
 plist="$bundle/Contents/Info.plist"
 cp "$root/app/Info.plist" "$plist"
 
-[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")" = ly.anoma.Hex ]
+[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$plist")" = com.kitlangton.hex2 ]
 [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$plist")" = hex ]
 [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleDisplayName' "$plist")" = Hex ]
 [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleName' "$plist")" = Hex ]
@@ -28,6 +28,8 @@ expect_rejection 'wrong bundle identifier'
 /usr/libexec/PlistBuddy -c 'Set :CFBundleIdentifier com.kitlangton.voice-control.agent' "$plist"
 expect_rejection 'wrong bundle identifier'
 /usr/libexec/PlistBuddy -c 'Set :CFBundleIdentifier ly.anoma.Hex' "$plist"
+expect_rejection 'wrong bundle identifier'
+/usr/libexec/PlistBuddy -c 'Set :CFBundleIdentifier com.kitlangton.hex2' "$plist"
 /usr/libexec/PlistBuddy -c 'Set :CFBundleExecutable voice-control-watch' "$plist"
 expect_rejection 'wrong executable name'
 
@@ -36,7 +38,7 @@ for script in build-app.sh release-app.sh; do
     echo "Unexpectedly allowed $script without an explicit signing team." >&2
     exit 1
   fi
-  printf '%s\n' "$output" | grep -Fq 'Set VOICE_CONTROL_TEAM_ID to the Anomaly Apple Developer Team ID'
+  printf '%s\n' "$output" | grep -Fq 'Set VOICE_CONTROL_TEAM_ID to the Apple Developer signing team'
 done
 
 for identity in 'Developer ID Application: Fixture (WRONGTEAM0)' 'Apple Development: Fixture (TESTTEAM00)'; do

--- a/scripts/validate-app.sh
+++ b/scripts/validate-app.sh
@@ -10,7 +10,7 @@ bundle=$1
 expected_name=$2
 version=$3
 build_number=$4
-team_id=${VOICE_CONTROL_TEAM_ID:?Set VOICE_CONTROL_TEAM_ID to the Anomaly Apple Developer Team ID}
+team_id=${VOICE_CONTROL_TEAM_ID:?Set VOICE_CONTROL_TEAM_ID to the Apple Developer signing team}
 feed_url=${HEX_EXPECTED_APP_FEED_URL:-https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/appcast.xml}
 sparkle_key=mIek27lttJe8cIBqVZFhh6reRKjpTx1h9ZY9OKWPtuM=
 plist="$bundle/Contents/Info.plist"
@@ -26,7 +26,7 @@ plist_value() {
 
 [ -d "$bundle" ] || fail "$bundle does not exist"
 [ "$(basename "$bundle")" = "$expected_name" ] || fail "expected $expected_name, found $(basename "$bundle")"
-[ "$(plist_value CFBundleIdentifier)" = ly.anoma.Hex ] || fail "wrong bundle identifier"
+[ "$(plist_value CFBundleIdentifier)" = com.kitlangton.hex2 ] || fail "wrong bundle identifier"
 [ "$(plist_value CFBundleExecutable)" = hex ] || fail "wrong executable name"
 [ "$(plist_value CFBundleDisplayName)" = Hex ] || fail "wrong display name"
 [ "$(plist_value CFBundleName)" = Hex ] || fail "wrong bundle name"
@@ -42,7 +42,7 @@ plist_value() {
 
 codesign --verify --deep --strict --verbose=2 "$bundle"
 signature=$(codesign -d --verbose=4 "$bundle" 2>&1)
-printf '%s\n' "$signature" | grep -Fq 'Identifier=ly.anoma.Hex' || fail "code signature has the wrong identifier"
+printf '%s\n' "$signature" | grep -Fq 'Identifier=com.kitlangton.hex2' || fail "code signature has the wrong identifier"
 printf '%s\n' "$signature" | grep -Fq "TeamIdentifier=$team_id" || fail "code signature has the wrong team"
 printf '%s\n' "$signature" | grep -Fq 'Authority=Developer ID Application:' || fail "not signed for Developer ID distribution"
 entitlements=$(codesign -d --entitlements - "$bundle" 2>/dev/null)


### PR DESCRIPTION
## Why

The release configuration required an Anomaly signing account even though Kit explicitly chose his personal Developer ID for Hex. This prevented the desktop release with the certificate already available on the release machine.

The new bundle ID also needs update-discovery compatibility: Sparkle 2.9.4 compares app filenames case-sensitively when bundle IDs differ, while existing Rust releases contain `HEX.app` rather than `Hex.app`.

## What Changes

| Surface | Release contract |
| --- | --- |
| App name | Hex, executable `hex` |
| Bundle identifier | `com.kitlangton.hex2` |
| Signing | Explicitly selected Developer ID team; Kit's `QC99C9JE59` team is approved |
| Manual download | Notarized DMG containing `Hex.app` |
| Sparkle update | Signed ZIP containing the same app under the existing Rust `HEX.app` archive name |
| Minimum macOS | 15.0 in both bundle metadata and the compiled executable |

Publication validates both app copies and requires identical contents, uploads the DMG and ZIP before the update feed, and keeps the existing Sparkle key and Rust R2 feed. Identity guards still reject the Swift bundle, old Rust identity, and incorrect signing teams. Builds use the committed Cargo lockfile.

## Published Artifacts

[Hex 2.1.0 DMG](https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/releases/HEX-2.1.0-arm64.dmg)

- DMG: 34,393,216 bytes; SHA-256 `d6452fc39b310d4fa91ff549d8d367693ab895c2e2fa28d140f4a724416706e6`.
- Updater ZIP: 32,785,329 bytes; SHA-256 `18b100f381ade80ce44125b60547a8c254e2759e69f967bdf70bb3f280d9b930`.
- Public versioned DMG, latest DMG, ZIP, and appcast were downloaded and compared byte-for-byte with the validated local artifacts.

## Scope

This changes Rust release identity and packaging, not the app's visible name or data location. Existing Rust data stays in place, but the new identity requires fresh macOS permissions. The legacy Swift app, data, and S3 feed are unchanged. No Linux release is included.

## Verification

```sh
./scripts/test-app-identity.sh
CMAKE=/opt/homebrew/lib/python3.10/site-packages/cmake/data/bin/cmake cargo test --locked --bin voice-control
VOICE_CONTROL_TEAM_ID=QC99C9JE59 HEX_NOTARY_PROFILE=AC_PASSWORD CMAKE=/opt/homebrew/lib/python3.10/site-packages/cmake/data/bin/cmake ./scripts/release-app.sh prepare
VOICE_CONTROL_TEAM_ID=QC99C9JE59 ./scripts/validate-app.sh target/app/Hex.app Hex.app 2.1.0 20100
spctl --assess --type execute --verbose=2 target/app/Hex.app
vtool -show-build target/app/Hex.app/Contents/MacOS/hex
git diff --check
```

- 334 Rust tests passed; 8 ignored. Identity rejection tests passed.
- Apple accepted app and DMG notarization; both are stapled. Gatekeeper accepted both.
- Signed packaged Settings, Modes, and onboarding previews opened without crashes.
- A disposable Sparkle 2.9.4 XCTest verified the exact ZIP against the public 2.0.24 app's key, extracted it, and installed it over a temporary copy of 2.0.24. New bundle ID, executable, build, nested code signatures, and signing team passed. No installed app or microphone was launched.
- That test covers native archive validation/discovery and temporary replacement, not updater XPC/relaunch or a clean-account physical dictation smoke test.
- Publication completed through the existing release script with the verified personal Cloudflare account, artifact-first/feed-last.
