### PR TITLE
fix: restore beta updates and permission-first setup in 2.1.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,8 +210,9 @@ CoreAudio formats, AppleScript details, or event serialization.
   rewriting, then selected TypeScript transformations. A failed step preserves
   the previous pipeline output. It applies to Paste and Send, but not meetings.
 - OpenCode availability checks stay off the UI thread. When the app finds the
-  `opencode2` executable, it loads the catalog through `opencode2 api`, which
-  automatically starts or reuses the managed service. HEX never invokes
+  `opencode2` executable, `opencode2 api` discovers or starts the managed service;
+  the catalog uses authenticated loopback HTTP to avoid large CLI pipe truncation.
+  HEX never invokes
   `opencode2 serve --service` or owns that service's lifecycle directly. A
   missing beta install is retried at a coarse interval so installing
   `opencode2` while Settings is open refreshes the model catalog without
@@ -368,6 +369,11 @@ and release scripts verify the selected team rather than assuming an Anomaly tea
 The manual DMG contains `Hex.app`; the signed Sparkle ZIP preserves `HEX.app`
 as its archive root so existing Rust 2.0.x installations can discover the update
 despite the new bundle ID. Both artifacts contain the same signed, stapled app.
+Sparkle compares `CFBundleVersion`, not source changes or signing timestamps.
+Public releases must advance beyond distributed beta builds as well as the feed;
+the older local Rust 2.1.0 beta already used build 20100. Do not reuse a released
+version/build for changed code. Validate updates from both the public 2.0.x app
+and the older 2.1.0 beta when changing update identity or packaging.
 There is no Swift migration: never import Swift preferences or data, adopt its
 bundle identifier, publish Rust artifacts to its S3 feed, or automatically quit,
 delete, or replace the Swift app. Prefer a website-only informational item in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8536,7 +8536,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voice-control"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice-control"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 default-run = "voice-control"
 license = "MIT"

--- a/docs/releases/2.1.1.md
+++ b/docs/releases/2.1.1.md
@@ -1,0 +1,24 @@
+## Hex 2.1.1
+
+This release makes the latest Rust Hex available to older Rust beta installations
+that already reported version 2.1.0, build 20100. Sparkle compares build numbers,
+so those betas could not detect the newer 2.1.0 release. Version 2.1.1 uses build
+20101 and is newer than both the old beta and the public 2.1.0 release.
+
+- Use **Check for Updates** in the existing Rust app to install this release.
+- The updater keeps the existing Rust feed, signing key, and compatible archive
+  filename so public 2.0.x installations can update too.
+- Settings now correctly describes automatic update checks, rather than claiming
+  updates are downloaded automatically.
+- New windows open Settings instead of Modes. Reopening the app with missing
+  permissions brings the permission controls into view.
+- OpenCode model discovery no longer relies on piping a large catalog through
+  the CLI, which could truncate the JSON response and leave processing unavailable.
+- Includes the missing-model notice, explicit history-retention choices,
+  shortcut fixes, and other improvements shipped in 2.1.0.
+
+The app remains Hex, signed with Kit Langton's Developer ID, with bundle ID
+`com.kitlangton.hex2`. Existing Rust settings and models stay in place. Users
+updating from an older bundle identity must grant the new app macOS permissions
+and re-enable Launch at Login if desired. The legacy Swift app and its separate
+update feed are unchanged.

