### PR TITLE
fix: keep dictation available and tighten runtime lifecycles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,9 @@ CoreAudio formats, AppleScript details, or event serialization.
   recognizer and executor.
 - On a new Mac, release dictation starts only after Microphone, Input Monitoring,
   Accessibility, and the selected dictation model are ready. Opt-in command
-  recognition additionally requires Moonshine.
+  recognition additionally requires Moonshine, but its background preparation or
+  failure must never block hotkey dictation. Failed preparation exposes explicit
+  retry and disable actions without silently changing the command opt-in.
 - Among recognized voice commands, sleeping mode accepts only standalone wake
   phrases. Dictation and explicit paste shortcuts remain available.
 - Unmatched completed speech is ignored and logged.
@@ -236,6 +238,8 @@ CoreAudio formats, AppleScript details, or event serialization.
   final text plus bounded metadata, never audio, full browser URLs, or window
   titles. Every retention window remains subject to hard entry and byte caps,
   and recording stops while retention is Off.
+  Time-based retention expires during idle uptime through the shared history
+  owner; searches never return expired entries while waiting for disk cleanup.
 - Developer-only meeting detection may inspect process audio metadata but must
   not capture samples. Detection can offer recording; it must never start
   automatically. Release builds must not start the meeting controller.
@@ -306,6 +310,7 @@ cargo run -- preview onboarding
 cargo run -- preview transcription-picker --language zh --model-state installed
 ./scripts/capture-preview.sh /tmp/hex-preview.png settings
 ./scripts/capture-preview.sh /tmp/hex-model-missing.png settings --model-missing
+./scripts/capture-preview.sh /tmp/hex-command-model-missing.png settings --command-model-missing
 ./scripts/capture-preview.sh /tmp/hex-history-retention.png history --open-history-retention
 ./scripts/capture-preview.sh /tmp/hex-modes.png modes
 ./scripts/capture-preview.sh /tmp/hex-modes-collapsed.png modes --collapse-mode-processing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8536,7 +8536,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voice-control"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice-control"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 default-run = "voice-control"
 license = "MIT"

--- a/docs/releases/2.1.2.md
+++ b/docs/releases/2.1.2.md
@@ -1,0 +1,20 @@
+## Hex 2.1.2
+
+- Hotkey dictation stays available while the optional voice-command model downloads
+  or fails to load. A visible status offers Retry or Turn off commands; failed
+  preparation never silently changes your command preference.
+- Time-based history retention now expires old entries while Hex is idle, rather
+  than waiting for another dictation or restart. Turning retention Off still
+  preserves existing entries until you delete them.
+- Composing text with an input method now creates one undoable edit, including
+  when the committed text matches the last composition candidate.
+- Failed update checks no longer leave Settings stuck on Checking.
+- Escape can cancel a completed transcription while its clipboard contents are
+  still being prepared. Once insertion begins, paste remains atomic with respect
+  to cancellation.
+- Simplified clipboard worker initialization by removing an unreachable failure
+  path and its redundant availability state.
+
+This release uses build 20102 and the existing Rust update feed, signing key, and
+`com.kitlangton.hex2` identity. Updates from 2.1.1 retain macOS permissions and
+settings. The legacy Swift app and its separate update feed are unchanged.

--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -56,6 +56,7 @@ use crate::onboarding::{
     PermissionAction, PermissionKind, PermissionState, PermissionWarning, SetupStatus,
 };
 use crate::personal_commands::{HostState, StatusContext, StatusSnapshot, StatusTransformation};