--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -253,7 +253,7 @@ pub struct AppWindowPreview {
     pub open_history_retention: bool,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 enum Pane {
     HudLab,
     Meetings,
@@ -263,6 +263,7 @@ enum Pane {
     History,
     Modes,
     VoiceAction,
+    #[default]
     Settings,
 }
 
@@ -288,6 +289,14 @@ enum HudControl {
 const HUD_MAX_SPEED: f32 = 24.0;
 
 impl Pane {
+    fn on_reopen(self, status: SetupStatus) -> Self {
+        if crate::onboarding::permission_warnings(status).is_empty() {
+            self
+        } else {
+            Self::Settings
+        }
+    }
+
     const ALL: [Self; 8] = [
         Self::Settings,
         Self::Modes,
@@ -849,7 +858,7 @@ impl AppWindow {
                         window.retry_model_catalog();
                         let application_catalog_changed = window.poll_application_catalog();
                         let transcription_changed = window.poll_transcription_download();
-                        let setup_changed = window.poll_setup();
+                        let setup_changed = window.poll_setup(false);
                         let login_item_changed = window.poll_login_item();
                         let personal_commands_changed = window.poll_personal_commands();
                         let personal_workspace_changed = window.poll_personal_workspace();
@@ -979,7 +988,7 @@ impl AppWindow {
             cx.observe_window_activation(native_window, |this, window, cx| {
                 if window.is_window_active() {
                     this.permission_refresh_at = Instant::now();
-                    if this.poll_setup() {
+                    if this.poll_setup(true) {
                         cx.notify();
                     }
                 }
@@ -1106,7 +1115,7 @@ impl AppWindow {
             preview: preview_mode,
             pane: preview
                 .as_ref()
-                .map_or(Pane::Modes, |preview| Pane::from_preview(preview.pane)),
+                .map_or(Pane::default(), |preview| Pane::from_preview(preview.pane)),
             event_reader: EventReader::open(event_path),
             activity: DesktopActivity::default(),
             meeting_requests,
@@ -1305,7 +1314,11 @@ impl AppWindow {
             self.ensure_application_catalog_load();
         }
         self.permission_refresh_at = Instant::now();
-        self.poll_setup();
+        self.poll_setup(true);
+        let pane = self.pane.on_reopen(self.setup_status);
+        if pane != self.pane {
+            self.select_pane(pane, cx);
+        }
         cx.notify();
     }
 
@@ -1483,13 +1496,14 @@ impl AppWindow {
         true
     }
 
-    fn poll_setup(&mut self) -> bool {
+    fn poll_setup(&mut self, force: bool) -> bool {
         if self.preview
-            || Instant::now() < self.permission_refresh_at
-            || !self.setup_visible
-                && self.recognition_start.is_none()
-                && self.pane != Pane::Settings
-                && self.setup_status.transcription_model
+            || !force
+                && (Instant::now() < self.permission_refresh_at
+                    || !self.setup_visible
+                        && self.recognition_start.is_none()
+                        && self.pane != Pane::Settings
+                        && self.setup_status.transcription_model)
         {
             return false;
         }
@@ -3472,7 +3486,7 @@ impl AppWindow {
                                     ))
                                     .child(settings_row(
                                         "Software updates",
-                                        "Download signed updates automatically in the background",
+                                        "Check for signed updates automatically in the background",
                                         compact_button(update_button_label)
                                             .id("check-for-updates-setting")
                                             .h(px(32.0))
@@ -8427,6 +8441,38 @@ mod tests {
 
     use super::*;
     use crate::personal_commands::StatusExecution;
+
+    #[test]
+    fn opening_the_app_prioritizes_settings_and_missing_permissions() {
+        assert_eq!(Pane::default(), Pane::Settings);
+        let ready = SetupStatus {
+            microphone: PermissionState::Ready,
+            input_monitoring: PermissionState::Ready,
+            accessibility: PermissionState::Ready,
+            command_model: true,
+            transcription_model: true,
+        };
+        assert_eq!(Pane::Modes.on_reopen(ready), Pane::Modes);
+        for status in [
+            SetupStatus {
+                microphone: PermissionState::NeedsRequest,
+                ..ready
+            },
+            SetupStatus {
+                input_monitoring: PermissionState::NeedsSettings,
+                ..ready
+            },
+            SetupStatus {
+                accessibility: PermissionState::NeedsSettings,
+                ..ready
+            },
+        ] {
+            assert_eq!(Pane::Modes.on_reopen(status), Pane::Settings);
+            assert_eq!(Pane::VoiceAction.on_reopen(status), Pane::Settings);
+            assert_eq!(Pane::Settings.on_reopen(status), Pane::Settings);
+        }
+        assert_eq!(Pane::from_preview(PreviewPane::Modes), Pane::Modes);
+    }
 
     #[test]
     fn missing_dictation_model_has_a_notice_even_with_all_permissions_granted() {

--- a/src/dictation_processor.rs
+++ b/src/dictation_processor.rs
@@ -320,8 +320,12 @@ fn model_is_available(model: &ModelInfo) -> bool {
 }
 
 pub fn load_model_catalog() -> Result<ModelCatalog> {
-    let models: ModelsResponse = opencode_api("/api/model")?;
-    let default: DefaultModelResponse = opencode_api("/api/model/default")?;
+    let (endpoint, password) =
+        discover_opencode_service(Duration::from_secs(10), &AtomicBool::new(false))?;
+    let workspace = crate::app_paths::opencode_workspace()?;
+    let models: ModelsResponse = opencode_api(&endpoint, &password, &workspace, "/api/model")?;
+    let default: DefaultModelResponse =
+        opencode_api(&endpoint, &password, &workspace, "/api/model/default")?;
     Ok(build_model_catalog(models.data, default.data))
 }
 
@@ -383,12 +387,17 @@ fn is_executable(path: &std::path::Path) -> bool {
         .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
 }
 
-fn opencode_api<T: for<'de> Deserialize<'de>>(path: &str) -> Result<T> {
-    let mut command = opencode_command()?;
-    command.args(["get", path]).stdin(Stdio::null());
+fn opencode_api<T: for<'de> Deserialize<'de>>(
+    endpoint: &str,
+    password: &str,
+    workspace: &Path,
+    path: &str,
+) -> Result<T> {
+    // The CLI can truncate large catalog responses when stdout is piped.
+    let (command, input) = opencode_http_command(endpoint, password, path, None, Some(workspace))?;
     let output = run_command(
         command,
-        None,
+        Some(input),
         Duration::from_secs(10),
         path,
         &AtomicBool::new(false),
@@ -505,7 +514,8 @@ fn generate_cancellable(
                 deadline.as_secs()
             ));
         }
-        let (command, input) = generation_command(&endpoint, &password, &data)?;
+        let (command, input) =
+            opencode_http_command(&endpoint, &password, "/api/generate", Some(&data), None)?;
         let output = run_command(command, Some(input), remaining, "/api/generate", cancelled)?;
         let status = output.status;
         if !status.success() {
@@ -638,7 +648,13 @@ fn read_service_registration(state: &Path, pid: u32, version: &str) -> Result<(S
     found.ok_or_else(|| eyre!("OpenCode active service registration is unavailable"))
 }
 
-fn generation_command(endpoint: &str, password: &str, data: &str) -> Result<(Command, Vec<u8>)> {
+fn opencode_http_command(
+    endpoint: &str,
+    password: &str,
+    path: &str,
+    data: Option<&str>,
+    workspace: Option<&Path>,
+) -> Result<(Command, Vec<u8>)> {
     let mut url = url::Url::parse(endpoint).wrap_err("invalid OpenCode service endpoint")?;
     if url.scheme() != "http"
         || !url.username().is_empty()
@@ -658,14 +674,46 @@ fn generation_command(endpoint: &str, password: &str, data: &str) -> Result<(Com
         Some(url::Host::Ipv6(ip)) if ip.is_loopback() => {}
         _ => return Err(eyre!("OpenCode service must use a loopback HTTP endpoint")),
     }
-    url.set_path("/api/generate");
-    let mut input = String::new();
-    for (key, value) in [
+    url.set_path(path);
+    let mut command = Command::new("/usr/bin/curl");
+    let directory = if let Some(workspace) = workspace {
+        fs::create_dir_all(workspace).wrap_err_with(|| {
+            format!(
+                "could not create OpenCode workspace {}",
+                workspace.display()
+            )
+        })?;
+        let workspace = workspace.canonicalize().wrap_err_with(|| {
+            format!(
+                "could not resolve OpenCode workspace {}",
+                workspace.display()
+            )
+        })?;
+        let directory = workspace
+            .to_str()
+            .ok_or_else(|| eyre!("OpenCode workspace path is not valid UTF-8"))?;
+        command.current_dir(&workspace);
+        Some(format!(
+            "x-opencode-directory:{}",
+            encode_uri_component(directory)
+        ))
+    } else {
+        None
+    };
+    let user = format!("opencode:{password}");
+    let mut options = vec![
         ("url", url.as_str()),
-        ("user", &format!("opencode:{password}")),
+        ("user", user.as_str()),
         ("header", "Content-Type: application/json"),
-        ("data-binary", data),
-    ] {
+    ];
+    if let Some(data) = data {
+        options.push(("data-binary", data));
+    }
+    if let Some(directory) = directory.as_deref() {
+        options.push(("header", directory));
+    }
+    let mut input = String::new();
+    for (key, value) in options {
         input.push_str(key);
         input.push_str(" = \"");
         for ch in value.chars() {
@@ -683,7 +731,6 @@ fn generation_command(endpoint: &str, password: &str, data: &str) -> Result<(Com
         }
         input.push_str("\"\n");
     }
-    let mut command = Command::new("/usr/bin/curl");
     // Ignore curlrc, proxies, and redirects. Both credentials and body stay off argv and disk.
     command.args([
         "--disable",
@@ -954,36 +1001,6 @@ fn version_manager_candidates(home: Option<&Path>) -> Vec<PathBuf> {
         .collect()
 }
 
-fn opencode_command() -> Result<Command> {
-    opencode_command_in(&crate::app_paths::opencode_workspace()?)
-}
-
-fn opencode_command_in(workspace: &Path) -> Result<Command> {
-    fs::create_dir_all(workspace).wrap_err_with(|| {
-        format!(
-            "could not create OpenCode workspace {}",
-            workspace.display()
-        )
-    })?;
-    let workspace = workspace.canonicalize().wrap_err_with(|| {
-        format!(
-            "could not resolve OpenCode workspace {}",
-            workspace.display()
-        )
-    })?;
-    let directory = workspace
-        .to_str()
-        .ok_or_else(|| eyre!("OpenCode workspace path is not valid UTF-8"))?;
-    let directory = encode_uri_component(directory);
-    let mut command = Command::new(opencode_executable());
-    command.current_dir(&workspace).args([
-        "api",
-        "--header",
-        &format!("x-opencode-directory:{directory}"),
-    ]);
-    Ok(command)
-}
-
 fn encode_uri_component(value: &str) -> String {
     let mut encoded = String::with_capacity(value.len());
     for byte in value.bytes() {
@@ -1045,33 +1062,105 @@ mod tests {
     }
 
     #[test]
-    fn opencode_requests_are_scoped_to_the_hex_workspace() {
+    fn catalog_http_decodes_large_responses_with_private_auth_and_workspace_scope() {
+        use std::io::BufRead;
+
         let root = std::env::temp_dir().join(format!(
             "hex-opencode-workspace-{}-{:?}",
             std::process::id(),
             thread::current().id()
         ));
-        let root = root.join("scope %2F café");
-
-        let command = opencode_command_in(&root).unwrap();
+        let root = root.join("scope %2F caf\u{00e9}");
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let (command, _) = opencode_http_command(
+            &endpoint,
+            "fixture-password",
+            "/api/model",
+            None,
+            Some(&root),
+        )
+        .unwrap();
         let workspace = root.canonicalize().unwrap();
-        let args = command
-            .get_args()
-            .map(|arg| arg.to_string_lossy().into_owned())
-            .collect::<Vec<_>>();
-
+        assert_eq!(command.get_program(), OsStr::new("/usr/bin/curl"));
         assert_eq!(command.get_current_dir(), Some(workspace.as_path()));
-        assert_eq!(
-            args,
-            [
-                "api",
-                "--header",
-                &format!(
-                    "x-opencode-directory:{}",
-                    encode_uri_component(workspace.to_str().unwrap())
-                )
-            ]
+        for arg in command.get_args() {
+            assert!(!arg.to_string_lossy().contains("fixture-password"));
+            assert!(
+                !arg.to_string_lossy()
+                    .contains("b3BlbmNvZGU6Zml4dHVyZS1wYXNzd29yZA==")
+            );
+        }
+        let scope_header = format!(
+            "x-opencode-directory:{}\r\n",
+            encode_uri_component(workspace.to_str().unwrap())
         );
+        let wire_models: Vec<_> = (0..2048)
+            .map(|index| {
+                serde_json::json!({
+                    "id": format!("rewrite-{index}"),
+                    "providerID": "example",
+                    "name": format!("Example Rewrite {index}"),
+                    "enabled": true,
+                    "capabilities": { "output": ["text"] },
+                    "variants": [{ "id": "high" }]
+                })
+            })
+            .collect();
+        let models = serde_json::json!({ "data": wire_models }).to_string();
+        let default = serde_json::json!({ "data": wire_models.last().unwrap() }).to_string();
+        assert!(models.len() > 256 * 1024);
+        let server = thread::spawn(move || {
+            for (path, response) in [("/api/model", models), ("/api/model/default", default)] {
+                let (mut stream, _) = listener.accept().unwrap();
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .unwrap();
+                stream
+                    .set_write_timeout(Some(Duration::from_secs(5)))
+                    .unwrap();
+                let mut reader = std::io::BufReader::new(&mut stream);
+                let mut headers = String::new();
+                loop {
+                    let mut line = String::new();
+                    assert!(reader.read_line(&mut line).unwrap() > 0);
+                    if line == "\r\n" {
+                        break;
+                    }
+                    headers.push_str(&line);
+                }
+                assert!(headers.starts_with(&format!("GET {path} HTTP/1.1\r\n")));
+                assert!(
+                    headers
+                        .contains("Authorization: Basic b3BlbmNvZGU6Zml4dHVyZS1wYXNzd29yZA==\r\n")
+                );
+                assert!(headers.contains(&scope_header));
+                assert!(!headers.to_ascii_lowercase().contains("content-length:"));
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response}",
+                    response.len()
+                )
+                .unwrap();
+            }
+        });
+        let models: ModelsResponse =
+            opencode_api(&endpoint, "fixture-password", &root, "/api/model").unwrap();
+        let default: DefaultModelResponse =
+            opencode_api(&endpoint, "fixture-password", &root, "/api/model/default").unwrap();
+        server.join().unwrap();
+        let catalog = build_model_catalog(models.data, default.data);
+        assert_eq!(catalog.models.len(), 2048);
+        assert_eq!(catalog.default_key.as_deref(), Some("example/rewrite-2047"));
+        assert_eq!(
+            catalog.default_name.as_deref(),
+            Some("Example Rewrite 2047")
+        );
+        for (index, model) in catalog.models.iter().enumerate() {
+            assert_eq!(model.key, format!("example/rewrite-{index}"));
+            assert_eq!(model.name, format!("Example Rewrite {index}"));
+            assert_eq!(model.variants, ["high"]);
+        }
         std::fs::remove_dir_all(root.parent().unwrap()).unwrap();
     }
 
@@ -1510,7 +1599,14 @@ mod tests {
             model: None,
         })
         .unwrap();
-        let (command, input) = generation_command(&endpoint, "fixture-password", &data).unwrap();
+        let (command, input) = opencode_http_command(
+            &endpoint,
+            "fixture-password",
+            "/api/generate",
+            Some(&data),
+            None,
+        )
+        .unwrap();
         for arg in command.get_args() {
             assert!(!arg.to_string_lossy().contains("fixture"));
             assert!(!arg.to_string_lossy().contains(&prompt));
@@ -1543,7 +1639,16 @@ mod tests {
             "http://127.0.0.1:0",
             "file:///tmp/fixture",
         ] {
-            assert!(generation_command(endpoint, "fixture-password", "{}").is_err());
+            assert!(
+                opencode_http_command(
+                    endpoint,
+                    "fixture-password",
+                    "/api/generate",
+                    Some("{}"),
+                    None,
+                )
+                .is_err()
+            );
         }
         for (endpoint, expected) in [
             (
@@ -1553,7 +1658,14 @@ mod tests {
             ("http://0.0.0.0:1234", "http://127.0.0.1:1234/api/generate"),
             ("http://[::]:1234", "http://[::1]:1234/api/generate"),
         ] {
-            let (_, input) = generation_command(endpoint, "fixture-password", "{}").unwrap();
+            let (_, input) = opencode_http_command(
+                endpoint,
+                "fixture-password",
+                "/api/generate",
+                Some("{}"),
+                None,
+            )
+            .unwrap();
             assert!(String::from_utf8(input).unwrap().contains(expected));
         }
     }
@@ -1572,7 +1684,14 @@ mod tests {
                 let mut byte = [0];
                 assert_eq!(stream.read(&mut byte).unwrap(), 0);
             });
-            let (command, input) = generation_command(&endpoint, "fixture-password", "{}").unwrap();
+            let (command, input) = opencode_http_command(
+                &endpoint,
+                "fixture-password",
+                "/api/generate",
+                Some("{}"),
+                None,
+            )
+            .unwrap();
             let started = Instant::now();
             let error = run_command(
                 command,
@@ -1609,6 +1728,14 @@ mod tests {
         .unwrap();
         assert!(error.to_string().contains("exceeded"));
         assert!(started.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    #[ignore = "requires the installed opencode2 CLI and its managed service"]
+    fn live_catalog() {
+        let catalog =
+            load_model_catalog().unwrap_or_else(|_| panic!("could not load live model catalog"));
+        println!("{}", catalog.models.len());
     }
 
     #[test]


### PR DESCRIPTION
## Why

An older Rust beta already reported 2.1.0/build 20100, the same build number as the public 2.1.0 release. Sparkle therefore considered the beta current despite its older executable. Existing users also opened Modes instead of the Settings permission controls, and a large OpenCode catalog could fail to load with an invalid-JSON error.

## What Changes

| Before | After |
| --- | --- |
| Old Rust beta and public 2.1.0 both report build 20100 | 2.1.1/build 20101 is strictly newer |
| New app windows open Modes | New windows open Settings |
| Reopening a window preserves Modes with missing permissions | Reopening refreshes permissions and selects Settings when needed |
| Catalog JSON is read from piped CLI stdout | Catalog GETs use the existing authenticated loopback curl transport |
| Settings promises automatic downloads | Settings describes automatic update checks |

The model-list failure was reproduced with the installed OpenCode CLI: a regular-file response was complete, but the same response piped through `jq` ended mid-string at exactly 262144 bytes. The fix keeps CLI-managed service discovery, workspace scoping, owner-only registration checks, bounded output, and stdin-only credentials. Generation continues using the same HTTP transport and behavior.

The update keeps the existing Rust feed and signing key, and the updater ZIP still contains `HEX.app` for old-app filename discovery. The manual DMG contains `Hex.app`.

## Scope

This is a focused macOS update and setup repair, not a broad refactor. The Swift app and its separate feed remain unchanged. Updating an older Rust bundle identity preserves Rust data but requires new macOS permission grants and re-enabling Launch at Login if desired.

## Verification

```sh
cargo fmt --check
cargo test --locked --bin voice-control
cargo test --locked --bin voice-control dictation_processor::tests::live_catalog -- --ignored --exact --nocapture
cargo clippy --locked --all-targets --all-features -- -D warnings
./scripts/test-app-identity.sh
git diff --check
```

335 tests passed, 9 ignored; Clippy, formatting, and identity guards passed. The navigation regression test was run failing before the fix. A loopback test serves a synthetic catalog larger than 256 KiB and verifies complete decoding, Basic authentication, and the encoded workspace header. Live catalog loading passed with 436 available text models. A final read-only review found no blockers.

Apple accepted both app and DMG notarization, both are stapled, and Gatekeeper accepts them. Signed Settings with missing permissions and Modes previews opened successfully. Screenshot capture is unavailable because the terminal has no Screen Recording permission.

Native Sparkle 2.9.4 update validation and temporary installation passed against three actual signed apps: public 2.0.24 (`com.kitlangton.voice-control.agent`, 20024), the old Rust 2.1.0 beta (`com.kitlangton.Hex`, 20100), and public 2.1.0 (`com.kitlangton.hex2`, 20100). Each test retains the old bundle filename and checks Sparkle's strict version comparison, EdDSA verification, extraction, installation, and the new app's nested signature and metadata.

Publication completed artifact-first/feed-last. Versioned DMG, latest DMG, updater ZIP, and appcast were downloaded and matched the prepared files byte-for-byte. After invoking the installed app's update check, the local app updated to 2.1.1/build 20101 and relaunched; installed file contents and signatures match the release.

## Release Artifacts

[Download Hex 2.1.1](https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/releases/HEX-2.1.1-arm64.dmg)

- DMG: 34,482,597 bytes; SHA-256 `c50c86690bad2e844a52ee5875ce5ff1e0ca1aa117b79f4f10625bb55593e2fd`.
- Updater ZIP: 32,793,904 bytes; SHA-256 `d6ab1d66b977b93cfa1a81885296c822dcbd7ad3e2d7495749dc723028fc6820`.