+use crate::recognition::CommandModelStatus;
 use crate::text_input::{
     Changed as TextChanged, Dismissed as TextDismissed, Navigate as TextNavigate,
     Submitted as TextSubmitted, TextInput,
@@ -82,6 +83,7 @@ actions!(
     [
         CloseWindow,
         CheckForUpdates,
+        RetryCommands,
         HideApplication,
         MinimizeWindow,
         QuitApplication,
@@ -250,6 +252,7 @@ pub struct AppWindowPreview {
     pub opencode_unavailable: bool,
     pub permissions_missing: bool,
     pub model_missing: bool,
+    pub command_model_missing: bool,
     pub open_history_retention: bool,
 }
 
@@ -758,6 +761,7 @@ pub struct AppWindow {
     update_status: crate::sparkle::UpdateStatus,
     update_status_changed_at: Instant,
     commands_toggle: ToggleSpring,
+    command_model_status: CommandModelStatus,
     release_microphone_toggle: ToggleSpring,
     pending_microphone_policy: Option<MicrophonePolicyChange>,
     double_tap_toggle: ToggleSpring,
@@ -859,6 +863,14 @@ impl AppWindow {
                         let application_catalog_changed = window.poll_application_catalog();
                         let transcription_changed = window.poll_transcription_download();
                         let setup_changed = window.poll_setup(false);
+                        let command_model_status = if window.preview {
+                            window.command_model_status
+                        } else {
+                            crate::recognition::command_model_status()
+                        };
+                        let command_model_changed =
+                            window.command_model_status != command_model_status;
+                        window.command_model_status = command_model_status;
                         let login_item_changed = window.poll_login_item();
                         let personal_commands_changed = window.poll_personal_commands();
                         let personal_workspace_changed = window.poll_personal_workspace();
@@ -887,6 +899,7 @@ impl AppWindow {
                             || application_catalog_changed
                             || transcription_changed
                             || setup_changed
+                            || command_model_changed
                             || login_item_changed
                             || personal_commands_changed
                             || personal_workspace_changed
@@ -907,7 +920,10 @@ impl AppWindow {
         let preview_mode = preview.is_some();
         let preview_choices = crate::transcription_models::choices_for_runtime;
         let (settings, settings_load_error) = if let Some(preview) = &preview {
-            let mut settings = AppSettings::default();
+            let mut settings = AppSettings {
+                commands_enabled: preview.command_model_missing,
+                ..AppSettings::default()
+            };
             if let Some((language, _)) = &preview.transcription_picker
                 && let Some(choice) = preview_choices(language).first()
             {
@@ -1053,7 +1069,6 @@ impl AppWindow {
                 microphone: PermissionState::NeedsRequest,
                 input_monitoring: PermissionState::NeedsRequest,
                 accessibility: PermissionState::NeedsRequest,
-                command_model: false,
                 transcription_model: false,
             }
         } else if preview
@@ -1064,7 +1079,6 @@ impl AppWindow {
                 microphone: PermissionState::NeedsRequest,
                 input_monitoring: PermissionState::NeedsSettings,
                 accessibility: PermissionState::NeedsSettings,
-                command_model: true,
                 transcription_model: !preview_model_missing,
             }
         } else if preview_mode {
@@ -1072,7 +1086,6 @@ impl AppWindow {
                 microphone: PermissionState::Ready,
                 input_monitoring: PermissionState::Ready,
                 accessibility: PermissionState::Ready,
-                command_model: true,
                 transcription_model: !preview_model_missing,
             }
         } else {
@@ -1141,6 +1154,16 @@ impl AppWindow {
             update_status: crate::sparkle::status(),
             update_status_changed_at: Instant::now(),
             commands_toggle: ToggleSpring::new(settings.commands_enabled),
+            command_model_status: if preview
+                .as_ref()
+                .is_some_and(|preview| preview.command_model_missing)
+            {
+                CommandModelStatus::Failed
+            } else if preview_mode {
+                CommandModelStatus::Disabled
+            } else {
+                crate::recognition::command_model_status()
+            },
             release_microphone_toggle: ToggleSpring::new(settings.release_microphone_while_idle),
             pending_microphone_policy: None,
             double_tap_toggle: ToggleSpring::new(settings.double_tap_lock),
@@ -1649,9 +1672,6 @@ impl AppWindow {
                 String::new()
             },
         };
-        let install_command_model = self.setup_visible
-            && self.settings.commands_enabled
-            && !crate::moonshine::model_installed();
         self.transcription_picker_error = None;
         if self.preview {
             self.apply_transcription_selection(selection);
@@ -1662,8 +1682,7 @@ impl AppWindow {
             model,
             &selection.language,
             self.transcription_model_installed(model, &selection.language),
-        ) && !install_command_model
-        {
+        ) {
             self.transcription_picker_language = None;
             return;
         }
@@ -1678,9 +1697,6 @@ impl AppWindow {
         self.transcription_activation_started = Some(Instant::now());
         thread::spawn(move || {
             let result = (|| {
-                if install_command_model {
-                    crate::moonshine::install_model()?;
-                }
                 if matches!(model.runtime, ModelRuntime::Gguf(_)) {
                     crate::transcription_models::download_with_progress(
                         model, &canceled, &progress,
@@ -3058,8 +3074,53 @@ impl AppWindow {
         if self.setup_visible {
             return None;
         }
-        let (title, description) =
-            dictation_model_notice(self.setup_status, self.transcription_downloading.is_some())?;
+        let dictation_notice =
+            dictation_model_notice(self.setup_status, self.transcription_downloading.is_some());
+        let (title, description) = dictation_notice.or_else(|| {
+            self.settings
+                .commands_enabled
+                .then(|| command_model_notice(&self.command_model_status))
+                .flatten()
+        })?;
+        let action = if dictation_notice.is_some() {
+            compact_button("Choose model")
+                .id("choose-required-model")
+                .bg(rgb(ACCENT))
+                .text_color(rgb(TEXT))
+                .on_click(cx.listener(|this, _, _, cx| {
+                    this.transcription_picker_language =
+                        Some(this.settings.transcription.language.clone());
+                    cx.notify();
+                }))
+                .into_any_element()
+        } else {
+            div()
+                .flex()
+                .items_center()
+                .gap_2()
+                .when(
+                    matches!(self.command_model_status, CommandModelStatus::Failed),
+                    |controls| {
+                        controls.child(compact_button("Retry").id("retry-command-model").on_click(
+                            cx.listener(|this, _, _, cx| {
+                                if !this.preview {
+                                    cx.dispatch_action(&RetryCommands);
+                                }
+                            }),
+                        ))
+                    },
+                )
+                .child(
+                    compact_button("Turn off commands")
+                        .id("disable-unavailable-commands")
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            if let Err(error) = this.developer_set_commands_enabled(false, cx) {
+                                tracing::warn!(%error, "could not disable voice commands");
+                            }
+                        })),
+                )
+                .into_any_element()
+        };
         Some(
             div()
                 .id("dictation-model-notice")
@@ -3088,18 +3149,7 @@ impl AppWindow {
                                 .pl_3()
                                 .child(settings_copy(title, description)),
                         )
-                        .child(
-                            compact_button("Choose model")
-                                .id("choose-required-model")
-                                .flex_shrink_0()
-                                .bg(rgb(ACCENT))
-                                .text_color(rgb(TEXT))
-                                .on_click(cx.listener(|this, _, _, cx| {
-                                    this.transcription_picker_language =
-                                        Some(this.settings.transcription.language.clone());
-                                    cx.notify();
-                                })),
-                        ),
+                        .child(div().flex_shrink_0().child(action)),
                 )
                 .into_any_element(),
         )
@@ -3493,10 +3543,7 @@ impl AppWindow {
                                             .border_1()
                                             .border_color(rgb(LINE))
                                             .bg(rgb(CANVAS))
-                                            .on_click(cx.listener(|this, _, _, cx| {
-                                                this.update_status =
-                                                    crate::sparkle::UpdateStatus::Checking;
-                                                this.update_status_changed_at = Instant::now();
+                                            .on_click(cx.listener(|_this, _, _, cx| {
                                                 cx.dispatch_action(&CheckForUpdates);
                                                 cx.notify();
                                             })),
@@ -3640,7 +3687,7 @@ impl AppWindow {
                 accessibility,
             ));
         }
-        let models_ready = status.command_model && status.transcription_model;
+        let models_ready = status.transcription_model;
         let model_notice = dictation_model_notice(status, self.transcription_downloading.is_some());
         let models = if models_ready {
             setup_ready_badge()
@@ -3695,11 +3742,7 @@ impl AppWindow {
                                     .text_size(px(12.0))
                                     .line_height(px(19.0))
                                     .text_color(rgb(MUTED))
-                                    .child(if self.settings.commands_enabled {
-                                        "Everything stays on this Mac. HEX starts listening after the required permissions and local models are ready."
-                                    } else {
-                                        "Everything stays on this Mac. HEX is ready once permissions and your local dictation model are set up."
-                                    }),
+                                    .child("Everything stays on this Mac. HEX is ready once permissions and your local dictation model are set up."),
                             ),
                     )
                     .when(!permission_rows.is_empty(), |setup| {
@@ -3719,15 +3762,11 @@ impl AppWindow {
                                 div().border_t_1().border_color(rgb(LINE)).child(setup_row(
                                     if let Some((title, _)) = model_notice {
                                         title
-                                    } else if self.settings.commands_enabled {
-                                        "Local speech models"
                                     } else {
                                         "Local dictation model"
                                     },
                                     if let Some((_, description)) = model_notice {
                                         description
-                                    } else if self.settings.commands_enabled {
-                                        "Command recognition and the selected dictation model."
                                     } else {
                                         "The selected model transcribes speech entirely on this Mac."
                                     },
@@ -8001,6 +8040,20 @@ fn dictation_model_notice(
     })
 }
 
+fn command_model_notice(status: &CommandModelStatus) -> Option<(&'static str, &'static str)> {
+    match status {
+        CommandModelStatus::Disabled | CommandModelStatus::Ready => None,
+        CommandModelStatus::Loading => Some((
+            "Preparing voice commands",
+            "The command model is loading. Hotkey dictation does not require it.",
+        )),
+        CommandModelStatus::Failed => Some((
+            "Voice commands are unavailable",
+            "The command model could not load. Retry or turn off commands; hotkey dictation is unaffected.",
+        )),
+    }
+}
+
 fn setup_row(title: &'static str, description: &'static str, control: AnyElement) -> Div {
     div()
         .w_full()
@@ -8443,13 +8496,27 @@ mod tests {
     use crate::personal_commands::StatusExecution;
 
     #[test]
+    fn command_model_failure_has_recovery_without_blocking_dictation() {
+        assert!(command_model_notice(&CommandModelStatus::Ready).is_none());
+        assert!(command_model_notice(&CommandModelStatus::Disabled).is_none());
+        assert_eq!(
+            command_model_notice(&CommandModelStatus::Loading)
+                .unwrap()
+                .0,
+            "Preparing voice commands"
+        );
+        let (_, description) = command_model_notice(&CommandModelStatus::Failed).unwrap();
+        assert!(description.contains("Retry"));
+        assert!(description.contains("dictation is unaffected"));
+    }
+
+    #[test]
     fn opening_the_app_prioritizes_settings_and_missing_permissions() {
         assert_eq!(Pane::default(), Pane::Settings);
         let ready = SetupStatus {
             microphone: PermissionState::Ready,
             input_monitoring: PermissionState::Ready,
             accessibility: PermissionState::Ready,
-            command_model: true,
             transcription_model: true,
         };
         assert_eq!(Pane::Modes.on_reopen(ready), Pane::Modes);
@@ -8480,7 +8547,6 @@ mod tests {
             microphone: PermissionState::Ready,
             input_monitoring: PermissionState::Ready,
             accessibility: PermissionState::Ready,
-            command_model: true,
             transcription_model: false,
         };
         let (title, description) = dictation_model_notice(status, false).unwrap();
@@ -8499,9 +8565,8 @@ mod tests {
         assert!(dictation_model_notice(status, false).is_none());
         assert!(dictation_model_notice(status, true).is_none());
 
-        // Permission and opt-in command-model failures have their own setup UI.
+        // Permission failures have their own setup UI.
         status.microphone = PermissionState::NeedsRequest;
-        status.command_model = false;
         assert!(dictation_model_notice(status, false).is_none());
     }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -9,8 +9,9 @@
 use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::{Arc, Mutex, TryLockError, mpsc};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
@@ -20,6 +21,7 @@ const MAX_TEXT_BYTES: usize = 16 * 1024;
 const MAX_LABEL_BYTES: usize = 256;
 const MAX_FALLBACK_BYTES: usize = 1_024;
 const MAX_TOTAL_TEXT_BYTES: usize = 4 * 1024 * 1024;
+const PRUNE_INTERVAL: Duration = Duration::from_secs(60);
 pub const MAX_SEARCH_RESULTS: usize = 200;
 
 /// How long successful results remain in retained history.
@@ -162,6 +164,8 @@ pub struct HistoryStore {
     entries: Vec<HistoryEntry>,
     next_id: u64,
     retention: HistoryRetention,
+    prune_pending: bool,
+    prune_error_reported: bool,
 }
 
 impl HistoryStore {
@@ -174,6 +178,8 @@ impl HistoryStore {
             entries: Vec::new(),
             next_id: 1,
             retention,
+            prune_pending: false,
+            prune_error_reported: false,
         };
         match fs::read(&store.path) {
             Ok(bytes) => match serde_json::from_slice::<LoadedHistory>(&bytes) {
@@ -199,11 +205,7 @@ impl HistoryStore {
                 tracing::warn!(%error, path = %store.path.display(), "could not read history");
             }
         }
-        if store.prune(now_ms)
-            && let Err(error) = store.persist()
-        {
-            tracing::warn!(%error, "could not persist pruned history");
-        }
+        store.expire(now_ms);
         store
     }
 
@@ -291,15 +293,29 @@ impl HistoryStore {
 
     /// Case-insensitive substring search over text, application, and
     /// processing profile. Newest first and bounded.
-    pub fn search(&self, query: &str) -> Vec<&HistoryEntry> {
+    pub fn search(&self, query: &str, now_ms: u64) -> Vec<&HistoryEntry> {
         let needle = query.trim().to_lowercase();
-        if needle.is_empty() {
-            return self.entries().take(MAX_SEARCH_RESULTS).collect();
-        }
+        let cutoff = self
+            .retention
+            .max_age_ms()
+            .map(|max_age| now_ms.saturating_sub(max_age));
         self.entries()
-            .filter(|entry| entry.matches(&needle))
+            .filter(|entry| cutoff.is_none_or(|cutoff| entry.timestamp_ms >= cutoff))
+            .filter(|entry| needle.is_empty() || entry.matches(&needle))
             .take(MAX_SEARCH_RESULTS)
             .collect()
+    }
+
+    fn expire(&mut self, now_ms: u64) {
+        self.prune(now_ms);
+        if self.prune_pending
+            && let Err(error) = self.persist()
+        {
+            if !self.prune_error_reported {
+                tracing::warn!(%error, "could not persist pruned history; will retry");
+            }
+            self.prune_error_reported = true;
+        }
     }
 
     fn prune(&mut self, now_ms: u64) -> bool {
@@ -319,10 +335,11 @@ impl HistoryStore {
             total -= self.entries.remove(0).text_bytes();
             changed = true;
         }
+        self.prune_pending |= changed;
         changed
     }
 
-    fn persist(&self) -> io::Result<()> {
+    fn persist(&mut self) -> io::Result<()> {
         let saved = SavedHistory {
             version: VERSION,
             next_id: self.next_id,
@@ -339,7 +356,10 @@ impl HistoryStore {
             file.write_all(&json)?;
             file.sync_all()?;
         }
-        fs::rename(&temporary, &self.path)
+        fs::rename(&temporary, &self.path)?;
+        self.prune_pending = false;
+        self.prune_error_reported = false;
+        Ok(())
     }
 
     fn preserve_corrupt(&self) {
@@ -354,12 +374,41 @@ impl HistoryStore {
 #[derive(Clone)]
 pub struct History {
     store: Arc<Mutex<HistoryStore>>,
+    // Only handles own senders: dropping the last clone wakes and stops the worker.
+    _shutdown: mpsc::Sender<()>,
 }
 
 impl History {
     pub fn new(store: HistoryStore) -> Self {
+        Self::with_clock(store, PRUNE_INTERVAL, now_ms)
+    }
+
+    fn with_clock(
+        store: HistoryStore,
+        interval: Duration,
+        clock: impl Fn() -> u64 + Send + 'static,
+    ) -> Self {
+        let store = Arc::new(Mutex::new(store));
+        let (shutdown, stopped) = mpsc::channel();
+        let worker_store = Arc::clone(&store);
+        if let Err(error) = thread::Builder::new()
+            .name("history-retention".into())
+            .spawn(move || {
+                while let Err(mpsc::RecvTimeoutError::Timeout) = stopped.recv_timeout(interval) {
+                    let mut store = match worker_store.try_lock() {
+                        Ok(store) => store,
+                        Err(TryLockError::WouldBlock) => continue,
+                        Err(TryLockError::Poisoned(error)) => error.into_inner(),
+                    };
+                    store.expire(clock());
+                }
+            })
+        {
+            tracing::warn!(%error, "could not start history retention worker");
+        }
         Self {
-            store: Arc::new(Mutex::new(store)),
+            store,
+            _shutdown: shutdown,
         }
     }
 
@@ -387,7 +436,11 @@ impl History {
 
     /// Bounded snapshot of matching entries, newest first.
     pub fn search(&self, query: &str) -> Vec<HistoryEntry> {
-        self.locked().search(query).into_iter().cloned().collect()
+        self.locked()
+            .search(query, now_ms())
+            .into_iter()
+            .cloned()
+            .collect()
     }
 
     fn locked(&self) -> std::sync::MutexGuard<'_, HistoryStore> {
@@ -499,6 +552,126 @@ mod tests {
     }
 
     #[test]
+    fn search_hides_expired_entries_before_the_next_idle_prune() {
+        let path = temp_path("search-expiry");
+        let day_ms = HistoryRetention::Day.max_age_ms().unwrap();
+        let mut store = HistoryStore::open(path.clone(), HistoryRetention::Day, 0);
+        store.record(draft("old"), 1_000).unwrap();
+        store.record(draft("fresh"), 2_000).unwrap();
+        fs::File::open(&path)
+            .unwrap()
+            .set_modified(UNIX_EPOCH)
+            .unwrap();
+
+        assert_eq!(store.search("", day_ms + 1_000).len(), 2);
+        assert!(store.search("old", day_ms + 1_001).is_empty());
+        let matches = store.search("", day_ms + 1_001);
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].final_text, "fresh");
+        assert_eq!(
+            store.len(),
+            2,
+            "reads filter without writing on the UI thread"
+        );
+        assert_eq!(fs::metadata(&path).unwrap().modified().unwrap(), UNIX_EPOCH);
+    }
+
+    #[test]
+    fn idle_worker_expires_entries_on_disk_without_recording_or_reading() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        let path = temp_path("idle-expiry");
+        let day_ms = HistoryRetention::Day.max_age_ms().unwrap();
+        let mut store = HistoryStore::open(path.clone(), HistoryRetention::Day, 0);
+        store.record(draft("old"), 1_000).unwrap();
+        store.record(draft("fresh"), 2_000).unwrap();
+        let clock = Arc::new(AtomicU64::new(2_000));
+        let worker_clock = Arc::clone(&clock);
+        let (ticks, ticked) = mpsc::channel();
+        let history = History::with_clock(store, Duration::from_millis(10), move || {
+            let now = worker_clock.load(Ordering::SeqCst);
+            let _ = ticks.send(now);
+            now
+        });
+        let tick = |now| {
+            clock.store(now, Ordering::SeqCst);
+            while ticked.recv_timeout(Duration::from_secs(2)).unwrap() != now {}
+            // The clock is sampled under the lock; acquiring it waits for that prune.
+            drop(history.locked());
+        };
+        fs::File::open(&path)
+            .unwrap()
+            .set_modified(UNIX_EPOCH)
+            .unwrap();
+
+        tick(day_ms + 1_000);
+        assert_eq!(fs::metadata(&path).unwrap().modified().unwrap(), UNIX_EPOCH);
+
+        tick(day_ms + 1_001);
+        let saved: LoadedHistory = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(saved.entries.len(), 1);
+        assert_eq!(saved.entries[0].final_text, "fresh");
+
+        tick(day_ms + 2_001);
+        let saved: LoadedHistory = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert!(saved.entries.is_empty());
+        fs::File::open(&path)
+            .unwrap()
+            .set_modified(UNIX_EPOCH)
+            .unwrap();
+        tick(2 * day_ms);
+        assert_eq!(fs::metadata(&path).unwrap().modified().unwrap(), UNIX_EPOCH);
+    }
+
+    #[test]
+    fn failed_expiry_persistence_retries_without_new_removals() {
+        let path = temp_path("expiry-retry");
+        let day_ms = HistoryRetention::Day.max_age_ms().unwrap();
+        let mut store = HistoryStore::open(path.clone(), HistoryRetention::Day, 0);
+        store.record(draft("old"), 1_000).unwrap();
+        let temporary = path.with_extension("json.tmp");
+        fs::create_dir(&temporary).unwrap();
+
+        store.expire(day_ms + 1_001);
+        assert!(store.entries.is_empty());
+        assert!(store.prune_pending);
+        assert!(store.prune_error_reported);
+        let saved: LoadedHistory = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(saved.entries.len(), 1);
+        store.expire(day_ms + 1_002);
+        assert!(store.prune_pending);
+        assert!(store.prune_error_reported);
+
+        fs::remove_dir(temporary).unwrap();
+        store.expire(day_ms + 1_003);
+        assert!(!store.prune_pending);
+        assert!(!store.prune_error_reported);
+        let saved: LoadedHistory = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert!(saved.entries.is_empty());
+    }
+
+    #[test]
+    fn idle_worker_stops_when_the_last_history_handle_is_dropped() {
+        let path = temp_path("worker-lifecycle");
+        let store = HistoryStore::open(path, HistoryRetention::Day, 0);
+        let (alive, stopped) = mpsc::channel::<()>();
+        let history = History::with_clock(store, Duration::from_secs(24 * 60 * 60), move || {
+            let _alive = &alive;
+            0
+        });
+        let clone = history.clone();
+        drop(history);
+        assert_eq!(stopped.try_recv(), Err(mpsc::TryRecvError::Empty));
+
+        drop(clone);
+        assert_eq!(
+            stopped.recv_timeout(Duration::from_secs(2)),
+            Err(mpsc::RecvTimeoutError::Disconnected),
+            "shutdown must wake the worker rather than wait for its timer"
+        );
+    }
+
+    #[test]
     fn choosing_week_retention_from_month_keeps_entries_newer_than_a_week() {
         let day_ms = 24 * 60 * 60 * 1_000;
         let now = 30 * day_ms;
@@ -523,12 +696,20 @@ mod tests {
     #[test]
     fn off_records_nothing_but_preserves_existing_entries() {
         let path = temp_path("off");
-        let mut store = HistoryStore::open(path, HistoryRetention::Week, 1_000);
+        let mut store = HistoryStore::open(path.clone(), HistoryRetention::Week, 1_000);
         store.record(draft("kept"), 1_000).unwrap();
         store.set_retention(HistoryRetention::Off, 1_500).unwrap();
+        fs::File::open(&path)
+            .unwrap()
+            .set_modified(UNIX_EPOCH)
+            .unwrap();
 
         assert_eq!(store.record(draft("dropped"), 2_000).unwrap(), None);
+        let later = HistoryRetention::Month.max_age_ms().unwrap() + 2_000;
+        store.expire(later);
         assert_eq!(store.len(), 1);
+        assert_eq!(store.search("kept", later).len(), 1);
+        assert_eq!(fs::metadata(&path).unwrap().modified().unwrap(), UNIX_EPOCH);
     }
 
     #[test]
@@ -572,11 +753,15 @@ mod tests {
         store.record(draft("Hello World"), 1_000).unwrap();
         store.record(draft("other text"), 2_000).unwrap();
 
-        assert_eq!(store.search("hello world").len(), 1);
-        assert_eq!(store.search("zed").len(), 2);
-        assert_eq!(store.search("messages").len(), 2);
-        assert_eq!(store.search("absent").len(), 0);
-        assert_eq!(store.search("  ").len(), 2, "blank queries list everything");
+        assert_eq!(store.search("hello world", 2_000).len(), 1);
+        assert_eq!(store.search("zed", 2_000).len(), 2);
+        assert_eq!(store.search("messages", 2_000).len(), 2);
+        assert_eq!(store.search("absent", 2_000).len(), 0);
+        assert_eq!(
+            store.search("  ", 2_000).len(),
+            2,
+            "blank queries list everything"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,9 @@ enum Command {
         /// Show the selected dictation model as missing without changing local files.
         #[arg(long)]
         model_missing: bool,
+        /// Show command-model recovery while dictation remains ready.
+        #[arg(long)]
+        command_model_missing: bool,
         /// Open the explicit history retention choices in the History preview.
         #[arg(long)]
         open_history_retention: bool,
@@ -443,6 +446,7 @@ fn main() -> Result<()> {
             opencode_unavailable,
             permissions_missing,
             model_missing,
+            command_model_missing,
             open_history_retention,
         } => {
             if matches!(target, AppPreviewTarget::DictationHud) {
@@ -488,6 +492,7 @@ fn main() -> Result<()> {
                     opencode_unavailable,
                     permissions_missing,
                     model_missing,
+                    command_model_missing,
                     open_history_retention,
                 },
             )

--- a/src/meeting_watcher.rs
+++ b/src/meeting_watcher.rs
@@ -360,6 +360,14 @@ fn run_with_shell_preview(
         cx.on_action(|_: &crate::app_window::CheckForUpdates, _| {
             crate::sparkle::check_for_updates()
         });
+        let retry_commands = recognition_control_sender.clone();
+        cx.on_action(move |_: &crate::app_window::RetryCommands, _| {
+            if let Err(error) =
+                retry_commands.try_send(crate::recognition::RecognitionControl::RetryCommands)
+            {
+                tracing::warn!(%error, "could not request command model retry");
+            }
+        });
         cx.on_action(|_: &crate::app_window::HideApplication, _| {
             crate::app_settings::hide_application()
         });

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -43,7 +43,6 @@ pub struct SetupStatus {
     pub microphone: PermissionState,
     pub input_monitoring: PermissionState,
     pub accessibility: PermissionState,
-    pub command_model: bool,
     pub transcription_model: bool,
 }
 
@@ -52,7 +51,6 @@ impl SetupStatus {
         self.microphone == PermissionState::Ready
             && self.input_monitoring == PermissionState::Ready
             && self.accessibility == PermissionState::Ready
-            && self.command_model
             && self.transcription_model
     }
 }
@@ -153,8 +151,6 @@ pub fn status_with_transcription_model(transcription_model: bool) -> SetupStatus
         microphone: microphone_state(),
         input_monitoring: settings(CGPreflightListenEventAccess()),
         accessibility: settings(CGPreflightPostEventAccess()),
-        command_model: !crate::app_settings::commands_enabled()
-            || crate::moonshine::model_installed(),
         transcription_model,
     }
 }
@@ -237,16 +233,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn setup_requires_every_required_capability() {
+    fn missing_commands_model_does_not_block_dictation_setup() {
         let mut status = SetupStatus {
             microphone: PermissionState::Ready,
             input_monitoring: PermissionState::Ready,
             accessibility: PermissionState::Ready,
-            command_model: true,
             transcription_model: true,
         };
         assert!(status.ready());
-        status.command_model = false;
+        status.transcription_model = false;
+        assert!(!status.ready());
+        status.transcription_model = true;
+        status.microphone = PermissionState::NeedsRequest;
+        assert!(!status.ready());
+        status.microphone = PermissionState::Ready;
+        status.input_monitoring = PermissionState::NeedsSettings;
+        assert!(!status.ready());
+        status.input_monitoring = PermissionState::Ready;
+        status.accessibility = PermissionState::NeedsSettings;
         assert!(!status.ready());
     }
 
@@ -341,7 +345,6 @@ mod tests {
             microphone: PermissionState::Ready,
             input_monitoring: PermissionState::Ready,
             accessibility: PermissionState::Ready,
-            command_model: true,
             transcription_model: true,
         }
     }

--- a/src/parakeet.rs
+++ b/src/parakeet.rs
@@ -18,7 +18,7 @@ use crate::dictation::{DictationClip, DictationProtocol, pad_for_parakeet};
 use crate::dictation_processor::ProcessingObservation;
 use crate::history::{History, HistoryDraft, HistoryKind};
 use crate::meeting::{self, TranscriptEntry, TranscriptPublication};
-use crate::paste::Paster;
+use crate::paste::{PasteMode, Paster};
 use crate::suppression::InputActivity;
 #[cfg(test)]
 use crate::text_replacements::ReplacementSet;
@@ -225,7 +225,6 @@ pub struct DictationWorker {
 }
 
 struct WorkerState {
-    output_available: bool,
     next_sequence: u64,
     jobs: BTreeMap<DictationJobId, Arc<JobControl>>,
     pending_pastes: usize,
@@ -233,9 +232,6 @@ struct WorkerState {
 
 impl WorkerState {
     fn next_output_sequence(&self) -> Result<u64, &'static str> {
-        if !self.output_available {
-            return Err("dictation worker is unavailable");
-        }
         // Count accepted work even after it leaves a channel for ordered buffering.
         if self.jobs.len() + self.pending_pastes >= MAX_PENDING_OUTPUTS {
             return Err("dictation queue is full");
@@ -263,7 +259,6 @@ impl DictationWorker {
         let (output_jobs, output_receiver) = mpsc::sync_channel::<OutputJob>(8);
         let (event_sender, events) = mpsc::channel();
         let state = Arc::new(Mutex::new(WorkerState {
-            output_available: true,
             next_sequence: 0,
             jobs: BTreeMap::new(),
             pending_pastes: 0,
@@ -272,19 +267,7 @@ impl DictationWorker {
         let output_state = state.clone();
         let output_events = event_sender.clone();
         let output_worker = thread::spawn(move || {
-            let mut paster = match Paster::new(activity) {
-                Ok(paster) => paster,
-                Err(error) => {
-                    let mut state = output_state
-                        .lock()
-                        .unwrap_or_else(|error| error.into_inner());
-                    state.output_available = false;
-                    state.jobs.clear();
-                    state.pending_pastes = 0;
-                    let _ = output_events.send(WorkerEvent::ModelFailed(error.to_string()));
-                    return;
-                }
-            };
+            let mut paster = Paster::new(activity);
             let mut last_transcript = None;
             let mut meeting_cursor = MeetingPasteCursor::default();
             let mut ordered = OrderedOutputs::default();
@@ -296,7 +279,7 @@ impl DictationWorker {
                 for job in ordered.push(job) {
                     let event = finish_output(
                         job,
-                        &mut paster,
+                        &mut |text, mode, commit| paster.paste(text, mode, commit),
                         &mut last_transcript,
                         &mut meeting_cursor,
                         history.as_ref(),
@@ -744,7 +727,7 @@ fn queue_error(error: TrySendError<impl Sized>) -> &'static str {
 
 fn finish_output(
     job: OutputJob,
-    paster: &mut Paster,
+    paste: &mut impl FnMut(&str, PasteMode, &dyn Fn() -> bool) -> Result<()>,
     last_transcript: &mut Option<String>,
     meeting_cursor: &mut MeetingPasteCursor,
     history: Option<&History>,
@@ -776,21 +759,22 @@ fn finish_output(
                 }
                 let paste_started = Instant::now();
                 if !completed.text.trim().is_empty() {
-                    if !control.begin_output() {
-                        return Err("dictation was cancelled".into());
-                    }
+                    let commit = || control.begin_output();
                     match target {
-                        TranscriptionTarget::Paste => paster
-                            .paste(&completed.text)
-                            .map_err(|error| error.to_string())?,
-                        TranscriptionTarget::Send => paster
-                            .paste_and_send(&completed.text)
-                            .map_err(|error| error.to_string())?,
-                        TranscriptionTarget::VoiceAction => paster
-                            .paste_standalone(&completed.text)
-                            .map_err(|error| error.to_string())?,
-                        TranscriptionTarget::Service => {}
+                        TranscriptionTarget::Paste => {
+                            paste(&completed.text, PasteMode::Continue, &commit)
+                        }
+                        TranscriptionTarget::Send => {
+                            paste(&completed.text, PasteMode::Send, &commit)
+                        }
+                        TranscriptionTarget::VoiceAction => {
+                            paste(&completed.text, PasteMode::Standalone, &commit)
+                        }
+                        TranscriptionTarget::Service => commit()
+                            .then_some(())
+                            .ok_or_else(|| eyre!("dictation was cancelled")),
                     }
+                    .map_err(|error| error.to_string())?;
                     if matches!(
                         target,
                         TranscriptionTarget::Paste | TranscriptionTarget::Send
@@ -832,11 +816,12 @@ fn finish_output(
                     .as_deref()
                     .ok_or_else(|| "no previous transcript is available".to_string())
                     .and_then(|text| {
-                        paster.paste(text).map_err(|error| error.to_string())?;
+                        paste(text, PasteMode::Continue, &|| true)
+                            .map_err(|error| error.to_string())?;
                         Ok(text.to_string())
                     }),
                 PasteKind::MeetingDelta => {
-                    paste_meeting_delta(paster, meeting_cursor).map_err(|error| error.to_string())
+                    paste_meeting_delta(paste, meeting_cursor).map_err(|error| error.to_string())
                 }
             };
             WorkerEvent::Pasted { kind, result }
@@ -898,7 +883,10 @@ struct MeetingPasteCursor {
     seen: HashSet<TranscriptEntry>,
 }
 
-fn paste_meeting_delta(paster: &mut Paster, cursor: &mut MeetingPasteCursor) -> Result<String> {
+fn paste_meeting_delta(
+    paste: &mut impl FnMut(&str, PasteMode, &dyn Fn() -> bool) -> Result<()>,
+    cursor: &mut MeetingPasteCursor,
+) -> Result<String> {
     let meetings = meeting::list()?;
     let selected = meeting::active_or_latest(&meetings)
         .ok_or_else(|| eyre!("no meeting transcript is available"))?;
@@ -913,7 +901,7 @@ fn paste_meeting_delta(paster: &mut Paster, cursor: &mut MeetingPasteCursor) -> 
     };
     let transcript = meeting::completed_transcript(&selected.id, publication)?;
     let (text, pasted_entries) = prepare_meeting_delta(&transcript.entries, seen)?;
-    paster.paste_standalone(&text)?;
+    paste(&text, PasteMode::Standalone, &|| true)?;
     if !same_meeting {
         cursor.seen.clear();
     }
@@ -1315,7 +1303,6 @@ mod tests {
             output_jobs: Some(output_sender),
             events,
             state: Arc::new(Mutex::new(WorkerState {
-                output_available: true,
                 next_sequence: 1,
                 jobs: BTreeMap::from([(DictationJobId(0), Arc::new(JobControl::default()))]),
                 pending_pastes: 0,
@@ -1393,13 +1380,160 @@ mod tests {
     }
 
     #[test]
+    fn output_stays_cancellable_through_preparation_but_not_after_mutation() {
+        use std::cell::{Cell, RefCell};
+        use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+        use crate::history::{HistoryRetention, HistoryStore};
+        use crate::paste::commit_prepared_paste;
+
+        let completed = |text: &str| CompletedTranscript {
+            text: text.into(),
+            raw: text.into(),
+            application: None,
+            total_started: Instant::now(),
+            queue_ms: 0,
+            audio_ms: 1_000,
+            prepare_ms: 0,
+            inference_ms: 0,
+            processing: None,
+        };
+        for target in [
+            TranscriptionTarget::Paste,
+            TranscriptionTarget::Send,
+            TranscriptionTarget::VoiceAction,
+        ] {
+            for cancel_during_preparation in [true, false] {
+                let path = std::env::temp_dir().join(format!(
+                    "hex-output-cancellation-{}-{}.json",
+                    std::process::id(),
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_nanos()
+                ));
+                let history = History::new(HistoryStore::open(
+                    path.clone(),
+                    HistoryRetention::Forever,
+                    crate::history::now_ms(),
+                ));
+                record_history(&history, TranscriptionTarget::Paste, &completed("previous"));
+                let saved_history = std::fs::read(&path).unwrap();
+                let mut last_transcript = Some("previous".into());
+                let clipboard = RefCell::new("original clipboard".to_string());
+                let pasted = RefCell::new(Vec::new());
+                let sent = Cell::new(false);
+                let control = Arc::new(JobControl::default());
+                let (blocked, blocking) = mpsc::channel();
+                let (resume, resumed) = mpsc::channel();
+                let cancelling = control.clone();
+                let cancellation = thread::spawn(move || {
+                    blocking.recv_timeout(Duration::from_secs(5)).unwrap();
+                    let accepted = cancelling.cancel();
+                    resume.send(()).unwrap();
+                    accepted
+                });
+                let pause = || {
+                    blocked.send(()).unwrap();
+                    resumed.recv_timeout(Duration::from_secs(5)).unwrap();
+                };
+                let event = finish_output(
+                    OutputJob::Completed {
+                        job_id: DictationJobId(0),
+                        control: control.clone(),
+                        target,
+                        result: Box::new(Ok(completed("new output"))),
+                    },
+                    &mut |text, mode, commit| {
+                        assert!(matches!(
+                            (target, mode),
+                            (TranscriptionTarget::Paste, PasteMode::Continue)
+                                | (TranscriptionTarget::Send, PasteMode::Send)
+                                | (TranscriptionTarget::VoiceAction, PasteMode::Standalone)
+                        ));
+                        commit_prepared_paste(
+                            || {
+                                // Model a blocked restore lock or lazy clipboard provider.
+                                if cancel_during_preparation {
+                                    pause();
+                                }
+                                Ok(clipboard.borrow().clone())
+                            },
+                            commit,
+                            |_previous| {
+                                *clipboard.borrow_mut() = text.into();
+                                if !cancel_during_preparation {
+                                    pause();
+                                }
+                                pasted.borrow_mut().push(text.to_string());
+                                Ok(())
+                            },
+                        )?;
+                        if matches!(mode, PasteMode::Send) {
+                            sent.set(true);
+                        }
+                        Ok(())
+                    },
+                    &mut last_transcript,
+                    &mut MeetingPasteCursor::default(),
+                    Some(&history),
+                );
+
+                assert_eq!(cancellation.join().unwrap(), cancel_during_preparation);
+                assert_eq!(control.is_cancelled(), cancel_during_preparation);
+                if cancel_during_preparation {
+                    assert!(matches!(
+                        event,
+                        WorkerEvent::Cancelled {
+                            job_id: DictationJobId(0)
+                        }
+                    ));
+                    assert_eq!(*clipboard.borrow(), "original clipboard");
+                    assert!(pasted.borrow().is_empty());
+                    assert!(!sent.get());
+                    assert_eq!(last_transcript.as_deref(), Some("previous"));
+                    assert_eq!(history.search("").len(), 1);
+                    assert_eq!(std::fs::read(&path).unwrap(), saved_history);
+                } else {
+                    assert!(matches!(
+                        event,
+                        WorkerEvent::Completed { result: Ok(ref text), .. } if text == "new output"
+                    ));
+                    assert_eq!(*clipboard.borrow(), "new output");
+                    assert_eq!(*pasted.borrow(), ["new output"]);
+                    assert_eq!(sent.get(), matches!(target, TranscriptionTarget::Send));
+                    let expected_last = if matches!(target, TranscriptionTarget::VoiceAction) {
+                        "previous"
+                    } else {
+                        "new output"
+                    };
+                    assert_eq!(last_transcript.as_deref(), Some(expected_last));
+                    let entries = history.search("");
+                    assert_eq!(entries.len(), 2);
+                    assert_eq!(entries[0].final_text, "new output");
+                    assert_eq!(
+                        entries[0].kind,
+                        match target {
+                            TranscriptionTarget::Paste => HistoryKind::Dictation,
+                            TranscriptionTarget::Send => HistoryKind::Send,
+                            TranscriptionTarget::VoiceAction => HistoryKind::VoiceAction,
+                            TranscriptionTarget::Service => unreachable!(),
+                        }
+                    );
+                }
+                drop(history);
+                std::fs::remove_file(path).unwrap();
+            }
+        }
+    }
+
+    #[test]
     fn repeated_cancellation_walks_back_through_pending_jobs() {
         let jobs = [0, 1, 2]
             .into_iter()
             .map(|sequence| (DictationJobId(sequence), Arc::new(JobControl::default())))
             .collect();
         let state = WorkerState {
-            output_available: true,
             next_sequence: 3,
             jobs,
             pending_pastes: 0,

--- a/src/paste.rs
+++ b/src/paste.rs
@@ -27,6 +27,13 @@ pub struct Paster {
     prepared_clipboard: Option<PreparedClipboard>,
 }
 
+#[derive(Clone, Copy)]
+pub enum PasteMode {
+    Continue,
+    Send,
+    Standalone,
+}
+
 struct PreparedClipboard {
     change_count: isize,
     snapshot: ClipboardSnapshot,
@@ -157,14 +164,14 @@ impl Drop for PasteboardHandle {
 }
 
 impl Paster {
-    pub fn new(activity: InputActivity) -> Result<Self> {
-        Ok(Self {
+    pub fn new(activity: InputActivity) -> Self {
+        Self {
             clipboard: NSPasteboard::generalPasteboard(),
             activity,
             continuation: None,
             clipboard_restore: Arc::new(Mutex::new(ClipboardRestore::default())),
             prepared_clipboard: None,
-        })
+        }
     }
 
     pub fn prepare(&mut self) {
@@ -194,55 +201,85 @@ impl Paster {
         }
     }
 
-    pub fn paste(&mut self, text: &str) -> Result<()> {
-        self.paste_text(text)
+    /// Commit only after clipboard preparation, immediately before the first write.
+    /// A rejected commit leaves both the clipboard and continuation unchanged.
+    pub fn paste(
+        &mut self,
+        text: &str,
+        mode: PasteMode,
+        commit: impl FnOnce() -> bool,
+    ) -> Result<()> {
+        if matches!(mode, PasteMode::Send) {
+            send_after_paste(|| self.paste_text(text, mode, commit), keyboard::post_enter)?;
+            self.continuation = None;
+            Ok(())
+        } else {
+            self.paste_text(text, mode, commit)
+        }
     }
 
-    fn paste_text(&mut self, text: &str) -> Result<()> {
+    fn paste_text(
+        &mut self,
+        text: &str,
+        mode: PasteMode,
+        commit: impl FnOnce() -> bool,
+    ) -> Result<()> {
         let revision = self.activity.revision();
         let text = self
             .continuation
             .as_ref()
-            .filter(|continuation| continuation.revision == revision)
+            .filter(|continuation| {
+                !matches!(mode, PasteMode::Standalone) && continuation.revision == revision
+            })
             .map_or_else(
                 || text.to_string(),
                 |continuation| join(&continuation.inserted, text),
             );
-        let mut restore = self
-            .clipboard_restore
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
-        let previous_change_count = self.clipboard.changeCount();
-        let prepared = self.prepared_clipboard.take();
-        let previous = if let Some(prepared) = prepared
-            && prepared.change_count == previous_change_count
-        {
-            tracing::debug!(
-                clipboard_capture_ms = prepared.capture_ms,
-                "used eagerly captured clipboard"
-            );
-            prepared.snapshot
-        } else {
-            let started = Instant::now();
-            let snapshot = capture_clipboard(&self.clipboard)?;
-            tracing::debug!(
-                clipboard_capture_ms = started.elapsed().as_millis(),
-                "captured clipboard at paste time"
-            );
-            snapshot
-        };
-        if self.clipboard.changeCount() != previous_change_count {
-            return Err(eyre!("clipboard changed while HEX was preserving it"));
-        }
-        if let Err(error) = write_clipboard_text(&self.clipboard, &text) {
-            if let Err(restore_error) = restore_clipboard(&self.clipboard, &previous) {
-                tracing::error!(%restore_error, "could not recover the clipboard after a failed write");
-            }
-            return Err(error);
-        }
-        let inserted_change_count = self.clipboard.changeCount();
-        let generation = restore.register(previous, previous_change_count, inserted_change_count);
-        drop(restore);
+        let generation = commit_prepared_paste(
+            || {
+                let restore = self
+                    .clipboard_restore
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner());
+                let previous_change_count = self.clipboard.changeCount();
+                let prepared = self.prepared_clipboard.take();
+                let previous = if let Some(prepared) = prepared
+                    && prepared.change_count == previous_change_count
+                {
+                    tracing::debug!(
+                        clipboard_capture_ms = prepared.capture_ms,
+                        "used eagerly captured clipboard"
+                    );
+                    prepared.snapshot
+                } else {
+                    let started = Instant::now();
+                    let snapshot = capture_clipboard(&self.clipboard)?;
+                    tracing::debug!(
+                        clipboard_capture_ms = started.elapsed().as_millis(),
+                        "captured clipboard at paste time"
+                    );
+                    snapshot
+                };
+                if self.clipboard.changeCount() != previous_change_count {
+                    return Err(eyre!("clipboard changed while HEX was preserving it"));
+                }
+                Ok((restore, previous, previous_change_count))
+            },
+            commit,
+            |(mut restore, previous, previous_change_count)| {
+                if matches!(mode, PasteMode::Standalone) {
+                    self.continuation = None;
+                }
+                if let Err(error) = write_clipboard_text(&self.clipboard, &text) {
+                    if let Err(restore_error) = restore_clipboard(&self.clipboard, &previous) {
+                        tracing::error!(%restore_error, "could not recover the clipboard after a failed write");
+                    }
+                    return Err(error);
+                }
+                let inserted_change_count = self.clipboard.changeCount();
+                Ok(restore.register(previous, previous_change_count, inserted_change_count))
+            },
+        )?;
 
         let clipboard_restore = self.clipboard_restore.clone();
         complete_paste(
@@ -274,25 +311,26 @@ impl Paster {
             },
             thread::sleep,
         )?;
-        self.continuation = Some(Continuation {
+        self.continuation = (!matches!(mode, PasteMode::Standalone)).then_some(Continuation {
             revision,
             inserted: text,
         });
         Ok(())
     }
+}
 
-    pub fn paste_and_send(&mut self, text: &str) -> Result<()> {
-        send_after_paste(|| self.paste(text), keyboard::post_enter)?;
-        self.continuation = None;
-        Ok(())
+pub(crate) fn commit_prepared_paste<P, T>(
+    prepare: impl FnOnce() -> Result<P>,
+    commit: impl FnOnce() -> bool,
+    paste: impl FnOnce(P) -> Result<T>,
+) -> Result<T> {
+    let prepared = prepare()?;
+    // Waiting for restoration and materializing promised clipboard data remain cancellable.
+    // Once committed, even a failed first write may have changed the clipboard.
+    if !commit() {
+        return Err(eyre!("paste was cancelled"));
     }
-
-    pub fn paste_standalone(&mut self, text: &str) -> Result<()> {
-        self.continuation = None;
-        self.paste(text)?;
-        self.continuation = None;
-        Ok(())
-    }
+    paste(prepared)
 }
 
 fn complete_paste(
@@ -631,6 +669,54 @@ mod tests {
     use objc2_foundation::NSData;
 
     static PASTEBOARD_TEST: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn rejected_commit_does_not_write_paste_restore_or_send() {
+        let steps = RefCell::new(Vec::new());
+        let result = send_after_paste(
+            || {
+                commit_prepared_paste(
+                    || {
+                        steps.borrow_mut().push("prepare");
+                        Ok(())
+                    },
+                    || {
+                        steps.borrow_mut().push("commit");
+                        false
+                    },
+                    |()| {
+                        steps.borrow_mut().push("write");
+                        complete_paste(
+                            || {
+                                steps.borrow_mut().push("post");
+                                Ok(())
+                            },
+                            || steps.borrow_mut().push("restore"),
+                            |_| steps.borrow_mut().push("settle"),
+                        )
+                    },
+                )
+            },
+            || {
+                steps.borrow_mut().push("enter");
+                Ok(())
+            },
+        );
+
+        assert_eq!(result.unwrap_err().to_string(), "paste was cancelled");
+        assert_eq!(steps.into_inner(), ["prepare", "commit"]);
+    }
+
+    #[test]
+    fn failed_preparation_does_not_commit_or_write() {
+        let result = commit_prepared_paste(
+            || Err::<(), _>(eyre!("snapshot failed")),
+            || panic!("failed preparation must remain cancellable"),
+            |()| -> Result<()> { panic!("failed preparation must not mutate the clipboard") },
+        );
+
+        assert_eq!(result.unwrap_err().to_string(), "snapshot failed");
+    }
 
     #[test]
     fn sequential_pastes_settle_before_overwrite_and_enter() {

--- a/src/recognition.rs
+++ b/src/recognition.rs
@@ -1,8 +1,8 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::path::Path;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender, TryRecvError, TrySendError};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use color_eyre::Result;
@@ -33,6 +33,28 @@ const UPDATE_INTERVAL: Duration = Duration::from_millis(200);
 const ACTIVATION_STABILITY_WINDOW: Duration = Duration::from_millis(750);
 const PROGRAMMATIC_LEASE: Duration = Duration::from_secs(10);
 const PROGRAMMATIC_COMPLETION_LIMIT: usize = 16;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommandModelStatus {
+    Disabled,
+    Loading,
+    Ready,
+    Failed,
+}
+
+static COMMAND_MODEL_STATUS: Mutex<CommandModelStatus> = Mutex::new(CommandModelStatus::Disabled);
+
+pub fn command_model_status() -> CommandModelStatus {
+    *COMMAND_MODEL_STATUS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+}
+
+fn set_command_model_status(status: CommandModelStatus) {
+    *COMMAND_MODEL_STATUS
+        .lock()
+        .unwrap_or_else(|error| error.into_inner()) = status;
+}
 
 #[derive(Default)]
 struct ActivationStability {
@@ -75,6 +97,7 @@ enum FinishResult {
 #[derive(Debug)]
 pub enum RecognitionControl {
     PasteLast,
+    RetryCommands,
     StartDictation {
         source: String,
         owner_token: String,
@@ -178,10 +201,10 @@ pub fn listen(
     feedback::preload()?;
     let mut microphone_policy = crate::app_settings::microphone_policy();
     let mut commands_enabled = microphone_policy.commands_enabled;
-    let mut recognizer = commands_enabled
-        .then(|| Moonshine::load(project_root))
-        .transpose()?;
-    let mut command_loader = None;
+    let mut recognizer = None;
+    set_command_model_status(CommandModelStatus::Disabled);
+    let mut command_loader =
+        commands_enabled.then(|| load_command_recognizer(project_root.to_path_buf()));
     let mut events = events;
     let input_monitor = InputMonitor::start()?;
     let context_monitor = ContextMonitor::start();
@@ -222,7 +245,7 @@ pub fn listen(
         history,
     );
     let (mut transcription_revision, _) = crate::app_settings::transcription_selection();
-    let mut action_executor = commands_enabled.then(ActionExecutor::start);
+    let mut action_executor: Option<ActionExecutor> = None;
     let mut personal_host_enabled =
         commands_enabled || crate::app_settings::custom_transformations_enabled();
     let mut personal_commands = personal_host_enabled
@@ -281,6 +304,15 @@ pub fn listen(
         if let Some(controls) = &controls {
             while let Ok(control) = controls.try_recv() {
                 match control {
+                    RecognitionControl::RetryCommands => {
+                        if crate::app_settings::commands_enabled()
+                            && command_loader.is_none()
+                            && recognizer.is_none()
+                        {
+                            command_loader =
+                                Some(load_command_recognizer(project_root.to_path_buf()));
+                        }
+                    }
                     RecognitionControl::PasteLast if programmatic.is_none() => {
                         handle_hotkey_action(
                             HotkeyAction::PasteLast,
@@ -574,12 +606,16 @@ pub fn listen(
             commands_enabled = next_commands_enabled;
             mode = Mode::Listening;
             if commands_enabled {
-                command_loader = Some(load_command_recognizer(project_root.to_path_buf()));
+                if command_loader.is_none() {
+                    command_loader = Some(load_command_recognizer(project_root.to_path_buf()));
+                } else {
+                    set_command_model_status(CommandModelStatus::Loading);
+                }
                 tracing::info!("voice commands enabled; loading command model");
             } else {
-                command_loader = None;
                 recognizer = None;
                 action_executor = None;
+                set_command_model_status(CommandModelStatus::Disabled);
                 tracing::info!("voice commands disabled");
             }
         }
@@ -608,17 +644,24 @@ pub fn listen(
                     recognition_origin = None;
                     action_executor = Some(ActionExecutor::start());
                     command_loader = None;
+                    set_command_model_status(CommandModelStatus::Ready);
                     tracing::info!("voice command model loaded");
                 }
                 Ok(Ok(_)) => command_loader = None,
                 Ok(Err(error)) => {
                     command_loader = None;
                     tracing::error!(%error, "could not enable voice commands");
+                    if commands_enabled {
+                        set_command_model_status(CommandModelStatus::Failed);
+                    }
                 }
                 Err(TryRecvError::Empty) => {}
                 Err(TryRecvError::Disconnected) => {
                     command_loader = None;
                     tracing::error!("voice command model loader stopped");
+                    if commands_enabled {
+                        set_command_model_status(CommandModelStatus::Failed);
+                    }
                 }
             }
         }
@@ -1349,12 +1392,18 @@ fn amplitude_db(amplitude: f32) -> f32 {
 fn load_command_recognizer(
     project_root: std::path::PathBuf,
 ) -> Receiver<Result<Moonshine, String>> {
+    set_command_model_status(CommandModelStatus::Loading);
+    spawn_command_load(move || {
+        crate::moonshine::install_model().and_then(|_| Moonshine::load(&project_root))
+    })
+}
+
+fn spawn_command_load<T: Send + 'static>(
+    load: impl FnOnce() -> Result<T> + Send + 'static,
+) -> Receiver<Result<T, String>> {
     let (sender, receiver) = mpsc::sync_channel(1);
     std::thread::spawn(move || {
-        let result = crate::moonshine::install_model()
-            .and_then(|_| Moonshine::load(&project_root))
-            .map_err(|error| error.to_string());
-        let _ = sender.send(result);
+        let _ = sender.send(load().map_err(|error| error.to_string()));
     });
     receiver
 }
@@ -2108,6 +2157,32 @@ fn handle_dictation_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn command_preparation_does_not_block_the_listener_or_propagate_failure() {
+        let (release, wait) = mpsc::sync_channel(1);
+        let (loaded, receiver) = mpsc::sync_channel(1);
+        let caller = std::thread::spawn(move || {
+            let pending = spawn_command_load(move || {
+                wait.recv().unwrap();
+                Err::<(), _>(color_eyre::eyre::eyre!("fixture download failed"))
+            });
+            loaded.send(pending).unwrap();
+        });
+        let pending = receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("listener must not wait for the command model");
+        assert!(matches!(pending.try_recv(), Err(TryRecvError::Empty)));
+        release.send(()).unwrap();
+        assert_eq!(
+            pending
+                .recv_timeout(Duration::from_secs(2))
+                .unwrap()
+                .unwrap_err(),
+            "fixture download failed"
+        );
+        caller.join().unwrap();
+    }
 
     fn say_protocol() -> DictationProtocol {
         DictationProtocol::try_new(

--- a/src/sparkle.rs
+++ b/src/sparkle.rs
@@ -1,16 +1,14 @@
 use std::cell::RefCell;
 use std::path::PathBuf;
-use std::ptr::NonNull;
 use std::sync::atomic::{AtomicU8, Ordering};
 
-use block2::RcBlock;
 use color_eyre::eyre::{Result, WrapErr, eyre};
 use libloading::Library;
 use objc2::rc::Retained;
-use objc2::runtime::{AnyClass, AnyObject, Bool, NSObjectProtocol, ProtocolObject};
-use objc2::{MainThreadMarker, msg_send};
+use objc2::runtime::{AnyClass, AnyObject, AnyProtocol, Bool, NSObjectProtocol, ProtocolObject};
+use objc2::{AnyThread, DefinedClass, MainThreadMarker, msg_send};
 use objc2_app_kit::NSApplication;
-use objc2_foundation::{NSNotification, NSNotificationCenter, NSString};
+use objc2_foundation::{NSError, NSInteger, NSObject};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
@@ -24,23 +22,67 @@ pub enum UpdateStatus {
 
 static UPDATE_STATUS: AtomicU8 = AtomicU8::new(UpdateStatus::Unavailable as u8);
 
+objc2::extern_protocol!(
+    /// # Safety
+    /// Implementations must match Sparkle's Objective-C callback signatures and
+    /// must not retain borrowed callback arguments without taking ownership.
+    #[allow(clippy::missing_safety_doc)] // objc2's trait expansion hides these docs from Clippy.
+    unsafe trait SPUUpdaterDelegate: NSObjectProtocol {}
+);
+
+objc2::define_class!(
+    #[unsafe(super = NSObject)]
+    #[name = "HexSparkleUpdaterDelegate"]
+    #[ivars = &'static AtomicU8]
+    struct SparkleDelegate;
+
+    unsafe impl NSObjectProtocol for SparkleDelegate {}
+
+    // Sparkle 2.9.4's SPUUpdaterDelegate.h: object arguments are borrowed,
+    // SPUUpdateCheck is NSInteger, and only the completion error is nullable.
+    unsafe impl SPUUpdaterDelegate for SparkleDelegate {
+        #[unsafe(method(updater:didFindValidUpdate:))]
+        fn did_find_update(&self, _updater: &AnyObject, _item: &AnyObject) {
+            self.ivars()
+                .store(UpdateStatus::UpdateAvailable as u8, Ordering::Release);
+        }
+
+        #[unsafe(method(updaterDidNotFindUpdate:error:))]
+        fn did_not_find_update(&self, _updater: &AnyObject, _error: &NSError) {
+            self.ivars()
+                .store(UpdateStatus::UpToDate as u8, Ordering::Release);
+        }
+
+        #[unsafe(method(updater:didFinishUpdateCycleForUpdateCheck:error:))]
+        fn did_finish_update_cycle(
+            &self,
+            _updater: &AnyObject,
+            _update_check: NSInteger,
+            _error: Option<&NSError>,
+        ) {
+            // No update is also an error (SUNoUpdateError). Keep that confirmation,
+            // and keep a found update available when installation is deferred.
+            clear_status(self.ivars(), UpdateStatus::Checking);
+        }
+    }
+);
+
+impl SparkleDelegate {
+    fn new(status: &'static AtomicU8) -> Retained<Self> {
+        let this = Self::alloc().set_ivars(status);
+        unsafe { msg_send![super(this), init] }
+    }
+}
+
 thread_local! {
     static UPDATER: RefCell<Option<SparkleUpdater>> = const { RefCell::new(None) };
 }
 
 struct SparkleUpdater {
     controller: Retained<AnyObject>,
-    observers: Vec<Retained<ProtocolObject<dyn NSObjectProtocol>>>,
+    // Both the controller and updater hold their delegate weakly.
+    _delegate: Retained<SparkleDelegate>,
     _framework: Library,
-}
-
-impl Drop for SparkleUpdater {
-    fn drop(&mut self) {
-        let center = NSNotificationCenter::defaultCenter();
-        for observer in &self.observers {
-            unsafe { center.removeObserver(observer.as_ref()) };
-        }
-    }
 }
 
 pub fn start() {
@@ -51,6 +93,9 @@ pub fn start() {
 
 fn start_inner() -> Result<()> {
     MainThreadMarker::new().ok_or_else(|| eyre!("Sparkle must start on the main thread"))?;
+    if UPDATER.with(|updater| updater.borrow().is_some()) {
+        return Ok(());
+    }
     let Some(framework_path) = framework_path()? else {
         tracing::debug!("Sparkle is unavailable outside the packaged app");
         return Ok(());
@@ -60,36 +105,18 @@ fn start_inner() -> Result<()> {
     // CLI and test binaries depend on an adjacent Sparkle.framework.
     let framework = unsafe { Library::new(&framework_path) }
         .wrap_err_with(|| format!("could not load {}", framework_path.display()))?;
-    let center = NSNotificationCenter::defaultCenter();
-    let observers = [
-        (
-            "SUUpdaterDidFindValidUpdateNotification",
-            UpdateStatus::UpdateAvailable,
-        ),
-        (
-            "SUUpdaterDidNotFindUpdateNotification",
-            UpdateStatus::UpToDate,
-        ),
-    ]
-    .into_iter()
-    .map(|(name, status)| {
-        let name = NSString::from_str(name);
-        let block = RcBlock::new(move |_: NonNull<NSNotification>| {
-            UPDATE_STATUS.store(status as u8, Ordering::Release);
-        });
-        unsafe {
-            center.addObserverForName_object_queue_usingBlock(Some(&name), None, None, &block)
-        }
-    })
-    .collect();
+    // define_class! needs the framework's protocol registered before allocation.
+    AnyProtocol::get(c"SPUUpdaterDelegate")
+        .ok_or_else(|| eyre!("Sparkle updater delegate protocol is unavailable"))?;
     let class = AnyClass::get(c"SPUStandardUpdaterController")
         .ok_or_else(|| eyre!("Sparkle updater class is unavailable"))?;
+    let delegate = SparkleDelegate::new(&UPDATE_STATUS);
     let controller: Retained<AnyObject> = unsafe {
         let allocated: *mut AnyObject = msg_send![class, alloc];
         let controller: *mut AnyObject = msg_send![
             allocated,
-            initWithStartingUpdater: Bool::YES,
-            updaterDelegate: std::ptr::null_mut::<AnyObject>(),
+            initWithStartingUpdater: Bool::NO,
+            updaterDelegate: ProtocolObject::<dyn SPUUpdaterDelegate>::from_ref(&*delegate),
             userDriverDelegate: std::ptr::null_mut::<AnyObject>()
         ];
         Retained::from_raw(controller)
@@ -97,6 +124,15 @@ fn start_inner() -> Result<()> {
     };
     unsafe {
         let updater: *mut AnyObject = msg_send![&*controller, updater];
+        let updater = updater
+            .as_ref()
+            .ok_or_else(|| eyre!("Sparkle controller returned no updater"))?;
+        let mut error: Option<Retained<NSError>> = None;
+        let started: Bool = msg_send![updater, startUpdater: &mut error];
+        if !started.as_bool() {
+            return Err(eyre!("Sparkle updater failed to start: {error:?}"));
+        }
+        UPDATE_STATUS.store(UpdateStatus::Idle as u8, Ordering::Release);
         let automatically_checks: Bool = msg_send![updater, automaticallyChecksForUpdates];
         if automatically_checks.as_bool() {
             let _: () = msg_send![updater, checkForUpdatesInBackground];
@@ -105,11 +141,10 @@ fn start_inner() -> Result<()> {
     UPDATER.with(|updater| {
         *updater.borrow_mut() = Some(SparkleUpdater {
             controller,
-            observers,
+            _delegate: delegate,
             _framework: framework,
         });
     });
-    UPDATE_STATUS.store(UpdateStatus::Idle as u8, Ordering::Release);
     Ok(())
 }
 
@@ -125,8 +160,15 @@ pub fn check_for_updates() {
             tracing::warn!("Sparkle updater is not available");
             return;
         };
-        UPDATE_STATUS.store(UpdateStatus::Checking as u8, Ordering::Release);
         unsafe {
+            let native_updater: *mut AnyObject = msg_send![&*updater.controller, updater];
+            let can_check: Bool = msg_send![native_updater, canCheckForUpdates];
+            let session_in_progress: Bool = msg_send![native_updater, sessionInProgress];
+            begin_check(
+                &UPDATE_STATUS,
+                can_check.as_bool(),
+                session_in_progress.as_bool(),
+            );
             #[allow(deprecated)]
             NSApplication::sharedApplication(mtm).activateIgnoringOtherApps(true);
             let _: () =
@@ -148,8 +190,23 @@ pub fn status() -> UpdateStatus {
 }
 
 pub fn clear_confirmation() {
-    let _ = UPDATE_STATUS.compare_exchange(
-        UpdateStatus::UpToDate as u8,
+    clear_status(&UPDATE_STATUS, UpdateStatus::UpToDate);
+}
+
+fn begin_check(status: &AtomicU8, can_check: bool, session_in_progress: bool) {
+    // An existing session may only be focused, and resuming a deferred install
+    // need not emit didFindValidUpdate again. Neither should erase its result.
+    if can_check && !session_in_progress {
+        let _ = status.fetch_update(Ordering::AcqRel, Ordering::Acquire, |value| {
+            (value == UpdateStatus::Idle as u8 || value == UpdateStatus::UpToDate as u8)
+                .then_some(UpdateStatus::Checking as u8)
+        });
+    }
+}
+
+fn clear_status(status: &AtomicU8, expected: UpdateStatus) {
+    let _ = status.compare_exchange(
+        expected as u8,
         UpdateStatus::Idle as u8,
         Ordering::AcqRel,
         Ordering::Acquire,
@@ -163,4 +220,164 @@ fn framework_path() -> Result<Option<PathBuf>> {
     };
     let path = macos_dir.join("../Frameworks/Sparkle.framework/Versions/B/Sparkle");
     Ok(path.exists().then_some(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use objc2::rc::autoreleasepool;
+    use objc2::runtime::ProtocolBuilder;
+    use objc2::{ClassType, ProtocolType, sel};
+    use objc2_foundation::NSString;
+
+    #[test]
+    fn status_transitions_preserve_results_and_unavailable() {
+        for initial in [
+            UpdateStatus::Unavailable,
+            UpdateStatus::Idle,
+            UpdateStatus::Checking,
+            UpdateStatus::UpToDate,
+            UpdateStatus::UpdateAvailable,
+        ] {
+            for (can_check, session_in_progress) in
+                [(false, false), (false, true), (true, false), (true, true)]
+            {
+                let status = AtomicU8::new(initial as u8);
+                begin_check(&status, can_check, session_in_progress);
+                let expected = if can_check
+                    && !session_in_progress
+                    && matches!(initial, UpdateStatus::Idle | UpdateStatus::UpToDate)
+                {
+                    UpdateStatus::Checking
+                } else {
+                    initial
+                };
+                assert_eq!(status.load(Ordering::Acquire), expected as u8);
+            }
+
+            for cleared in [UpdateStatus::Checking, UpdateStatus::UpToDate] {
+                let status = AtomicU8::new(initial as u8);
+                clear_status(&status, cleared);
+                let expected = if initial == cleared {
+                    UpdateStatus::Idle
+                } else {
+                    initial
+                };
+                assert_eq!(status.load(Ordering::Acquire), expected as u8);
+            }
+        }
+    }
+
+    #[test]
+    fn native_delegate_completion_allows_retry_and_preserves_results() {
+        // Exercise objc_msgSend without loading Sparkle, starting an updater,
+        // touching preferences, or showing UI. objc2 needs protocol metadata.
+        let protocol = AnyProtocol::get(c"SPUUpdaterDelegate").unwrap_or_else(|| {
+            let mut protocol = ProtocolBuilder::new(c"SPUUpdaterDelegate").unwrap();
+            protocol.add_protocol(<dyn NSObjectProtocol>::protocol().unwrap());
+            protocol.add_method_description::<(&AnyObject, &AnyObject), ()>(
+                sel!(updater:didFindValidUpdate:),
+                false,
+            );
+            protocol.add_method_description::<(&AnyObject, &NSError), ()>(
+                sel!(updaterDidNotFindUpdate:error:),
+                false,
+            );
+            protocol.add_method_description::<(&AnyObject, NSInteger, Option<&NSError>), ()>(
+                sel!(updater:didFinishUpdateCycleForUpdateCheck:error:),
+                false,
+            );
+            protocol.register()
+        });
+
+        autoreleasepool(|_| {
+            static STATUS: AtomicU8 = AtomicU8::new(UpdateStatus::Idle as u8);
+            let delegate = SparkleDelegate::new(&STATUS);
+            assert!(SparkleDelegate::class().conforms_to(protocol));
+            let completion = SparkleDelegate::class()
+                .instance_method(sel!(updater:didFinishUpdateCycleForUpdateCheck:error:))
+                .unwrap();
+            assert_eq!(&*completion.return_type(), c"v");
+            assert_eq!(completion.arguments_count(), 5);
+            // The third explicit argument is nullable id; SPUUpdateCheck is
+            // signed, pointer-width NSInteger, not a C int or unsigned enum.
+            for (index, encoding) in [c"@", c":", c"@", c"q", c"@"].into_iter().enumerate() {
+                assert_eq!(&*completion.argument_type(index).unwrap(), encoding);
+            }
+
+            let object = NSObject::new();
+            let failure = unsafe {
+                NSError::errorWithDomain_code_userInfo(
+                    &NSString::from_str("NSURLErrorDomain"),
+                    -1009,
+                    None,
+                )
+            };
+            // Both an offline failure and a cancellation (nil error) finish
+            // Checking. A subsequent click must be able to start again.
+            for error in [Some(&*failure), None] {
+                begin_check(&STATUS, true, false);
+                assert_eq!(STATUS.load(Ordering::Acquire), UpdateStatus::Checking as u8);
+                unsafe {
+                    let _: () = msg_send![
+                        &*delegate,
+                        updater: &*object,
+                        didFinishUpdateCycleForUpdateCheck: 0 as NSInteger,
+                        error: error
+                    ];
+                }
+                assert_eq!(STATUS.load(Ordering::Acquire), UpdateStatus::Idle as u8);
+            }
+
+            let no_update = unsafe {
+                NSError::errorWithDomain_code_userInfo(
+                    &NSString::from_str("SUSparkleErrorDomain"),
+                    1001,
+                    None,
+                )
+            };
+            begin_check(&STATUS, true, false);
+            unsafe {
+                let _: () = msg_send![
+                    &*delegate, updaterDidNotFindUpdate: &*object, error: &*no_update
+                ];
+                let _: () = msg_send![
+                    &*delegate,
+                    updater: &*object,
+                    didFinishUpdateCycleForUpdateCheck: 0 as NSInteger,
+                    error: Some(&*no_update)
+                ];
+            }
+            assert_eq!(STATUS.load(Ordering::Acquire), UpdateStatus::UpToDate as u8);
+            clear_status(&STATUS, UpdateStatus::UpToDate);
+            assert_eq!(STATUS.load(Ordering::Acquire), UpdateStatus::Idle as u8);
+
+            unsafe {
+                let _: () = msg_send![
+                    &*delegate, updater: &*object, didFindValidUpdate: &*object
+                ];
+            }
+            // Dismissal, resuming without another found callback, and a failed
+            // installation must leave the known update accessible for retry.
+            for error in [None, Some(&*failure)] {
+                begin_check(&STATUS, true, false);
+                assert_eq!(
+                    STATUS.load(Ordering::Acquire),
+                    UpdateStatus::UpdateAvailable as u8
+                );
+                unsafe {
+                    let _: () = msg_send![
+                        &*delegate,
+                        updater: &*object,
+                        didFinishUpdateCycleForUpdateCheck: 1 as NSInteger,
+                        error: error
+                    ];
+                }
+                assert_eq!(
+                    STATUS.load(Ordering::Acquire),
+                    UpdateStatus::UpdateAvailable as u8
+                );
+            }
+        });
+    }
 }

--- a/src/text_input.rs
+++ b/src/text_input.rs
@@ -130,15 +130,65 @@ pub struct TextInput {
     multiline: bool,
     height: Pixels,
     picker: bool,
-    undo_stack: Vec<EditState>,
-    redo_stack: Vec<EditState>,
+    history: EditHistory,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct EditState {
     content: SharedString,
     selected_range: Range<usize>,
     selection_reversed: bool,
+}
+
+#[derive(Default)]
+struct EditHistory {
+    undo: Vec<EditState>,
+    redo: Vec<EditState>,
+    composition: Option<EditState>,
+}
+
+impl EditHistory {
+    fn replace(&mut self, before: EditState, content: &str, is_marked: bool) {
+        if is_marked {
+            // Candidates share the state from before the first marked edit.
+            self.composition.get_or_insert(before);
+        } else {
+            let before = self.composition.take().unwrap_or(before);
+            self.record(before, content);
+        }
+    }
+
+    fn finish_composition(&mut self, content: &str) {
+        if let Some(before) = self.composition.take() {
+            self.record(before, content);
+        }
+    }
+
+    fn record(&mut self, before: EditState, content: &str) {
+        // Cancelling back to the original text must also preserve redo.
+        if before.content.as_ref() == content {
+            return;
+        }
+        if self.undo.len() == 100 {
+            self.undo.remove(0);
+        }
+        self.undo.push(before);
+        self.redo.clear();
+    }
+
+    fn undo(&mut self, current: EditState) -> Option<EditState> {
+        self.finish_composition(&current.content);
+        let state = self.undo.pop()?;
+        self.redo.push(current);
+        Some(state)
+    }
+
+    fn redo(&mut self, current: EditState) -> Option<EditState> {
+        self.finish_composition(&current.content);
+        let state = self.redo.pop()?;
+        self.undo.push(current);
+        Some(state)
+    }
 }
 
 #[derive(Clone)]
@@ -266,8 +316,7 @@ impl TextInput {
                 TEXT_INPUT_HEIGHT
             }),
             picker,
-            undo_stack: Vec::new(),
-            redo_stack: Vec::new(),
+            history: EditHistory::default(),
         }
     }
 
@@ -286,8 +335,7 @@ impl TextInput {
         self.selection_reversed = false;
         self.marked_range = None;
         self.preferred_x = None;
-        self.undo_stack.clear();
-        self.redo_stack.clear();
+        self.history = EditHistory::default();
         cx.notify();
     }
 
@@ -442,24 +490,22 @@ impl TextInput {
     }
 
     fn undo(&mut self, _: &Undo, _: &mut Window, cx: &mut Context<Self>) {
-        let Some(state) = self.undo_stack.pop() else {
-            return;
-        };
-        let current = self.edit_state();
-        self.restore_edit_state(state);
-        self.redo_stack.push(current);
-        cx.emit(Changed);
+        let state = self.history.undo(self.edit_state());
+        self.marked_range = None;
+        if let Some(state) = state {
+            self.restore_edit_state(state);
+            cx.emit(Changed);
+        }
         cx.notify();
     }
 
     fn redo(&mut self, _: &Redo, _: &mut Window, cx: &mut Context<Self>) {
-        let Some(state) = self.redo_stack.pop() else {
-            return;
-        };
-        let current = self.edit_state();
-        self.restore_edit_state(state);
-        self.undo_stack.push(current);
-        cx.emit(Changed);
+        let state = self.history.redo(self.edit_state());
+        self.marked_range = None;
+        if let Some(state) = state {
+            self.restore_edit_state(state);
+            cx.emit(Changed);
+        }
         cx.notify();
     }
 
@@ -807,6 +853,18 @@ impl TextInput {
         );
 
         let is_marked = marked_selection_utf16.is_some();
+        let before = if is_marked {
+            self.edit_state()
+        } else {
+            EditState {
+                content: self.content.clone(),
+                selected_range: range.clone(),
+                selection_reversed: false,
+            }
+        };
+        // An empty marked replacement ends composition even without a later unmark.
+        self.history
+            .replace(before, &content, is_marked && !new_text.is_empty());
         if let Some(selection) = marked_selection_utf16.as_ref() {
             self.marked_range =
                 (!new_text.is_empty()).then_some(range.start..range.start + new_text.len());
@@ -822,17 +880,6 @@ impl TextInput {
         self.preferred_x = None;
 
         if self.content.as_ref() != content {
-            if !is_marked {
-                if self.undo_stack.len() == 100 {
-                    self.undo_stack.remove(0);
-                }
-                self.undo_stack.push(EditState {
-                    content: self.content.clone(),
-                    selected_range: range.clone(),
-                    selection_reversed: false,
-                });
-                self.redo_stack.clear();
-            }
             self.content = content.into();
             cx.emit(Changed);
         }
@@ -882,8 +929,10 @@ impl EntityInputHandler for TextInput {
             .map(|range| self.range_to_utf16(range))
     }
 
-    fn unmark_text(&mut self, _: &mut Window, _: &mut Context<Self>) {
+    fn unmark_text(&mut self, _: &mut Window, cx: &mut Context<Self>) {
+        self.history.finish_composition(&self.content);
         self.marked_range = None;
+        cx.notify();
     }
 
     fn replace_text_in_range(
@@ -1415,6 +1464,153 @@ fn utf8_offset_for_utf16(text: &str, offset: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn edit_state(content: &str) -> EditState {
+        EditState {
+            content: content.to_owned().into(),
+            selected_range: content.len()..content.len(),
+            selection_reversed: false,
+        }
+    }
+
+    #[test]
+    fn same_text_composition_commit_restores_original_selection() {
+        let mut history = EditHistory::default();
+        let before = EditState {
+            selected_range: 0..3,
+            selection_reversed: true,
+            ..edit_state("old")
+        };
+        let marked = edit_state("candidate");
+        history.replace(before.clone(), "candidate", true);
+        assert!(history.undo.is_empty());
+        history.replace(marked.clone(), "candidate", false);
+        history.finish_composition("candidate");
+
+        assert_eq!(history.undo.len(), 1);
+        assert_eq!(history.undo(marked.clone()), Some(before.clone()));
+        assert_eq!(history.redo(before), Some(marked));
+        assert!(history.composition.is_none());
+    }
+
+    #[test]
+    fn different_final_candidate_undo_skips_all_intermediate_text() {
+        let mut history = EditHistory::default();
+        let before = EditState {
+            selected_range: 0..3,
+            selection_reversed: true,
+            ..edit_state("old")
+        };
+        // Marking unchanged text still starts the transaction before selection changes.
+        history.replace(before.clone(), "old", true);
+        history.replace(edit_state("old"), "draft", true);
+        history.replace(edit_state("draft"), "candidate", true);
+        history.replace(edit_state("candidate"), "final", false);
+
+        assert_eq!(history.undo.len(), 1);
+        assert_eq!(history.undo(edit_state("final")), Some(before.clone()));
+        assert_eq!(history.redo(before), Some(edit_state("final")));
+    }
+
+    #[test]
+    fn unmark_commits_once_and_following_regular_edit_is_separate() {
+        let mut history = EditHistory::default();
+        let before = edit_state("");
+        let committed = edit_state("candidate");
+        let typed = edit_state("candidate!");
+        history.replace(before.clone(), "draft", true);
+        history.replace(edit_state("draft"), "candidate", true);
+        history.finish_composition("candidate");
+        history.finish_composition("candidate");
+        history.replace(committed.clone(), "candidate!", false);
+
+        assert_eq!(history.undo.len(), 2);
+        assert_eq!(history.undo(typed.clone()), Some(committed.clone()));
+        assert_eq!(history.undo(committed.clone()), Some(before.clone()));
+        assert_eq!(history.redo(before), Some(committed.clone()));
+        assert_eq!(history.redo(committed), Some(typed));
+    }
+
+    #[test]
+    fn cancelled_composition_is_a_noop_and_preserves_redo() {
+        for unmark in [false, true] {
+            let mut history = EditHistory::default();
+            let before = edit_state("");
+            let future = edit_state("future");
+            history.replace(before.clone(), "future", false);
+            assert_eq!(history.undo(future.clone()), Some(before.clone()));
+            history.replace(before.clone(), "draft", true);
+            history.replace(edit_state("draft"), "", unmark);
+            if unmark {
+                history.finish_composition("");
+            }
+
+            assert!(history.undo.is_empty());
+            assert!(history.composition.is_none());
+            assert_eq!(history.redo(before.clone()), Some(future.clone()));
+            assert_eq!(history.undo(future), Some(before.clone()));
+            history.replace(before.clone(), "next", false);
+            assert!(history.redo.is_empty());
+            assert_eq!(history.undo(edit_state("next")), Some(before));
+        }
+    }
+
+    #[test]
+    fn committed_composition_invalidates_redo_but_candidates_do_not() {
+        let mut history = EditHistory::default();
+        let before = edit_state("");
+        history.replace(before.clone(), "old", false);
+        assert_eq!(history.undo(edit_state("old")), Some(before.clone()));
+        history.replace(before.clone(), "new", true);
+        assert_eq!(history.redo.len(), 1);
+        history.replace(edit_state("new"), "new", false);
+
+        assert!(history.redo.is_empty());
+        assert_eq!(history.undo(edit_state("new")), Some(before));
+    }
+
+    #[test]
+    fn undo_during_composition_finishes_then_undoes_the_composition() {
+        let mut history = EditHistory::default();
+        let before = edit_state("prefix");
+        let marked = edit_state("prefix candidate");
+        history.replace(before.clone(), &marked.content, true);
+
+        assert_eq!(history.undo(marked.clone()), Some(before.clone()));
+        assert!(history.composition.is_none());
+        assert_eq!(history.redo(before), Some(marked));
+    }
+
+    #[test]
+    fn redo_during_changed_composition_does_not_restore_stale_text() {
+        let mut history = EditHistory::default();
+        let before = edit_state("");
+        history.replace(before.clone(), "old", false);
+        assert_eq!(history.undo(edit_state("old")), Some(before.clone()));
+        let marked = edit_state("new");
+        history.replace(before.clone(), &marked.content, true);
+
+        assert_eq!(history.redo(marked.clone()), None);
+        assert!(history.composition.is_none());
+        assert_eq!(history.undo(marked), Some(before));
+    }
+
+    #[test]
+    fn regular_edits_keep_noop_and_bounded_history_behavior() {
+        let mut history = EditHistory::default();
+        for index in 0..101 {
+            history.replace(
+                edit_state(&index.to_string()),
+                &(index + 1).to_string(),
+                false,
+            );
+        }
+        assert_eq!(history.undo.len(), 100);
+        assert_eq!(history.undo.first(), Some(&edit_state("1")));
+        assert_eq!(history.undo(edit_state("101")), Some(edit_state("100")));
+        history.replace(edit_state("100"), "100", false);
+        assert_eq!(history.redo(edit_state("100")), Some(edit_state("101")));
+    }
 
     #[test]
     fn single_line_inputs_flatten_pasted_line_breaks() {


### PR DESCRIPTION
## Why

An interrupted optional command-model download could prevent ordinary dictation from starting after a restart. The remaining review also found idle retention that did not expire, IME commits missing from undo, failed update checks stuck on Checking, and cancellation ending before clipboard preparation finished.

## What Changes

| Case | New behavior |
| --- | --- |
| Commands model is missing or fails to load | Dictation starts normally; command preparation is asynchronous and failure offers Retry or Turn off commands |
| Hex stays idle past the selected retention window | Searches hide expired entries immediately; one shared worker persists expiry at most a minute later when storage is available |
| An IME candidate is committed or unmarked | One undo restores the pre-composition text and selection, including same-text commits |
| An update check fails | Checking returns to Idle without erasing successful no-update confirmation or a pending available update |
| Escape arrives during clipboard preparation | Output is cancelled before any clipboard write, paste, Send, history record, or last-result update |

The persisted command opt-in is not silently changed. Repeated retries and disable/re-enable transitions reuse an in-flight model preparation rather than spawning concurrent loads. The clipboard commit gate still prevents cancellation once mutation begins.

Simplifications remove the infallible paster constructor's Result/error branch and redundant availability flag, obsolete setup-time command-model probing, and unused command-error state. Existing channel-disconnection handling remains.

## Scope

This addresses the six reviewed findings and prepares macOS 2.1.2/build 20102. It retains the existing app identity, Rust data location, update feed, signing key, and beta-compatible ZIP filename. The Swift app/feed and unrelated SDK and paused Linux work are unchanged.

## Verification

```sh
cargo fmt --check
cargo test --locked --bin voice-control
cargo clippy --locked --all-targets --all-features -- -D warnings
./scripts/test-app-identity.sh
git diff --check
```

The missing-command setup regression was run failing before the fix. New tests cover asynchronous command preparation, history clock advancement and persistence retries without a new recording, last-owner worker shutdown, IME transaction/selection/redo behavior, native Objective-C delegate dispatch, and blocked clipboard preparation with cancellation.

354 tests passed, 9 ignored; Clippy and identity guards passed. The native delegate test also passed with Sparkle 2.9.4 preloaded rather than only synthetic protocol metadata. Three read-only correctness, reuse, and lifecycle reviews found no blockers; their two worthwhile state-removal suggestions were applied.

Native IME event delivery and physical microphone dictation are not exercised by these unit tests. Screenshot capture remains unavailable because the terminal lacks Screen Recording permission. Signed Settings with command-model recovery, History retention, and Modes previews opened successfully.

Apple accepted app and DMG notarization; both are stapled, and Gatekeeper accepts the app and DMG. Native Sparkle 2.9.4 validation and temporary installation passed from public 2.0.24, 2.1.0, and 2.1.1 to build 20102. A temporary app with an isolated identity/data root exercised a real offline update error and a subsequent retry; its logs confirmed two independent failed network checks. The fixture and its preferences were removed afterward.

Publication completed artifact-first/feed-last. Public versioned DMG, latest DMG, ZIP, and feed were downloaded and matched the prepared artifacts byte-for-byte. The installed app updated through Sparkle from 2.1.1 to 2.1.2 and relaunched; its file contents, bundle metadata, and signatures match the release.

## Release Artifacts

[Download Hex 2.1.2](https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/releases/HEX-2.1.2-arm64.dmg)

- DMG: 34,481,023 bytes; SHA-256 `7a67570e915aca1a605d7dcdd26569840f9d4ecc356a3393270f938d6a2ff151`.
- Updater ZIP: 32,790,761 bytes; SHA-256 `24e9a2bd9e62b5d3604c2ff3f57bbe16b27e106ad7457de2c0c37f455c6bc294`.
