### PR TITLE
feat(linux): add wlroots Wayland support and Nix packaging

### DIFF
--- a/.github/workflows/check-linux.yml
+++ b/.github/workflows/check-linux.yml
@@ -1,0 +1,97 @@
+name: Check Linux
+
+on:
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "build.rs"
+      - "src/**"
+      - "native/**"
+      - "resources/**"
+      - "assets/**"
+      - "tests/fixtures/**"
+      - "scripts/test-wayland-paste.sh"
+      - "flake.*"
+      - "nix/**"
+      - ".github/workflows/check-linux.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "build.rs"
+      - "src/**"
+      - "native/**"
+      - "resources/**"
+      - "assets/**"
+      - "tests/fixtures/**"
+      - "scripts/test-wayland-paste.sh"
+      - "flake.*"
+      - "nix/**"
+      - ".github/workflows/check-linux.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: linux-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      CARGO_BUILD_JOBS: "2"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      SOURCE_DATE_EPOCH: "0"
+      BLA_VENDOR: OpenBLAS
+      OPENSSL_NO_VENDOR: "1"
+      CC: clang
+      CXX: clang++
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Install native libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake pkg-config python3 libasound2-dev \
+            libssl-dev libgtk-3-dev libgtk-layer-shell-dev libayatana-appindicator3-dev \
+            libxkbcommon-x11-dev libx11-xcb-dev libfontconfig1-dev libfreetype-dev \
+            libxcursor-dev libxi-dev libxrandr-dev libopenblas-dev libvulkan-dev \
+            glslc libshaderc-dev xvfb xauth x11-xserver-utils \
+            sway wl-clipboard wtype dbus-x11 jq mesa-vulkan-drivers
+      - run: cargo fmt --all --check
+      - run: cargo test --locked --bin voice-control
+      - name: Exercise X11 grabs on an isolated display
+        run: |
+          xvfb-run -a --server-args="-screen 0 1280x900x24 -noreset" sh -c '
+            xmodmap -e "keycode 191 = F24"
+            cargo test --locked --bin voice-control linux_input::tests -- --ignored --test-threads=1
+          '
+      - name: Exercise native Wayland paste into GTK
+        run: |
+          binary=$(cargo test --locked --bin voice-control --no-run --message-format=json |
+            jq -r 'select(.reason == "compiler-artifact" and .profile.test == true and .target.name == "voice-control") | .executable // empty')
+          app=$(cargo build --locked --bin voice-control --message-format=json |
+            jq -r 'select(.reason == "compiler-artifact" and .target.name == "voice-control") | .executable // empty')
+          scripts/test-wayland-paste.sh "$binary" "$app"
+      - run: cargo clippy --locked --bin voice-control --tests -- -D warnings
+
+  nix:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+      - run: nix flake check --all-systems --no-build
+      - name: Check packaging configuration and session readiness
+        run: |
+          nix build --no-link \
+            .#checks.x86_64-linux.shell-environment \
+            .#checks.x86_64-linux.modules \
+            .#checks.x86_64-linux.session-readiness

--- a/.github/workflows/check-linux.yml
+++ b/.github/workflows/check-linux.yml
@@ -12,6 +12,8 @@ on:
       - "assets/**"
       - "tests/fixtures/**"
       - "scripts/test-wayland-paste.sh"
+      - "scripts/test-linux-dictation.sh"
+      - "scripts/*install-linux*.sh"
       - "flake.*"
       - "nix/**"
       - ".github/workflows/check-linux.yml"
@@ -27,6 +29,8 @@ on:
       - "assets/**"
       - "tests/fixtures/**"
       - "scripts/test-wayland-paste.sh"
+      - "scripts/test-linux-dictation.sh"
+      - "scripts/*install-linux*.sh"
       - "flake.*"
       - "nix/**"
       - ".github/workflows/check-linux.yml"
@@ -41,7 +45,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CARGO_BUILD_JOBS: "2"
       CARGO_PROFILE_DEV_DEBUG: "0"
@@ -64,7 +68,8 @@ jobs:
             libxkbcommon-x11-dev libx11-xcb-dev libfontconfig1-dev libfreetype-dev \
             libxcursor-dev libxi-dev libxrandr-dev libopenblas-dev libvulkan-dev \
             glslc libshaderc-dev xvfb xauth x11-xserver-utils \
-            sway wl-clipboard wtype dbus-x11 jq mesa-vulkan-drivers
+            sway wl-clipboard wtype dbus-x11 jq mesa-vulkan-drivers \
+            pulseaudio pulseaudio-utils libasound2-plugins xdotool
       - run: cargo fmt --all --check
       - run: cargo test --locked --bin voice-control
       - name: Exercise X11 grabs on an isolated display
@@ -80,6 +85,26 @@ jobs:
           app=$(cargo build --locked --bin voice-control --message-format=json |
             jq -r 'select(.reason == "compiler-artifact" and .target.name == "voice-control") | .executable // empty')
           scripts/test-wayland-paste.sh "$binary" "$app"
+      - uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/hex-model-test/models
+          key: linux-dictation-model-${{ hashFiles('src/transcription_models.rs') }}
+      - name: Exercise capture, inference, and paste through a virtual microphone
+        env:
+          HEX_APPLICATION_SUPPORT_DIR: ${{ runner.temp }}/hex-model-test
+        run: |
+          target/debug/voice-control model install
+          curl --fail --location --silent --show-error --max-time 60 \
+            https://raw.githubusercontent.com/ggml-org/whisper.cpp/b0a11594aec50892a02cd8d129eee2dfe93a8bb8/samples/jfk.wav \
+            --output "$RUNNER_TEMP/jfk.wav"
+          printf '%s  %s\n' \
+            59dfb9a4acb36fe2a2affc14bacbee2920ff435cb13cc314a08c13f66ba7860e \
+            "$RUNNER_TEMP/jfk.wav" | sha256sum --check
+          scripts/test-linux-dictation.sh target/debug/voice-control \
+            "$HEX_APPLICATION_SUPPORT_DIR/models/parakeet-unified-en-0.6b-Q8_0.gguf" \
+            "$RUNNER_TEMP/jfk.wav"
+      - name: Exercise signed installer and tamper rejection
+        run: scripts/test-install-linux-release.sh
       - run: cargo clippy --locked --bin voice-control --tests -- -D warnings
 
   nix:

--- a/.github/workflows/check-linux.yml
+++ b/.github/workflows/check-linux.yml
@@ -115,6 +115,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          use-gha-cache: enabled
+          use-flakehub: disabled
+          diagnostic-endpoint: ""
       - run: nix flake check --all-systems --no-build
       - name: Check packaging configuration and session readiness
         run: |

--- a/.github/workflows/check-linux.yml
+++ b/.github/workflows/check-linux.yml
@@ -60,6 +60,8 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Install native libraries
         run: |
           sudo apt-get update

--- a/.github/workflows/check-linux.yml
+++ b/.github/workflows/check-linux.yml
@@ -84,7 +84,7 @@ jobs:
 
   nix:
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
@@ -95,3 +95,7 @@ jobs:
             .#checks.x86_64-linux.shell-environment \
             .#checks.x86_64-linux.modules \
             .#checks.x86_64-linux.session-readiness
+      - name: Build and test the installed Nix package
+        run: |
+          nix build --no-link --print-build-logs --max-jobs 1 --cores 1 \
+            .#checks.x86_64-linux.package

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__/
 *.rmeta
 /ios/*DerivedData
 /ios/HEXMobile.xcodeproj
+/result
+/result-*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,10 @@
 
 ## Purpose
 
-Build HEX as a local, observable macOS voice appliance with an explicit Linux
-X11 beta contract. Keep the engine native Rust and keep consequential behavior
-explicit. Protected commands and typed captures remain compiled Rust; ordinary
-literal commands live in the explicit TypeScript user config. User-facing
+Build HEX as a local, observable macOS voice appliance with explicit Linux
+X11 and wlroots-compatible Wayland beta contracts. Keep the engine native Rust
+and keep consequential behavior explicit. Protected commands and typed captures
+remain compiled Rust; ordinary literal commands live in the explicit TypeScript user config. User-facing
 runtime settings persist in Application Support.
 
 The distributed release starts in hotkey-dictation-only mode. Voice commands and
@@ -83,9 +83,15 @@ only in debug builds.
   installation, the release startup gate, and opt-in command-model setup.
 - `sparkle`: packaged-app-only Sparkle lifecycle and manual update checks.
 - `linux`, `linux_app`, `linux_dictation`, `linux_input`, `linux_paste`,
-  `linux_settings`, `linux_transcriber`: the X11 beta CLI, GPUI shell and tray,
-  hotkey capture-transcribe-paste loop, X11 grabs and synthetic paste,
-  persisted Linux settings, and the `transcribe.cpp` session.
+  `linux_settings`, `linux_transcriber`: the Linux beta CLI, GPUI shell,
+  hotkey capture-transcribe-paste loop, persisted settings, and `transcribe.cpp`.
+- `linux_session`: display-backend selection matching GPUI's nonempty
+  `WAYLAND_DISPLAY` rule, independent of persisted preferences.
+- `linux_wayland_input`: read-only evdev input, explicit physical key mappings,
+  cancellable shortcut capture, exact chord state, and bounded device rediscovery.
+- `linux_desktop`: the single process-owned GTK thread for the X11 tray and
+  focus-free, click-through Wayland recording/processing HUD. A listener never
+  initializes or shuts down a separate GTK runtime.
 - `linux_updater`: signed direct-install updates, bounded downloads, atomic
   version activation, and restart handoff for user-local Linux installs.
 - `history`: the owner-only bounded retained-dictation store: retention
@@ -261,6 +267,23 @@ CoreAudio formats, AppleScript details, or event serialization.
   x86_64 manifest, verify exact size and SHA-256 from a content-addressed
   artifact, and atomically switch the user-local `current` version. Never
   overwrite development, root, or package-manager-owned binaries.
+- The Wayland beta requires compatible clipboard, virtual-keyboard, and
+  layer-shell protocols plus explicit read access to all `/dev/input/event*`
+  nodes. Do not silently fall back to XWayland or privileged input injection.
+  Raw input observes, but does not suppress, physical US-labeled keys. Explain
+  the broad keystroke access; never grant device permissions automatically.
+- X11 shortcut capture uses focused GPUI input, not evdev permissions. Editing
+  shortcut/double-tap settings stops and restores only a previously running
+  listener; cancellation restores the old binding unless its save already
+  committed. Settings must expose listener state, recovery, and errors. Without
+  a usable tray, closing Settings quits after draining workers, never detaches
+  an unmanageable microphone. HUD teardown only hides that listener's HUD.
+- Linux paste keeps transcripts off helper argv, bounds helper I/O, and waits
+  for physical modifiers without discarding accepted output. Shutdown cancels
+  that wait. New installs use Ctrl-V; the terminal-paste preference selects
+  Ctrl-Shift-V and defaults on for persisted legacy X11 settings. The beta retains
+  the transcript clipboard; arbitrary MIME restoration and consumption
+  acknowledgments remain unimplemented.
 
 ## Development
 
@@ -341,15 +364,21 @@ native build dependencies with:
 
 ```sh
 sudo pacman -S --needed base-devel git rustup python alsa-lib curl jq openssl xxd \
-  util-linux gtk3 libappindicator-gtk3 libxkbcommon \
+  util-linux gtk3 gtk-layer-shell libappindicator-gtk3 libxkbcommon \
   libxkbcommon-x11 libx11 libxcb openblas vulkan-headers vulkan-icd-loader \
-  shaderc spirv-headers clang cmake pkgconf
+  shaderc spirv-headers clang cmake pkgconf wl-clipboard wtype
 rustup default stable
 ```
 
 For a source install, run `scripts/install-linux.sh`, then `hex model install`.
 The installer owns the user-local version layout, desktop entry, and autostart
 entry; only that managed layout participates in automatic updates.
+
+`nix develop` supplies the same native build environment as the Nix package;
+`nix flake check` checks modules, shell configuration, session readiness, and
+the display-free Rust suite. See `docs/nix.md`. Nix owns package updates and
+optional Home Manager autostart. Native Linux PR checks do not replace real
+X11/Wayland, keyboard hotplug, microphone, and target-application smoke tests.
 
 Automatic microphone selection follows the compiled preference order in
 `src/config.rs`, then falls back to the macOS default. A saved microphone takes
@@ -421,6 +450,8 @@ seam once there are two real adapters or a current test requires substitution.
 
 - Validate public onboarding from a clean macOS account and signed Linux updates
   on the supported Arch/i3 host.
+- Validate native Wayland on a real compatible compositor, including physical
+  device reconnect, focus/click-through, target paste, and tray-less shutdown.
 - Add a second real browser adapter before generalizing browser context.
 - Do not turn concrete macOS, Linux X11, or command modules into hypothetical
   platform or plugin frameworks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,9 @@ Linux dependencies and installation are documented in
 native code, exercises X11 grabs on Xvfb, and tests native Wayland clipboard
 insertion into a GTK target with Settings open under isolated headless Sway.
 It also builds the Nix package with its tests and checks the installed wrapper.
-It does not replace physical input, microphone, or broader target-application
-smoke tests.
+An X11 virtual-microphone test exercises real capture, local inference, paste,
+and shutdown using a public speech sample. These checks do not replace physical
+input, microphone, or broader target-application smoke tests.
 
 ## Validate Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing To HEX
 
-HEX is a native Rust macOS application with an explicit x86_64 Arch Linux X11
-beta. Read [`AGENTS.md`](AGENTS.md) before changing behavior; it defines the
-architecture and invariants.
+HEX is a native Rust macOS application with an explicit x86_64 Linux beta for
+X11 and compatible wlroots Wayland compositors. Read [`AGENTS.md`](AGENTS.md)
+before changing behavior; it defines the architecture and invariants.
 
 ## Set Up
 
@@ -14,7 +14,11 @@ On macOS:
 ```
 
 Linux dependencies and installation are documented in
-[`docs/linux.md`](docs/linux.md).
+[`docs/linux.md`](docs/linux.md); Nix development is covered in
+[`docs/nix.md`](docs/nix.md). The Linux pull-request workflow builds and tests
+native code, exercises X11 grabs on Xvfb, and tests native Wayland clipboard
+insertion into a GTK target under isolated headless Sway. It does not replace
+physical input, microphone, or broader target-application smoke tests.
 
 ## Validate Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,10 @@ Linux dependencies and installation are documented in
 [`docs/linux.md`](docs/linux.md); Nix development is covered in
 [`docs/nix.md`](docs/nix.md). The Linux pull-request workflow builds and tests
 native code, exercises X11 grabs on Xvfb, and tests native Wayland clipboard
-insertion into a GTK target under isolated headless Sway. It does not replace
-physical input, microphone, or broader target-application smoke tests.
+insertion into a GTK target with Settings open under isolated headless Sway.
+It also builds the Nix package with its tests and checks the installed wrapper.
+It does not replace physical input, microphone, or broader target-application
+smoke tests.
 
 ## Validate Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -286,6 +286,9 @@ dependencies = [
  "serde",
  "serde_repr",
  "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.32.13",
  "zbus",
 ]
 
@@ -558,7 +561,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -736,6 +739,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
  "no_std_io2",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -939,7 +954,7 @@ checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -954,6 +969,18 @@ dependencies = [
  "rustix 0.38.44",
  "slab",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
 ]
 
 [[package]]
@@ -1026,7 +1053,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4ece8474b5f766c63426647e7b4b316b67431ade1036a8313cee24a03ae917"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -2050,7 +2087,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2109,6 +2146,12 @@ dependencies = [
  "crossbeam-queue",
  "futures-util",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -2292,7 +2335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2318,6 +2361,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "evdev"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b686663ba7f08d92880ff6ba22170f1df4e83629341cba34cf82cd65ebea99"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "libc",
+ "nix 0.29.0",
 ]
 
 [[package]]
@@ -2651,6 +2706,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,7 +2875,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2831,7 +2892,7 @@ dependencies = [
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -2937,7 +2998,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "winapi",
 ]
 
@@ -2985,7 +3046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3039,7 +3100,7 @@ checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3089,6 +3150,7 @@ dependencies = [
  "block",
  "bytemuck",
  "calloop",
+ "calloop-wayland-source",
  "cbindgen",
  "cocoa 0.26.0",
  "cocoa-foundation 0.2.0",
@@ -3150,6 +3212,11 @@ dependencies = [
  "usvg",
  "uuid",
  "waker-fn",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-cursor",
+ "wayland-protocols 0.31.2",
+ "wayland-protocols-plasma",
  "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-numerics 0.2.0",
@@ -3365,6 +3432,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "gtk-layer-shell"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc759b3184830a547b31549ab40c4b54450ab702bba79ba23f049bc1d1e3ca98"
+dependencies = [
+ "bitflags 2.13.0",
+ "gdk",
+ "glib",
+ "glib-sys",
+ "gtk",
+ "gtk-layer-shell-sys",
+ "libc",
+]
+
+[[package]]
+name = "gtk-layer-shell-sys"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4eee067e022416d53a70de69d3d3929d8a6e687f3278b8934faa671750fa6eb"
+dependencies = [
+ "gdk-sys",
+ "glib-sys",
+ "gtk-sys",
+ "libc",
+ "system-deps 7.0.8",
+]
+
+[[package]]
 name = "gtk-sys"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3379,7 +3474,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pango-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3923,7 +4018,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4569,7 +4664,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4747,7 +4842,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5408,7 +5503,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -5942,6 +6037,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5994,7 +6098,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6017,6 +6121,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -6595,7 +6705,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6744,6 +6854,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -7139,7 +7255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7197,7 +7313,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7564,10 +7680,23 @@ version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
  "heck 0.5.0",
  "pkg-config",
  "toml 0.8.23",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr 0.20.9",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 1.1.3+spec-1.1.0",
  "version-compare",
 ]
 
@@ -7602,10 +7731,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -7617,7 +7758,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7650,7 +7791,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8190,7 +8331,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8246,7 +8387,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8540,11 +8681,13 @@ dependencies = [
  "ctrlc",
  "dirs 6.0.0",
  "ed25519-dalek",
+ "evdev",
  "fs2",
  "getrandom 0.3.4",
  "gpui",
  "gpui-symbols",
  "gtk",
+ "gtk-layer-shell",
  "hound",
  "libc",
  "libloading 0.9.0",
@@ -8714,6 +8857,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols 0.31.2",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.41.0",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8854,7 +9094,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9521,6 +9761,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x11"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9577,7 +9826,7 @@ checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
- "quick-xml",
+ "quick-xml 0.30.0",
  "x11",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,9 +61,12 @@ screencapturekit = { version = "=8.0.0", features = ["macos_15_0"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 base64 = "0.22.1"
+ctrlc = { version = "3.5.2", features = ["termination"] }
 ed25519-dalek = "2.2.0"
-gpui = { version = "0.2.2", default-features = false, features = ["font-kit", "x11"] }
+evdev = "0.13.2"
+gpui = { version = "0.2.2", default-features = false, features = ["font-kit", "wayland", "x11"] }
 gtk = "0.18.2"
+gtk-layer-shell = { version = "0.8.2", features = ["v0_6"] }
 semver = "1.0.28"
 tray-icon = { version = "0.24.1", default-features = false, features = ["gtk"] }
 transcribe-cpp = { version = "=0.1.3", features = ["vulkan"] }

--- a/README.md
+++ b/README.md
@@ -110,15 +110,17 @@ Diagnostics are stored at:
 - macOS: `~/Library/Application Support/voice-control/logs/`
 - Linux: `~/.local/share/voice-control/logs/`, or under `XDG_DATA_HOME`
 
-## Linux X11 Beta
+## Linux Beta
 
-The Linux beta targets x86_64 Arch Linux on i3/X11. It supports local hotkey
-dictation, automatic paste, shortcut rebinding, a tray app, and user-local
-updates. It does not support voice commands, meetings, native Wayland, or a
-package-manager install.
+The Linux beta targets x86_64 Linux on i3/X11 and compatible wlroots Wayland
+compositors. It supports local hotkey dictation, a GPUI settings shell, and
+signed updates for direct installs. Native Wayland requires explicit input-device
+access and compositor support for clipboard, virtual-keyboard, and layer-shell
+protocols. Voice commands and meetings are not included.
 
-See the [Linux installation guide](docs/linux.md) for the verified user-local
+See the [Linux installation guide](docs/linux.md) for the user-local
 installer, source-build fallback, requirements, and limitations.
+For Nix/NixOS packaging and per-user autostart, see the [Nix guide](docs/nix.md).
 
 ## Contributing
 

--- a/build.rs
+++ b/build.rs
@@ -6,8 +6,9 @@ fn main() {
         if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux") {
             // transcribe-cpp's static manifest records OpenBLAS as an absolute
             // link argument, which Cargo does not propagate through the -sys
-            // crate to this final binary.
-            println!("cargo:rustc-link-lib=dylib=openblas");
+            // crate to this final binary. Keep it after the static archives so
+            // GNU ld's --as-needed does not discard it before seeing cblas_*.
+            println!("cargo:rustc-link-arg=-lopenblas");
         }
         return;
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,8 @@ override shipped behavior.
 ## User Guides
 
 - [`../README.md`](../README.md): install and use HEX on macOS.
-- [`linux.md`](linux.md): install the supported Linux X11 beta from source.
+- [`linux.md`](linux.md): Linux X11 and native Wayland beta requirements and installation.
+- [`nix.md`](nix.md): Nix packaging, development, and per-user autostart.
 - [`../ios/README.md`](../ios/README.md): build and test the iOS prototype.
 
 ## Engineering Reference
@@ -29,7 +30,7 @@ override shipped behavior.
   and Linux GPUI applications on one capability-driven product shell.
 - [`plans/typescript-sdk.md`](plans/typescript-sdk.md): private SDK packaging,
   validation, and first-consumer work.
-- [`plans/linux.md`](plans/linux.md): Linux X11 validation and later capability
+- [`plans/linux.md`](plans/linux.md): Linux X11/Wayland validation and later capability
   slices.
 
 When a plan disagrees with `AGENTS.md` about shipped behavior, update the plan.

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,11 +1,16 @@
-# Install The Linux X11 Beta
+# Install The Linux Beta
 
-HEX currently supports one Linux beta target: x86_64 Arch Linux running i3 on
-X11. Audio uses ALSA, including PipeWire systems with ALSA compatibility.
-Inference uses Vulkan when available and can fall back to the CPU.
+The Linux beta targets x86_64 Linux: i3/X11 and compatible wlroots-based Wayland
+compositors such as Hyprland or Sway. Audio uses ALSA, including PipeWire systems
+with ALSA compatibility. Inference uses Vulkan when available and can fall back
+to the CPU. See the Wayland requirements below before enabling native input.
 
-The beta does not support voice commands, application or browser context,
-meetings, native Wayland, or package-manager installation.
+The beta does not support voice commands, application or browser context, or
+meetings. This is not universal Wayland support: GNOME and KDE are not covered
+by the current clipboard, virtual-keyboard, and overlay protocol contract.
+
+For Nix/NixOS, use the [Nix guide](nix.md). Nix owns updates to that installation;
+HEX's signed updater owns only the direct-install layout below.
 
 ## Install A Published Build
 
@@ -13,8 +18,9 @@ After the first signed Linux release is published, download and inspect the
 installer before running it:
 
 ```sh
-sudo pacman -S --needed alsa-lib curl gtk3 jq libappindicator-gtk3 libxkbcommon \
-  libxkbcommon-x11 libx11 libxcb openblas openssl util-linux vulkan-icd-loader xxd
+sudo pacman -S --needed alsa-lib curl gtk3 gtk-layer-shell jq libappindicator-gtk3 \
+  libxkbcommon libxkbcommon-x11 libx11 libxcb openblas openssl util-linux \
+  vulkan-icd-loader wl-clipboard wtype xxd
 curl --proto '=https' --tlsv1.2 -fsSLO \
   https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/install-linux.sh
 less install-linux.sh
@@ -40,9 +46,9 @@ Install the native dependencies and, for a source build, the Rust toolchain:
 
 ```sh
 sudo pacman -S --needed base-devel git rustup python alsa-lib curl jq openssl xxd \
-  util-linux gtk3 libappindicator-gtk3 libxkbcommon \
+  util-linux gtk3 gtk-layer-shell libappindicator-gtk3 libxkbcommon \
   libxkbcommon-x11 libx11 libxcb openblas vulkan-headers vulkan-icd-loader \
-  shaderc spirv-headers clang cmake pkgconf
+  shaderc spirv-headers clang cmake pkgconf wl-clipboard wtype
 rustup default stable
 ```
 
@@ -62,8 +68,55 @@ launcher, and autostart entry.
 ## Dictate
 
 Hold **Alt-Space**, speak, then release. Double-tap the shortcut to keep
-recording, press it again to finish, or press Escape to cancel. Stop the listener
-before changing the shortcut in Settings.
+recording, press the same chord again to finish, or press Escape to cancel the
+active recording. Settings shows listener state, Start/Stop, and operational
+errors. Changing the shortcut or double-tap setting temporarily stops listening
+and restores the previous running state after the edit. Cancelling shortcut
+capture restores the old binding and running state.
+
+With a working X11 tray, closing Settings hides the window. Without a working
+tray, closing Settings quits after stopping its workers; it never leaves an
+unmanageable microphone running. `--hidden` is honored only with a usable tray.
+On Wayland, leave Settings open while dictating; the recording/processing pill
+uses layer-shell without taking focus or intercepting clicks.
+
+Insertion uses the clipboard and **Ctrl-V** for new installations. Enable
+**Terminal paste shortcut** in Settings for targets that require **Ctrl-Shift-V**.
+Existing X11 settings retain their previous Ctrl-Shift-V behavior until changed.
+The target application must accept the selected binding. The beta leaves the
+transcript on the clipboard; arbitrary previous
+clipboard formats are not restored. A short settling delay prevents immediate
+back-to-back replacement, but is not an acknowledgment from a stalled target
+application (see [#24](https://github.com/anomalyco/hex/issues/24)).
+
+## Native Wayland Requirements
+
+- Export the compositor's nonempty `WAYLAND_DISPLAY` in the launch environment.
+  HEX, GTK, and GPUI select the same native backend even when XWayland's
+  `DISPLAY` is also present. `XDG_SESSION_TYPE` alone does not select Wayland.
+- Install `wl-clipboard` and `wtype`. The compositor must support their clipboard
+  and virtual-keyboard protocols. There is no silent XWayland, direct-typing, or
+  privileged input-injection fallback. Transcript text travels on stdin, not
+  command-line arguments.
+- The overlay requires layer-shell. Settings reports when the HUD is unavailable
+  rather than presenting a normal focus-taking window as an overlay.
+- The evdev backend requires read access to **every `/dev/input/event*` node**
+  so it can inspect which devices may hold modifier keys. An unreadable node
+  causes an explicit startup error, not a listener that reports ready but cannot
+  paste. Configure this deliberately using your distribution's input-group or
+  equivalent policy; HEX does not grant permissions or run as root.
+- **This access exposes all keyboard input to processes running as your user,
+  not only HEX's shortcut.** Do not make event devices world-readable. X11 does
+  not require this additional access.
+- Shortcut labels use physical evdev keys with US-layout names. The backend
+  observes keys without suppressing delivery to other applications. Reserve the
+  chosen chord with a no-op compositor binding if it would otherwise reach the
+  focused client. Modifier-only shortcuts are not supported.
+- Devices are rescanned once per second. Device loss or an input-stream gap
+  cancels an active recording rather than fabricating a release; a reconnected
+  keyboard can be used after the next scan.
+
+## Updates And Validation
 
 Managed installs check for signed updates at startup and every 24 hours. HEX
 downloads, verifies, and installs an available update, then asks before
@@ -71,4 +124,15 @@ restarting into it. The signed update path is implemented but still awaiting a
 complete cross-version validation on the supported Arch/i3 host.
 
 See [`plans/linux.md`](plans/linux.md) for the engineering contract and remaining
-validation work.
+validation work. The native Wayland implementation builds on the feature
+proposed in [PR #28](https://github.com/anomalyco/hex/pull/28), with separate
+input-state, lifecycle, and paste regression coverage. Physical device,
+compositor, and target-application smoke tests remain necessary before a release.
+`scripts/test-wayland-paste.sh /path/to/compiled-test-executable /path/to/voice-control` runs the real
+paste helpers against a GTK target under an isolated headless Sway compositor.
+It also launches Settings with `--hidden` and verifies that the tray-less native
+window remains visible and closes cleanly. It requires the GTK development
+libraries, Sway, `wl-clipboard`, `wtype`, `dbus-run-session`, and a Vulkan driver
+(Mesa's software driver is sufficient), and must run as a non-root user. It uses
+isolated app data and no microphone; CI runs it with the display-free suite and
+Xvfb hotkey tests.

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -130,8 +130,8 @@ input-state, lifecycle, and paste regression coverage. Physical device,
 compositor, and target-application smoke tests remain necessary before a release.
 `scripts/test-wayland-paste.sh /path/to/compiled-test-executable /path/to/voice-control` runs the real
 paste helpers against a GTK target under an isolated headless Sway compositor.
-It also launches Settings with `--hidden` and verifies that the tray-less native
-window remains visible and closes cleanly. It requires the GTK development
+It also launches Settings with `--hidden`, repeats paste while Settings remains
+open, and verifies that the tray-less native window closes cleanly. It requires the GTK development
 libraries, Sway, `wl-clipboard`, `wtype`, `dbus-run-session`, and a Vulkan driver
 (Mesa's software driver is sufficient), and must run as a non-root user. It uses
 isolated app data and no microphone; CI runs it with the display-free suite and

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -138,10 +138,11 @@ isolated app data and no microphone; CI runs it with the display-free suite and
 Xvfb hotkey tests.
 
 `scripts/test-linux-dictation.sh /path/to/voice-control /path/to/parakeet-unified-en-0.6b-Q8_0.gguf /path/to/jfk.wav`
-checks the complete X11 dictation path with a private PulseAudio virtual
-microphone and Xvfb display. It replays the public JFK sample from whisper.cpp,
-holds and releases the real shortcut, verifies the transcribed words in a GTK
-editor, and checks orderly listener shutdown. It needs PulseAudio, its ALSA
+checks the complete X11 app dictation path with a private PulseAudio virtual
+microphone and Xvfb display. It verifies Settings stays visible without a tray,
+replays the public JFK sample from whisper.cpp, holds and releases the real
+shortcut, verifies the transcribed words in a GTK editor, and checks orderly
+application shutdown and microphone release. It needs PulseAudio, its ALSA
 plugin, `xdotool`, Xvfb, and the GTK development libraries. It runs as a normal
 user with temporary settings; it does not use physical audio devices or personal
 recordings. CI downloads and verifies the pinned model and sample for this check.

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -136,3 +136,12 @@ libraries, Sway, `wl-clipboard`, `wtype`, `dbus-run-session`, and a Vulkan drive
 (Mesa's software driver is sufficient), and must run as a non-root user. It uses
 isolated app data and no microphone; CI runs it with the display-free suite and
 Xvfb hotkey tests.
+
+`scripts/test-linux-dictation.sh /path/to/voice-control /path/to/parakeet-unified-en-0.6b-Q8_0.gguf /path/to/jfk.wav`
+checks the complete X11 dictation path with a private PulseAudio virtual
+microphone and Xvfb display. It replays the public JFK sample from whisper.cpp,
+holds and releases the real shortcut, verifies the transcribed words in a GTK
+editor, and checks orderly listener shutdown. It needs PulseAudio, its ALSA
+plugin, `xdotool`, Xvfb, and the GTK development libraries. It runs as a normal
+user with temporary settings; it does not use physical audio devices or personal
+recordings. CI downloads and verifies the pinned model and sample for this check.

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -1,0 +1,135 @@
+# Nix
+
+The flake packages HEX for `x86_64-linux`. It supports the Linux X11 beta
+and native Wayland on compatible wlroots compositors. Wayland requires
+layer-shell for the recording overlay, the clipboard protocol used by
+`wl-copy`, the virtual-keyboard protocol used by `wtype`, and read access to
+every `/dev/input/event*` device for global hotkeys. This is not a claim of support
+for every Wayland desktop; GNOME and KDE are not covered by this contract.
+
+## Run Or Install
+
+From a checkout, with Nix flakes enabled:
+
+```sh
+nix build
+nix run . -- model install
+nix run . -- app
+```
+
+Or add `hex.url = "github:anomalyco/hex"` to your configuration's flake inputs
+and install `hex.packages.x86_64-linux.default`. The package supplies the
+`hex` command and desktop launcher, native libraries, and the `curl`,
+`wl-copy`, and `wtype` runtime dependencies. Your system still needs a
+working audio session and graphics drivers. On non-NixOS hosts, Nix GUI
+applications may require the host's usual Nix graphics integration.
+
+Models are downloaded into your user data directory, not the Nix store.
+Run `hex model install` once, then launch HEX as your normal desktop user.
+Do not run HEX as root.
+
+The Nix store is not HEX's user-local managed installation layout. In-app
+updates do not replace a Nix installation. Update the flake input and
+rebuild or switch your Nix/Home Manager configuration instead. Remove any
+old source-install XDG autostart entry before enabling a second autostart
+mechanism; do not run two HEX listeners.
+
+## NixOS
+
+Import `hex.nixosModules.hex` and enable the package:
+
+```nix
+{
+  imports = [ hex.nixosModules.hex ];
+  programs.hex.enable = true;
+}
+```
+
+This installs HEX system-wide. It does not start a root service, enable
+autostart for every account, or change input-device permissions. Use the
+Home Manager module below for per-user autostart. Both modules accept an
+explicit `programs.hex.package` override. The flake also exports
+`hex.overlays.default` for configurations that prefer `pkgs.hex`.
+
+## Home Manager
+
+```nix
+{
+  imports = [ hex.homeManagerModules.hex ];
+  programs.hex = {
+    enable = true;
+    autostart = true;
+    # Use your compositor's session target when appropriate:
+    # systemdTarget = "sway-session.target";
+  };
+}
+```
+
+Autostart defaults to `false`. When enabled, HEX is a systemd **user**
+service, wanted by `graphical-session.target` by default. It waits for a
+Wayland socket or an X11 window manager before launching with `app --hidden`.
+The service stops with the configured target and retries failed starts
+without a tight restart loop. Quitting HEX normally leaves it stopped until
+the next session or an explicit `systemctl --user start hex.service`.
+
+Your session manager must import its current `DISPLAY`, `XAUTHORITY`,
+`WAYLAND_DISPLAY`, and `XDG_RUNTIME_DIR` values as applicable into the systemd
+user environment **before** starting the target, and stop the target at
+logout. Use your compositor's systemd integration, such as Home Manager's
+Sway integration, rather than starting the target from a shell login.
+The module does not create a graphical session or grant permission to use
+one. A bare `startx`/i3 session without systemd session integration will not
+start this service automatically.
+
+Home Manager's normal service-switch policy applies: newly enabled services
+can start during a switch if the session target is already active, and
+package changes can restart a running service. Do not switch during an
+active recording. Inspect failures with:
+
+```sh
+systemctl --user status hex.service
+journalctl --user -u hex.service
+```
+
+## Wayland Input Access
+
+The native Wayland beta requires the intended user to be able to read
+**every `/dev/input/event*` node**, as with deliberate `input`-group access.
+Keyboard-only ACLs are insufficient: HEX cannot rule out held modifiers on
+an unreadable device. Monitoring, shortcut capture, and paste fail with a
+permission error if any event device is unreadable.
+
+Neither module adds users to the `input` group, installs permissive udev
+rules, or grants capabilities to HEX. Make this access decision explicitly
+for the intended account; do not make event devices world-readable.
+**Raw input access exposes all keystrokes on those keyboards, not just
+HEX's hotkeys, and can expose other input devices.** Other processes running
+as the same user receive the same broad access.
+
+Wayland shortcuts use physical evdev key positions and US-style key labels,
+not the current layout's characters. HEX observes the keys but does not
+suppress them. The compositor or focused app can still act on the chord;
+use an appropriate compositor binding if you need to reserve it. The paste
+helper is `wtype`; no privileged input-injection fallback is installed.
+
+## Development
+
+```sh
+nix develop
+cargo build --locked
+cargo test --locked
+cargo run --locked -- app
+```
+
+The package and shell share the native build environment and runtime
+library/plugin paths. OpenBLAS link ordering is handled by `build.rs`, not
+by Nix-only `RUSTFLAGS`. The shell also supplies the paste and download
+helpers, so it does not rely on the installed app's wrapper. Desktop commands
+still require a real graphical/audio session and the permissions described above.
+
+`nix flake check` evaluates the module and shell-environment regressions and
+builds the package with its normal display-free Rust tests. Tests explicitly
+marked ignored because they require a desktop or installed model remain
+ignored; the Nix build does not download models or exercise live input.
+
+The initial packaging design builds on [PR #29](https://github.com/anomalyco/hex/pull/29).

--- a/docs/plans/linux.md
+++ b/docs/plans/linux.md
@@ -1,36 +1,46 @@
 # Linux Plan
 
-**Status:** Active validation and capability plan. The x86_64 Arch/i3 X11 beta
-is implemented. The immediate blocker is validating a genuine signed update on
-the target machine.
+**Status:** Active validation and capability plan. The x86_64 X11 beta,
+wlroots-compatible native Wayland path, and Nix packaging are implemented.
+Physical desktop/input validation and a genuine signed update remain release
+gates; automated checks alone do not establish those behaviors.
 
 ## The Supported Contract Is Narrow
 
-HEX currently supports one Linux beta contract:
+The Linux beta keeps its contracts explicit:
 
 | Area | Contract |
 | --- | --- |
-| Distribution | User-local direct install with signed automatic updates |
-| Host | x86_64 Arch Linux rolling |
-| Desktop | i3 on X11 |
+| Distribution | Signed user-local direct install, or Nix-owned package updates |
+| Host | x86_64 Linux; Arch/i3 reference and NixOS packaging |
+| Desktop | i3/X11 or compatible wlroots Wayland compositor |
 | Audio | CPAL through ALSA, typically backed by PipeWire |
 | Inference | Vulkan with CPU fallback |
 | Shortcut | Configurable key-containing chord; default `Alt+Space` |
-| Insertion | X11 clipboard and synthetic paste |
-| UI | GPUI settings shell and tray |
+| Insertion | Clipboard plus Ctrl-V, with a Ctrl-Shift-V terminal setting |
+| UI | GPUI shell; X11 tray where available; Wayland layer-shell HUD |
 
 The beta does not claim voice commands, application or browser context,
-meetings, native Wayland support, or package-manager installation. XWayland is
-not native Wayland support.
+meetings, or universal Wayland support. Wayland needs explicit read access to
+all event devices, `wl-copy`, `wtype`, and compatible compositor protocols.
+There is no hidden XWayland or privileged injection fallback. See
+[`../linux.md`](../linux.md) and [`../nix.md`](../nix.md).
 
 ## What Is Implemented
 
 - Global hold/release dictation, Escape cancellation, and double-tap lock.
 - Configurable persisted shortcut binding.
 - Local model installation and transcription.
-- Automatic clipboard insertion and restoration.
+- Automatic clipboard insertion with bounded settling. The transcript remains
+  on the clipboard; arbitrary previous formats are not restored.
 - CLI microphone override.
 - GPUI shell, tray integration, desktop launcher, and autostart entry.
+- Native Wayland evdev input with explicit key mapping, cancellation, and
+  device rediscovery; persistent click-through recording/processing overlay.
+- Visible listener controls, transactional shortcut edits, and orderly tray-less
+  shutdown instead of a detached invisible microphone.
+- Nix package and matching development shell, NixOS installation, optional
+  Home Manager user service, and evaluated session-readiness checks.
 - XDG paths, diagnostics, and exclusive listener ownership.
 - Signed user-local updates with bounded download, exact size and SHA-256
   verification, atomic version activation, and restart handoff.
@@ -98,9 +108,12 @@ links without recording samples. Normalize process and media metadata into the
 existing meeting-candidate model. Detection remains offer-only and never starts
 recording automatically.
 
-### 5. Choose A Native Wayland Contract
+### 5. Expand Wayland Only With Explicit Capabilities
 
-Wayland support requires an explicit capability decision:
+The implemented beta uses read-only evdev observation plus compositor-provided
+clipboard and virtual-keyboard protocols. It does not suppress the shortcut;
+users may need a compositor no-op binding. It does not grant input permissions.
+Broader or less-privileged support requires a separate capability decision:
 
 | Contract | Input and insertion behavior |
 | --- | --- |
@@ -116,10 +129,11 @@ that handles keyboard hotplug, crash-safe key release, access policy, and exact
 re-injection of non-suppressed events. Do not build a general-purpose root
 daemon.
 
-### 6. Add Distribution Channels Deliberately
+### 6. Validate Distribution Channels Deliberately
 
-The app-managed updater owns only the user-local direct-install layout. A future
-Arch package must leave updates to the package manager. Add architectures,
+The app-managed updater owns only the user-local direct-install layout. Nix owns
+its packaged installation and optional user service; a future Arch package must
+also leave updates to the package manager. Add architectures,
 distros, or package formats one validated channel at a time.
 
 ## Preserve The Portable Core
@@ -160,6 +174,7 @@ cargo test
 cargo clippy --all-targets --all-features -- -D warnings
 git diff --check
 ./scripts/test-install-linux-release.sh
+nix flake check
 ```
 
 Run behavior tests against real adapters rather than mocks that repeat
@@ -193,6 +208,10 @@ implementation assumptions.
 - Target x86_64 Arch Linux rolling on i3/X11.
 - Ship through a signed user-local direct-install channel.
 - Require automatic insertion and a key-containing shortcut.
-- Exclude meetings and native Wayland from the first beta.
+- Exclude meetings; scope native Wayland to compatible wlroots protocols and
+  explicit raw-input permissions rather than claiming every compositor.
 - Keep package-manager and app-managed update ownership separate.
 - Do not install a privileged helper for the X11 contract.
+- Rebuild the proposals in [#28](https://github.com/anomalyco/hex/pull/28) and
+  [#29](https://github.com/anomalyco/hex/pull/29) with regression coverage for
+  input state, GTK ownership, helper I/O, settings restart, and Nix environments.

--- a/docs/releases/2.1.0.md
+++ b/docs/releases/2.1.0.md
@@ -30,4 +30,16 @@ there is no automatic migration or preference import.
   beam and glow.
 - The development installer refuses to replace another app with the same name.
 
-Intel Macs and Macs running macOS 14 remain on HEX 0.8.4.
+Older Macs can continue using the legacy Swift app.
+
+### Linux Beta
+
+- Add native Wayland dictation on compatible wlroots compositors, with explicit
+  input-device permissions and a click-through recording/processing indicator
+  ([#28](https://github.com/anomalyco/hex/pull/28)).
+- Keep shortcut changes, cancellation, keyboard reconnects, and tray-less
+  listener recovery manageable from Settings
+  ([#26](https://github.com/anomalyco/hex/issues/26)).
+- Add Nix packaging and a matching development shell, plus optional per-user
+  Home Manager autostart. Nix installations leave updates to Nix
+  ([#29](https://github.com/anomalyco/hex/pull/29)).

--- a/docs/releases/linux-wayland-beta.md
+++ b/docs/releases/linux-wayland-beta.md
@@ -7,6 +7,7 @@ release gates; passing container tests alone does not establish those behaviors.
   input-device permissions and a click-through recording/processing indicator.
 - Keep shortcut changes, cancellation, keyboard reconnects, and tray-less
   listener recovery manageable from Settings.
+- Cancelling a new capture keeps older pending transcription visible in Settings.
 - Add Nix packaging and a matching development shell, plus optional per-user
   Home Manager autostart. Nix installations leave updates to Nix.
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787797243,
+        "narHash": "sha256-8+Q7NOB7RPajRjA4pbCDLzqH+MTjnG9x6LUPLfL2joA=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "HEX local-first voice dictation";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { self, nixpkgs, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      hex = pkgs.callPackage ./nix/package.nix { };
+    in
+    {
+      packages.${system} = {
+        inherit hex;
+        default = hex;
+      };
+
+      overlays.default = final: _prev: {
+        hex = final.callPackage ./nix/package.nix { };
+      };
+
+      nixosModules.hex = {
+        imports = [ ./nix/module.nix ];
+        programs.hex.package = nixpkgs.lib.mkDefault hex;
+      };
+      nixosModules.default = self.nixosModules.hex;
+
+      homeManagerModules.hex = {
+        imports = [ ./nix/hm-module.nix ];
+        programs.hex.package = nixpkgs.lib.mkDefault hex;
+      };
+      homeManagerModules.default = self.homeManagerModules.hex;
+
+      devShells.${system}.default = hex.devShell;
+      checks.${system} = import ./nix/checks.nix { inherit self pkgs; };
+      formatter.${system} = pkgs.nixfmt;
+    };
+}

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,0 +1,132 @@
+{ self, pkgs }:
+let
+  inherit (pkgs) lib;
+  hex = self.packages.${pkgs.stdenv.hostPlatform.system}.hex;
+  shell = self.devShells.${pkgs.stdenv.hostPlatform.system}.default;
+  home =
+    settings:
+    (self.inputs.home-manager.lib.homeManagerConfiguration {
+      inherit pkgs;
+      modules = [
+        self.homeManagerModules.hex
+        {
+          home.username = "hex-test";
+          home.homeDirectory = "/home/hex-test";
+          home.stateVersion = "26.05";
+          programs.hex = settings;
+        }
+      ];
+    }).config;
+  enabled = home {
+    enable = true;
+    autostart = true;
+  };
+  manual = home { enable = true; };
+  disabled = home { enable = false; };
+  custom = home {
+    enable = true;
+    autostart = true;
+    package = pkgs.hello;
+    systemdTarget = "sway-session.target";
+  };
+  system =
+    (self.inputs.nixpkgs.lib.nixosSystem {
+      system = pkgs.stdenv.hostPlatform.system;
+      modules = [
+        self.nixosModules.hex
+        {
+          programs.hex.enable = true;
+          system.stateVersion = "26.05";
+        }
+      ];
+    }).config;
+in
+{
+  package = pkgs.runCommand "hex-package-check" { } ''
+    export HOME="$TMPDIR/home"
+    mkdir -p "$HOME"
+    ${lib.getExe hex} --version
+    ${lib.getExe hex} model status | grep '^missing[[:space:]]'
+    touch "$out"
+  '';
+
+  shell-environment =
+    assert lib.all (name: shell.${name} == hex.${name}) [
+      "BLA_VENDOR"
+      "OPENSSL_NO_VENDOR"
+    ];
+    # OpenBLAS ordering belongs to build.rs, not an injected Nix-only workaround.
+    assert !(hex ? RUSTFLAGS) && !(shell ? RUSTFLAGS);
+    assert lib.all
+      (package: builtins.elem "${lib.getLib package}/lib" (lib.splitString ":" shell.LD_LIBRARY_PATH))
+      [
+        pkgs.vulkan-loader
+        pkgs.libayatana-appindicator
+        pkgs.gtk-layer-shell
+        pkgs.wayland
+        pkgs.libxkbcommon
+      ];
+    assert lib.all (package: builtins.elem (lib.getDev package) shell.nativeBuildInputs) [
+      pkgs.curl
+      pkgs.wl-clipboard
+      pkgs.wtype
+    ];
+    pkgs.runCommand "hex-shell-environment-check" { } ''
+      test -d ${shell.ALSA_PLUGIN_DIR}
+      touch "$out"
+    '';
+
+  modules =
+    assert builtins.elem hex system.environment.systemPackages;
+    assert builtins.elem hex enabled.home.packages;
+    assert !(builtins.elem hex disabled.home.packages);
+    assert !(manual.systemd.user.services ? hex);
+    assert !(disabled.systemd.user.services ? hex);
+    assert enabled.systemd.user.services.hex.Service.ExecStart == [ "${lib.getExe hex} app --hidden" ];
+    assert enabled.systemd.user.services.hex.Service.Restart == "on-failure";
+    assert
+      custom.systemd.user.services.hex.Service.ExecStart == [ "${lib.getExe pkgs.hello} app --hidden" ];
+    assert lib.all (name: custom.systemd.user.services.hex.Unit.${name} == [ "sway-session.target" ]) [
+      "After"
+      "Requisite"
+      "PartOf"
+    ];
+    assert custom.systemd.user.services.hex.Install.WantedBy == [ "sway-session.target" ];
+    pkgs.runCommand "hex-module-check" { } ''
+      bash -n ${enabled.systemd.user.services.hex.Service.ExecStartPre}
+      touch "$out"
+    '';
+
+  session-readiness =
+    let
+      xprop = pkgs.writeShellScriptBin "xprop" ''
+        printf '%s\n' "''${HEX_TEST_XPROP:-}"
+      '';
+      sleep = pkgs.writeShellScriptBin "sleep" "exit 0";
+    in
+    pkgs.runCommand "hex-session-readiness-check" { } ''
+      run() {
+        env -i PATH=${
+          lib.makeBinPath [
+            xprop
+            sleep
+            pkgs.gnugrep
+          ]
+        } "$@" \
+          ${pkgs.bash}/bin/bash -euo pipefail ${./wait-for-session.sh}
+      }
+
+      if run; then exit 1; fi
+      if run DISPLAY=:1 HEX_TEST_XPROP='_NET_SUPPORTING_WM_CHECK: not found.'; then exit 1; fi
+      if run DISPLAY=:1 HEX_TEST_XPROP='_NET_SUPPORTING_WM_CHECK(WINDOW): window id # 0x0'; then exit 1; fi
+      run DISPLAY=:1 HEX_TEST_XPROP='_NET_SUPPORTING_WM_CHECK(WINDOW): window id # 0xa00001'
+
+      if run WAYLAND_DISPLAY=wayland-test XDG_RUNTIME_DIR="$TMPDIR"; then exit 1; fi
+      ${pkgs.python3}/bin/python -c \
+        'import socket, sys; sock = socket.socket(socket.AF_UNIX); sock.bind(sys.argv[1])' \
+        "$TMPDIR/wayland-test"
+      run WAYLAND_DISPLAY=wayland-test XDG_RUNTIME_DIR="$TMPDIR"
+      run WAYLAND_DISPLAY="$TMPDIR/wayland-test"
+      touch "$out"
+    '';
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.hex;
+  waitForSession = pkgs.writeShellApplication {
+    name = "hex-wait-for-session";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.gnugrep
+      pkgs.xprop
+    ];
+    text = builtins.readFile ./wait-for-session.sh;
+  };
+in
+{
+  options.programs.hex = {
+    enable = lib.mkEnableOption "HEX local voice dictation";
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "HEX package to install.";
+    };
+    autostart = lib.mkEnableOption "HEX startup with the graphical session";
+    systemdTarget = lib.mkOption {
+      type = lib.types.str;
+      default = "graphical-session.target";
+      example = "sway-session.target";
+      description = ''
+        User target that owns the graphical session. The compositor or session
+        manager must import its display environment before starting this target,
+        and stop the target at logout. This module does not start a session.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = pkgs.stdenv.hostPlatform.system == "x86_64-linux";
+        message = "The HEX Nix package supports x86_64-linux only.";
+      }
+    ];
+    home.packages = [ cfg.package ];
+    systemd.user.services.hex = lib.mkIf cfg.autostart {
+      Unit = {
+        Description = "HEX local voice dictation";
+        After = [ cfg.systemdTarget ];
+        Requisite = [ cfg.systemdTarget ];
+        PartOf = [ cfg.systemdTarget ];
+      };
+      Service = {
+        ExecStartPre = lib.getExe waitForSession;
+        ExecStart = "${lib.getExe cfg.package} app --hidden";
+        TimeoutStartSec = 35;
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+      Install.WantedBy = [ cfg.systemdTarget ];
+    };
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,28 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.hex;
+in
+{
+  options.programs.hex = {
+    enable = lib.mkEnableOption "HEX local voice dictation";
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "HEX package to install.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = pkgs.stdenv.hostPlatform.system == "x86_64-linux";
+        message = "The HEX Nix package supports x86_64-linux only.";
+      }
+    ];
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,165 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  cmake,
+  python3,
+  shaderc,
+  vulkan-headers,
+  vulkan-loader,
+  spirv-headers,
+  openblas,
+  gtk3,
+  gtk-layer-shell,
+  libayatana-appindicator,
+  alsa-lib,
+  alsa-plugins,
+  pipewire,
+  openssl,
+  libxkbcommon,
+  wayland,
+  fontconfig,
+  freetype,
+  curl,
+  wl-clipboard,
+  wtype,
+  wrapGAppsHook3,
+  autoAddDriverRunpath,
+  symlinkJoin,
+  libx11,
+  libxcb,
+  libxcursor,
+  libxrandr,
+  libxi,
+  mkShell,
+  rust-analyzer,
+  rustfmt,
+  clippy,
+}:
+
+let
+  buildEnv = {
+    OPENSSL_NO_VENDOR = "1";
+    BLA_VENDOR = "OpenBLAS";
+  };
+  runtimeEnv = {
+    LD_LIBRARY_PATH = lib.makeLibraryPath [
+      vulkan-loader
+      libayatana-appindicator
+      gtk-layer-shell
+      openblas
+      alsa-lib
+      wayland
+      libxkbcommon
+      fontconfig
+    ];
+    ALSA_PLUGIN_DIR = symlinkJoin {
+      name = "hex-alsa-plugins";
+      paths = [
+        "${pipewire}/lib/alsa-lib"
+        "${alsa-plugins}/lib/alsa-lib"
+      ];
+    };
+  };
+  runtimePackages = [
+    curl
+    wl-clipboard
+    wtype
+  ];
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hex";
+  version = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).package.version;
+
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../Cargo.toml
+      ../Cargo.lock
+      ../build.rs
+      ../src
+      ../native
+      ../resources
+      ../assets
+      ../packaging
+    ];
+  };
+
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+    outputHashes = {
+      "transcribe-rs-0.3.11" = "sha256-MJJiug3LfbKsuHcL2+LJk95+j5kk/MWzb5ihdBlHLmE=";
+    };
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    python3
+    shaderc
+    wrapGAppsHook3
+    autoAddDriverRunpath
+  ];
+  buildInputs = [
+    vulkan-headers
+    vulkan-loader
+    spirv-headers
+    openblas
+    gtk3
+    gtk-layer-shell
+    libayatana-appindicator
+    alsa-lib
+    openssl
+    libxkbcommon
+    wayland
+    fontconfig
+    freetype
+    libx11
+    libxcb
+    libxcursor
+    libxrandr
+    libxi
+  ];
+
+  dontUseCmakeConfigure = true;
+  env = buildEnv;
+  # Desktop and installed-model tests are #[ignore]; run the remaining suite.
+  doCheck = true;
+  preCheck = ''
+    export HOME="$TMPDIR/hex-test-home"
+    mkdir -p "$HOME"
+  '';
+
+  postInstall = ''
+    mv $out/bin/voice-control $out/bin/hex
+    install -Dm644 ${../packaging/hex.desktop} $out/share/applications/hex.desktop
+    substituteInPlace $out/share/applications/hex.desktop \
+      --replace-fail '@HEX_BIN@' "$out/bin/hex"
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath runtimePackages}
+      --prefix LD_LIBRARY_PATH : ${runtimeEnv.LD_LIBRARY_PATH}
+      --set ALSA_PLUGIN_DIR ${runtimeEnv.ALSA_PLUGIN_DIR}
+    )
+  '';
+
+  passthru.devShell = mkShell {
+    inputsFrom = [ finalAttrs.finalPackage ];
+    env = buildEnv // runtimeEnv;
+    packages = runtimePackages ++ [
+      rust-analyzer
+      rustfmt
+      clippy
+    ];
+  };
+
+  meta = {
+    description = "Local-first voice dictation (Linux beta)";
+    homepage = "https://github.com/anomalyco/hex";
+    license = lib.licenses.mit;
+    mainProgram = "hex";
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/nix/wait-for-session.sh
+++ b/nix/wait-for-session.sh
@@ -1,0 +1,21 @@
+for ((attempt = 0; attempt < 30; attempt++)); do
+  if [[ -n "${WAYLAND_DISPLAY:-}" ]]; then
+    case "$WAYLAND_DISPLAY" in
+      /*) socket="$WAYLAND_DISPLAY" ;;
+      *) socket="${XDG_RUNTIME_DIR:-/nonexistent}/$WAYLAND_DISPLAY" ;;
+    esac
+    if [[ -S "$socket" ]]; then
+      exit 0
+    fi
+  elif [[ -n "${DISPLAY:-}" ]]; then
+    # graphical-session.target can precede the window manager on NixOS/i3.
+    if xprop -root _NET_SUPPORTING_WM_CHECK 2>/dev/null |
+      grep -Eq 'window id # 0x0*[1-9a-fA-F][0-9a-fA-F]*'; then
+      exit 0
+    fi
+  fi
+  sleep 1
+done
+
+echo "HEX: no ready graphical session. Import its display environment into the systemd user manager; retrying." >&2
+exit 1

--- a/scripts/test-install-linux-release.sh
+++ b/scripts/test-install-linux-release.sh
@@ -85,6 +85,8 @@ until curl --fail --silent "http://127.0.0.1:$port/linux-update.json" >/dev/null
 done
 
 home="$temporary/home"
+export XDG_DATA_HOME="$home/.local/share"
+export XDG_CONFIG_HOME="$home/.config"
 install_dir="$home/.local/bin"
 support_dir="$home/.local/share/voice-control"
 mkdir -p "$support_dir"

--- a/scripts/test-linux-dictation.sh
+++ b/scripts/test-linux-dictation.sh
@@ -47,8 +47,9 @@ trap 'exit 143' TERM
 export HOME="$work/home" XDG_RUNTIME_DIR="$work/runtime"
 export HEX_APPLICATION_SUPPORT_DIR="$work/support"
 export PULSE_SERVER="unix:$work/pulse" PULSE_SOURCE=hex-fixture.monitor
-export GDK_BACKEND=x11 VK_ICD_FILENAMES=/nonexistent
-unset WAYLAND_DISPLAY
+# GPUI still needs software Vulkan; only inference uses the CPU in this fixture.
+export GDK_BACKEND=x11 GGML_VK_VISIBLE_DEVICES=""
+unset WAYLAND_DISPLAY VK_ICD_FILENAMES
 mkdir -m 700 "$HOME" "$XDG_RUNTIME_DIR" "$HEX_APPLICATION_SUPPORT_DIR"
 mkdir "$HEX_APPLICATION_SUPPORT_DIR/models"
 ln -s "$model" "$HEX_APPLICATION_SUPPORT_DIR/models/$(basename "$model")"
@@ -68,7 +69,7 @@ cc "$root/tests/fixtures/wayland-paste-target.c" $(pkg-config --cflags --libs gt
 target=$!
 window=$(xdotool search --sync --name '^Hex Wayland Test$' | head -n 1)
 xdotool windowfocus --sync "$window"
-"$binary" dictate >"$work/listener.log" 2>&1 &
+"$binary" app --hidden >"$work/listener.log" 2>&1 &
 listener=$!
 echo 'Waiting for the model and virtual microphone...'
 for ((attempt = 0; attempt < 1200; attempt++)); do
@@ -77,6 +78,8 @@ for ((attempt = 0; attempt < 1200; attempt++)); do
   sleep 0.05
 done
 grep -q 'HEX dictation is ready' "$work/listener.log"
+xdotool search --onlyvisible --name '^HEX$' >/dev/null
+xdotool windowfocus --sync "$window"
 echo 'Replaying speech through the held dictation shortcut...'
 xdotool keydown Alt_L keydown space
 sleep 0.5

--- a/scripts/test-linux-dictation.sh
+++ b/scripts/test-linux-dictation.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${1:-} != --inside ]]; then
+  if [[ $# != 3 || $(id -u) == 0 ]]; then
+    echo "Usage: $0 /path/to/voice-control /path/to/model.gguf /path/to/jfk.wav (non-root)" >&2
+    exit 1
+  fi
+  for command in cc pkg-config pulseaudio pactl paplay xdotool xvfb-run timeout; do
+    command -v "$command" >/dev/null
+  done
+  exec timeout 180 xvfb-run -a --server-args="-screen 0 1280x900x24 -noreset" \
+    "$0" --inside "$(realpath "$1")" "$(realpath "$2")" "$(realpath "$3")"
+fi
+shift
+binary=$1
+model=$2
+audio=$3
+root=$(cd -- "$(dirname -- "$0")/.." && pwd)
+work=$(mktemp -d)
+listener=
+target=
+pulse=
+finish() {
+  status=$?
+  trap - EXIT
+  for pid in "$listener" "$target" "$pulse"; do
+    if [[ -n "$pid" ]]; then kill "$pid" 2>/dev/null || true; fi
+  done
+  if [[ $status != 0 ]]; then
+    for log in "$work"/*.log "$work"/support/logs/live.ndjson; do
+      if [[ -f "$log" ]]; then printf '\n%s\n' "$log"; cat "$log"; fi
+    done
+  fi
+  rm -rf -- "$work"
+  exit "$status"
+}
+trap finish EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+export HOME="$work/home" XDG_RUNTIME_DIR="$work/runtime"
+export HEX_APPLICATION_SUPPORT_DIR="$work/support"
+export PULSE_SERVER="unix:$work/pulse" PULSE_SOURCE=hex-fixture.monitor
+export GDK_BACKEND=x11 VK_ICD_FILENAMES=/nonexistent
+unset WAYLAND_DISPLAY
+mkdir -m 700 "$HOME" "$XDG_RUNTIME_DIR" "$HEX_APPLICATION_SUPPORT_DIR"
+mkdir "$HEX_APPLICATION_SUPPORT_DIR/models"
+ln -s "$model" "$HEX_APPLICATION_SUPPORT_DIR/models/$(basename "$model")"
+printf 'pcm.!default { type pulse server "%s" }\n' "$PULSE_SERVER" > "$HOME/.asoundrc"
+pulseaudio -n --daemonize=no --use-pid-file=no --exit-idle-time=-1 \
+  --load="module-native-protocol-unix socket=$work/pulse auth-anonymous=1" \
+  --load='module-null-sink sink_name=hex-fixture rate=16000 channels=1' \
+  >"$work/pulse.log" 2>&1 &
+pulse=$!
+for ((attempt = 0; attempt < 100; attempt++)); do
+  if pactl info >/dev/null 2>&1; then break; fi
+  sleep 0.05
+done
+pactl info >/dev/null
+cc "$root/tests/fixtures/wayland-paste-target.c" $(pkg-config --cflags --libs gtk+-3.0) -o "$work/target"
+"$work/target" "$work/pasted.txt" >"$work/target.log" 2>&1 &
+target=$!
+window=$(xdotool search --sync --name '^Hex Wayland Test$' | head -n 1)
+xdotool windowfocus --sync "$window"
+"$binary" dictate >"$work/listener.log" 2>&1 &
+listener=$!
+echo 'Waiting for the model and virtual microphone...'
+for ((attempt = 0; attempt < 1200; attempt++)); do
+  kill -0 "$listener"
+  if grep -q 'HEX dictation is ready' "$work/listener.log"; then break; fi
+  sleep 0.05
+done
+grep -q 'HEX dictation is ready' "$work/listener.log"
+echo 'Replaying speech through the held dictation shortcut...'
+xdotool keydown Alt_L keydown space
+sleep 0.5
+paplay --device=hex-fixture "$audio"
+sleep 0.5
+xdotool keyup space keyup Alt_L
+echo 'Waiting for transcribed text in the focused GTK target...'
+for ((attempt = 0; attempt < 1800; attempt++)); do
+  kill -0 "$listener"
+  if [[ -s "$work/pasted.txt" ]]; then break; fi
+  sleep 0.05
+done
+grep -qi 'ask not what your country can do for you' "$work/pasted.txt"
+grep -qi 'ask what you can do for your country' "$work/pasted.txt"
+printf 'Captured, transcribed, and pasted: %s\n' "$(<"$work/pasted.txt")"
+kill -TERM "$listener"
+wait "$listener"
+listener=
+test -z "$(pactl list short source-outputs)"
+echo 'Linux virtual-microphone dictation and orderly shutdown passed.'

--- a/scripts/test-linux-dictation.sh
+++ b/scripts/test-linux-dictation.sh
@@ -9,7 +9,7 @@ if [[ ${1:-} != --inside ]]; then
   for command in cc pkg-config pulseaudio pactl paplay xdotool xvfb-run timeout; do
     command -v "$command" >/dev/null
   done
-  exec timeout 180 xvfb-run -a --server-args="-screen 0 1280x900x24 -noreset" \
+  exec timeout --kill-after=10 180 xvfb-run -a --server-args="-screen 0 1280x900x24 -noreset" \
     "$0" --inside "$(realpath "$1")" "$(realpath "$2")" "$(realpath "$3")"
 fi
 shift
@@ -23,10 +23,16 @@ target=
 pulse=
 finish() {
   status=$?
-  trap - EXIT
+  trap - EXIT INT TERM
   for pid in "$listener" "$target" "$pulse"; do
     if [[ -n "$pid" ]]; then kill "$pid" 2>/dev/null || true; fi
   done
+  for ((attempt = 0; attempt < 100; attempt++)); do
+    if [[ -z $(jobs -pr) ]]; then break; fi
+    sleep 0.05
+  done
+  for pid in $(jobs -pr); do kill -KILL "$pid" 2>/dev/null || true; done
+  wait 2>/dev/null || true
   if [[ $status != 0 ]]; then
     for log in "$work"/*.log "$work"/support/logs/live.ndjson; do
       if [[ -f "$log" ]]; then printf '\n%s\n' "$log"; cat "$log"; fi
@@ -89,5 +95,6 @@ printf 'Captured, transcribed, and pasted: %s\n' "$(<"$work/pasted.txt")"
 kill -TERM "$listener"
 wait "$listener"
 listener=
-test -z "$(pactl list short source-outputs)"
+outputs=$(pactl list short source-outputs)
+test -z "$outputs"
 echo 'Linux virtual-microphone dictation and orderly shutdown passed.'

--- a/scripts/test-wayland-paste.sh
+++ b/scripts/test-wayland-paste.sh
@@ -54,6 +54,30 @@ if [[ "${1:-}" == --inside ]]; then
     sleep 0.05
   done
   swaymsg -t get_tree -r | grep '"name": "HEX"' >/dev/null
+
+  # Keep GPUI connected while the paste helper creates a virtual keyboard.
+  export HEX_WAYLAND_PASTE_OUTPUT="$HEX_WAYLAND_PASTE_OUTPUT-coexist"
+  "$HEX_WAYLAND_TEST_TARGET" "$HEX_WAYLAND_PASTE_OUTPUT" &
+  target=$!
+  for ((attempt = 0; attempt < 100; attempt++)); do
+    if swaymsg -t get_tree -r | grep '"name": "Hex Wayland Test"' >/dev/null; then break; fi
+    sleep 0.05
+  done
+  swaymsg -t get_tree -r | grep '"name": "Hex Wayland Test"' >/dev/null
+  wtype -p v -p VoidSymbol -s 60000 &
+  keyboard=$!
+  for ((attempt = 0; attempt < 100; attempt++)); do
+    if [[ -f "$HEX_WAYLAND_PASTE_OUTPUT.ready" ]]; then break; fi
+    sleep 0.05
+  done
+  test -f "$HEX_WAYLAND_PASTE_OUTPUT.ready"
+  "$HEX_WAYLAND_TEST_BINARY" --exact linux_paste::tests::native_wayland_clipboard_shortcut \
+    --ignored --nocapture --test-threads=1
+  kill -0 "$app"
+  kill "$target"
+  wait "$target" 2>/dev/null || true
+  target=
+
   swaymsg '[app_id="hex"] kill' >/dev/null
   wait "$app"
   app=

--- a/scripts/test-wayland-paste.sh
+++ b/scripts/test-wayland-paste.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == --inside ]]; then
+  target=
+  keyboard=
+  app=
+  finish() {
+    status=$?
+    trap - EXIT
+    if [[ -n "$target" ]]; then kill "$target" 2>/dev/null || true; fi
+    if [[ -n "$keyboard" ]]; then kill "$keyboard" 2>/dev/null || true; fi
+    if [[ -n "$app" ]]; then kill "$app" 2>/dev/null || true; fi
+    printf '%s\n' "$status" > "$HEX_WAYLAND_TEST_RESULT"
+    swaymsg exit >/dev/null 2>&1 || true
+    exit "$status"
+  }
+  trap finish EXIT
+
+  # Seed the isolated compositor's keyboard state before any window exists.
+  wtype -k v -p VoidSymbol -s 60000 &
+  keyboard=$!
+  for ((attempt = 0; attempt < 100; attempt++)); do
+    if swaymsg -t get_inputs -r | grep -q wlr_virtual_keyboard; then break; fi
+    sleep 0.05
+  done
+  "$HEX_WAYLAND_TEST_TARGET" "$HEX_WAYLAND_PASTE_OUTPUT" &
+  target=$!
+  for ((attempt = 0; attempt < 100; attempt++)); do
+    if [[ -f "$HEX_WAYLAND_PASTE_OUTPUT.ready" ]]; then break; fi
+    sleep 0.05
+  done
+  test -f "$HEX_WAYLAND_PASTE_OUTPUT.ready"
+  "$HEX_WAYLAND_TEST_BINARY" --exact linux_paste::tests::native_wayland_clipboard_shortcut \
+    --ignored --nocapture --test-threads=1
+  kill "$target"
+  wait "$target" 2>/dev/null || true
+  target=
+
+  # The app-window check uses compositor IPC, not keyboard input. Remove the
+  # synthetic seat first rather than expose a transient, keymap-less keyboard.
+  kill "$keyboard"
+  wait "$keyboard" 2>/dev/null || true
+  keyboard=
+  for ((attempt = 0; attempt < 100; attempt++)); do
+    if ! swaymsg -t get_inputs -r | grep wlr_virtual_keyboard >/dev/null; then break; fi
+    sleep 0.05
+  done
+  "$HEX_WAYLAND_APP_BINARY" app --hidden >"$HEX_WAYLAND_APP_LOG" 2>&1 &
+  app=$!
+  for ((attempt = 0; attempt < 200; attempt++)); do
+    kill -0 "$app"
+    if swaymsg -t get_tree -r | grep '"name": "HEX"' >/dev/null; then break; fi
+    sleep 0.05
+  done
+  swaymsg -t get_tree -r | grep '"name": "HEX"' >/dev/null
+  swaymsg '[app_id="hex"] kill' >/dev/null
+  wait "$app"
+  app=
+  exit 0
+fi
+
+if [[ $# != 2 || $(id -u) == 0 ]]; then
+  echo "Usage: $0 /path/to/compiled-test /path/to/voice-control (run as an unprivileged user)" >&2
+  exit 1
+fi
+for command in cc pkg-config sway swaymsg wtype wl-copy dbus-run-session timeout; do
+  command -v "$command" >/dev/null
+done
+root=$(cd -- "$(dirname -- "$0")/.." && pwd)
+work=$(mktemp -d)
+trap 'rm -rf -- "$work"' EXIT
+export HEX_WAYLAND_TEST_BINARY
+HEX_WAYLAND_TEST_BINARY=$(realpath -- "$1")
+export HEX_WAYLAND_APP_BINARY
+HEX_WAYLAND_APP_BINARY=$(realpath -- "$2")
+export HEX_WAYLAND_TEST_SCRIPT="$root/scripts/test-wayland-paste.sh"
+export HEX_WAYLAND_TEST_TARGET="$work/target"
+export HEX_WAYLAND_PASTE_OUTPUT="$work/pasted.txt"
+export HEX_WAYLAND_TEST_RESULT="$work/result"
+export HEX_WAYLAND_APP_LOG="$work/hex.log"
+export XDG_RUNTIME_DIR="$work/runtime"
+export XDG_DATA_HOME="$work/data"
+mkdir -m 700 "$XDG_RUNTIME_DIR"
+cc "$root/tests/fixtures/wayland-paste-target.c" $(pkg-config --cflags --libs gtk+-3.0) -o "$HEX_WAYLAND_TEST_TARGET"
+unset DISPLAY WAYLAND_DISPLAY SWAYSOCK
+export WLR_BACKENDS=headless WLR_RENDERER=pixman WLR_LIBINPUT_NO_DEVICES=1 GDK_BACKEND=wayland
+if ! timeout 25 dbus-run-session -- sway --config "$root/tests/fixtures/wayland-paste.conf" >"$work/compositor.log" 2>&1 \
+  || [[ ! -f "$work/result" || $(<"$work/result") != 0 ]]; then
+  cat "$work/compositor.log"
+  if [[ -f "$work/hex.log" ]]; then cat "$work/hex.log"; fi
+  exit 1
+fi
+echo "Native Wayland clipboard insertion and tray-less app checks passed."

--- a/src/desktop_activity.rs
+++ b/src/desktop_activity.rs
@@ -1,4 +1,4 @@
-use crate::events::{EventReader, TranscriptPhase, VoiceEvent, VoiceState};
+use crate::events::{DictationPhase, EventReader, TranscriptPhase, VoiceEvent, VoiceState};
 
 const TRANSCRIPT_LIMIT: usize = 8;
 
@@ -9,6 +9,7 @@ pub(crate) struct DesktopActivity {
     pub(crate) device: Option<String>,
     pub(crate) transcripts: Vec<String>,
     pub(crate) error: Option<String>,
+    pub(crate) last_failure: Option<(u64, String)>,
 }
 
 impl DesktopActivity {
@@ -49,6 +50,13 @@ impl DesktopActivity {
                     ..
                 } if activity.transcripts.len() < TRANSCRIPT_LIMIT && !text.trim().is_empty() => {
                     activity.transcripts.push(text.clone());
+                }
+                VoiceEvent::Dictation {
+                    timestamp_ms,
+                    phase: DictationPhase::Failed(message),
+                    ..
+                } if activity.last_failure.is_none() => {
+                    activity.last_failure = Some((*timestamp_ms, message.clone()));
                 }
                 _ => {}
             }
@@ -131,5 +139,34 @@ mod tests {
         let activity = DesktopActivity::from_events(events.iter().rev());
 
         assert_eq!(activity.transcripts, ["Current session"]);
+    }
+
+    #[test]
+    fn projects_the_latest_failure_only_from_the_current_session() {
+        let mut events = vec![
+            VoiceEvent::SessionStarted { timestamp_ms: 1 },
+            VoiceEvent::Dictation {
+                timestamp_ms: 2,
+                phase: DictationPhase::Failed("first".into()),
+                text: String::new(),
+                processing: None,
+            },
+            VoiceEvent::Dictation {
+                timestamp_ms: 3,
+                phase: DictationPhase::Failed("second".into()),
+                text: String::new(),
+                processing: None,
+            },
+        ];
+        assert_eq!(
+            DesktopActivity::from_events(events.iter().rev()).last_failure,
+            Some((3, "second".into()))
+        );
+        events.push(VoiceEvent::SessionStarted { timestamp_ms: 4 });
+        assert!(
+            DesktopActivity::from_events(events.iter().rev())
+                .last_failure
+                .is_none()
+        );
     }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -22,9 +22,9 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    /// Open the Linux X11 transcription shell.
+    /// Open the Linux transcription shell.
     App {
-        /// Start with only the tray icon visible.
+        /// Start hidden when a working system tray is available.
         #[arg(long)]
         hidden: bool,
     },
@@ -34,7 +34,7 @@ enum Command {
         #[arg(long)]
         device: Option<String>,
     },
-    /// Run X11 hotkey dictation and automatic paste until interrupted.
+    /// Run X11 or Wayland hotkey dictation and automatic paste until interrupted.
     Dictate {
         /// Select an input device by a case-insensitive name fragment.
         #[arg(long)]
@@ -70,6 +70,14 @@ enum ModelCommand {
 }
 
 pub fn run(shutdown: &'static AtomicBool) -> Result<()> {
+    // This is the Linux entry point, before signal handlers or any worker threads.
+    // GTK and GPUI must connect to the same display backend.
+    unsafe {
+        std::env::set_var(
+            "GDK_BACKEND",
+            crate::linux_session::LinuxSession::detect().as_str(),
+        );
+    }
     color_eyre::install()?;
     let log_dir = crate::app_paths::logs_dir()?;
     fs::create_dir_all(&log_dir)?;
@@ -87,11 +95,11 @@ pub fn run(shutdown: &'static AtomicBool) -> Result<()> {
 
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let event_path = log_dir.join("live.ndjson");
-    match Cli::parse()
+    let result = (|| match Cli::parse()
         .command
         .unwrap_or(Command::App { hidden: false })
     {
-        Command::App { hidden } => crate::linux_app::open(event_path, hidden),
+        Command::App { hidden } => crate::linux_app::open(event_path, hidden, shutdown),
         Command::Listen { device } => {
             let _instance = crate::instance::acquire("listener")?;
             listen(&root, &event_path, device.as_deref(), shutdown)
@@ -142,7 +150,9 @@ pub fn run(shutdown: &'static AtomicBool) -> Result<()> {
                 Ok(())
             }
         },
-    }
+    })();
+    crate::linux_desktop::shutdown();
+    result
 }
 
 pub(crate) fn listen(

--- a/src/linux_app.rs
+++ b/src/linux_app.rs
@@ -1,4 +1,6 @@
+use std::cell::Cell;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::sync::{Arc, Mutex};
@@ -7,11 +9,9 @@ use std::time::{Duration, Instant};
 
 use color_eyre::Result;
 use gpui::{
-    AnyElement, App, Application, Bounds, Context, Keystroke, Timer, TitlebarOptions, Window,
-    WindowBounds, WindowKind, WindowOptions, div, prelude::*, px, rgb, size,
+    AnyElement, App, Application, Bounds, Context, Keystroke, Timer, Window, WindowBounds,
+    WindowKind, WindowOptions, div, prelude::*, px, rgb, size,
 };
-use tray_icon::menu::{Menu, MenuEvent, MenuItem};
-use tray_icon::{Icon, MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::ConnectionExt;
 
@@ -27,10 +27,12 @@ use crate::desktop_transcription_picker::{
 };
 use crate::desktop_ui::{
     LINE, MUTED, NavigationIcon, SIDEBAR_WIDTH, SURFACE, TEXT_SOFT, compact_button,
-    disclosure_button, hotkey_keycaps, navigation_item, pane_header, settings_panel, settings_row,
-    settings_section_label, sidebar_frame, toggle, window_frame,
+    disclosure_button, hotkey_keycaps, navigation_item, pane_body, pane_content, pane_header,
+    settings_panel, settings_row, settings_section_label, sidebar_frame, toggle, window_frame,
 };
 use crate::events::EventReader;
+use crate::linux_desktop::TrayCommand;
+use crate::linux_session::LinuxSession;
 use crate::linux_updater::InstalledUpdate;
 
 const WINDOW_WIDTH: f32 = 1040.0;
@@ -56,29 +58,19 @@ struct TranscriptionPreparation {
     worker: Option<JoinHandle<()>>,
 }
 
-#[derive(Clone, Copy)]
-enum TrayCommand {
-    Show,
-    ToggleListening,
-    Quit,
+enum SettingsChange {
+    Capture,
+    Hotkey(crate::linux_settings::LinuxHotkey),
+    DoubleTap(bool),
+    PasteWithShift(bool),
 }
 
-struct TrayRuntime {
-    worker: Mutex<Option<JoinHandle<()>>>,
-}
-
-impl TrayRuntime {
-    fn shutdown(&self) {
-        if let Some(worker) = self
-            .worker
-            .lock()
-            .unwrap_or_else(|error| error.into_inner())
-            .take()
-        {
-            gtk::glib::MainContext::default().invoke(gtk::main_quit);
-            let _ = worker.join();
-        }
-    }
+struct SettingsEdit {
+    change: Option<SettingsChange>,
+    capturing: bool,
+    resume: bool,
+    canceled: Arc<AtomicBool>,
+    worker: Option<JoinHandle<Result<crate::linux_settings::LinuxSettings>>>,
 }
 
 struct LinuxDesktopHost {
@@ -93,8 +85,10 @@ struct LinuxDesktopHost {
     listen_when_ready: bool,
     status: String,
     error: Option<String>,
+    dismissed_failure_at: Option<u64>,
     settings_error: Option<String>,
     settings: crate::linux_settings::LinuxSettings,
+    settings_edit: Option<SettingsEdit>,
     prepared_transcriber: Option<crate::linux_transcriber::LinuxTranscriber>,
     transcription_preparation: Option<TranscriptionPreparation>,
     transcription_error: Option<String>,
@@ -103,7 +97,8 @@ struct LinuxDesktopHost {
 
 struct LinuxApp {
     host: LinuxDesktopHost,
-    capturing_hotkey: bool,
+    quitting: bool,
+    restart_requested: bool,
     transcription_picker: TranscriptionPickerState,
 }
 
@@ -130,18 +125,20 @@ enum UpdateState {
     Ready(InstalledUpdate),
 }
 
-pub fn open(event_path: PathBuf, start_hidden: bool) -> Result<()> {
+pub fn open(event_path: PathBuf, start_hidden: bool, shutdown: &'static AtomicBool) -> Result<()> {
     let listener_stop = Arc::new(Mutex::new(None));
     let quit_stop = listener_stop.clone();
     let (tray_sender, tray_commands) = mpsc::channel();
-    let tray = match spawn_tray(tray_sender) {
-        Ok(tray) => Some(tray),
-        Err(error) => {
-            tracing::warn!(%error, "system tray is unavailable; closing HEX will quit");
-            None
-        }
-    };
-    let close_to_tray = tray.is_some();
+    let session = LinuxSession::detect();
+    // GPUI cannot hide/reopen a native Wayland toplevel. Keep it manageable without a tray.
+    let close_to_tray = !session.is_wayland()
+        && match crate::linux_desktop::start_tray(tray_sender) {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::warn!(%error, "system tray is unavailable; closing HEX will quit");
+                false
+            }
+        };
     let (settings, settings_error) = match crate::linux_settings::LinuxSettings::load() {
         Ok(settings) => (settings, None),
         Err(error) => (
@@ -162,10 +159,7 @@ pub fn open(event_path: PathBuf, start_hidden: bool) -> Result<()> {
                     window_bounds: Some(WindowBounds::Windowed(bounds)),
                     window_min_size: Some(size(px(MINIMUM_WIDTH), px(MINIMUM_HEIGHT))),
                     kind: WindowKind::Floating,
-                    titlebar: Some(TitlebarOptions {
-                        title: Some("HEX".into()),
-                        ..Default::default()
-                    }),
+                    app_id: Some("hex".into()),
                     ..Default::default()
                 },
                 |_, cx| {
@@ -177,14 +171,16 @@ pub fn open(event_path: PathBuf, start_hidden: bool) -> Result<()> {
                             settings_error.clone(),
                             update,
                         ),
-                        capturing_hotkey: false,
+                        quitting: false,
+                        restart_requested: false,
                         transcription_picker: TranscriptionPickerState::Closed,
                     })
                 },
             )
-            .expect("could not open the HEX X11 window");
+            .expect("could not open the HEX window");
         let app = window.update(cx, |_, _, cx| cx.entity()).unwrap();
-        let x11_window = find_hex_window().ok();
+        let quit_app = app.downgrade();
+        let x11_window = Rc::new(Cell::new(None));
         app.update(cx, |app, cx| {
             let _ = app.host.dispatch(DesktopAction::StartListening);
             cx.notify();
@@ -199,14 +195,22 @@ pub fn open(event_path: PathBuf, start_hidden: bool) -> Result<()> {
         })
         .detach();
         let tray_window = window;
+        let tray_x11_window = x11_window.clone();
         cx.spawn(async move |cx| {
+            let mut had_tray = close_to_tray;
             loop {
                 Timer::after(Duration::from_millis(250)).await;
+                let has_tray = close_to_tray && crate::linux_desktop::tray_available();
+                if had_tray && !has_tray && !session.is_wayland() {
+                    let _ = set_x11_window_mapped(&tray_x11_window, true);
+                    let _ = tray_window.update(cx, |_, window, _| window.activate_window());
+                }
+                had_tray = has_tray;
                 while let Ok(command) = tray_commands.try_recv() {
                     match command {
                         TrayCommand::Show => {
-                            if let Some(window) = x11_window {
-                                set_x11_window_mapped(window, true);
+                            if !session.is_wayland() {
+                                let _ = set_x11_window_mapped(&tray_x11_window, true);
                             }
                             let _ = tray_window.update(cx, |_, window, _| {
                                 window.activate_window();
@@ -214,14 +218,9 @@ pub fn open(event_path: PathBuf, start_hidden: bool) -> Result<()> {
                         }
                         TrayCommand::ToggleListening => {
                             let _ = tray_window.update(cx, |app, _, cx| {
-                                if app
-                                    .host
-                                    .snapshot()
-                                    .listener
-                                    .is_some_and(|listener| listener.running)
-                                {
+                                if !app.quitting && app.host.is_running() {
                                     let _ = app.host.dispatch(DesktopAction::StopListening);
-                                } else {
+                                } else if !app.quitting {
                                     let _ = app.host.dispatch(DesktopAction::StartListening);
                                 }
                                 cx.notify();
@@ -229,16 +228,31 @@ pub fn open(event_path: PathBuf, start_hidden: bool) -> Result<()> {
                         }
                         TrayCommand::Quit => {
                             let _ = tray_window.update(cx, |app, _, cx| {
-                                let _ = app.host.dispatch(DesktopAction::StopListening);
-                                cx.quit();
+                                app.request_quit();
+                                cx.notify();
                             });
-                            return;
                         }
                     }
                 }
                 if app
                     .update(cx, |this, cx| {
+                        if shutdown.load(Ordering::Relaxed) {
+                            this.request_quit();
+                        }
                         this.host.refresh();
+                        if this.quitting && !this.host.has_pending_work() {
+                            if this.restart_requested
+                                && this
+                                    .host
+                                    .dispatch(DesktopAction::RestartIntoUpdate)
+                                    .is_err()
+                            {
+                                this.restart_requested = false;
+                                this.quitting = false;
+                            } else {
+                                cx.quit();
+                            }
+                        }
                         if matches!(
                             this.transcription_picker,
                             TranscriptionPickerState::Preparing(_)
@@ -266,25 +280,37 @@ pub fn open(event_path: PathBuf, start_hidden: bool) -> Result<()> {
         .detach();
         window
             .update(cx, |_, window, cx| {
-                if close_to_tray {
-                    window.on_window_should_close(cx, move |_, _| {
-                        if let Some(window) = x11_window {
-                            set_x11_window_mapped(window, false);
-                        }
-                        false
-                    });
-                }
+                window.set_window_title("HEX");
+                let close_app = cx.entity().downgrade();
+                let close_x11_window = x11_window.clone();
+                window.on_window_should_close(cx, move |_, cx| {
+                    if close_to_tray
+                        && crate::linux_desktop::tray_available()
+                        && set_x11_window_mapped(&close_x11_window, false)
+                    {
+                        return false;
+                    }
+                    // A missing X11 handle must not swallow close and strand a microphone.
+                    if close_app
+                        .update(cx, |app, cx| {
+                            app.request_quit();
+                            cx.notify();
+                        })
+                        .is_err()
+                    {
+                        cx.quit();
+                    }
+                    false
+                });
                 window.activate_window();
             })
             .ok();
         cx.activate(true);
-        if start_hidden
-            && close_to_tray
-            && let Some(window) = x11_window
-        {
-            set_x11_window_mapped(window, false);
+        if start_hidden && close_to_tray {
+            let _ = set_x11_window_mapped(&x11_window, false);
         }
-        cx.on_app_quit(move |_| {
+        cx.on_app_quit(move |cx| {
+            let _ = quit_app.update(cx, |app, _| app.request_quit());
             if let Some(stop) = quit_stop
                 .lock()
                 .unwrap_or_else(|error| error.into_inner())
@@ -292,13 +318,12 @@ pub fn open(event_path: PathBuf, start_hidden: bool) -> Result<()> {
             {
                 stop.store(true, Ordering::Relaxed);
             }
-            if let Some(tray) = &tray {
-                tray.shutdown();
-            }
+            crate::linux_desktop::shutdown();
             async {}
         })
         .detach();
     });
+    crate::linux_desktop::shutdown();
     Ok(())
 }
 
@@ -320,6 +345,7 @@ fn find_hex_window() -> color_eyre::Result<u32> {
         )?
         .reply()?;
     let windows = clients.value32().into_iter().flatten();
+    let pid_atom = connection.intern_atom(false, b"_NET_WM_PID")?.reply()?.atom;
     let mut hex_window = None;
     for window in windows {
         let title = connection
@@ -333,7 +359,19 @@ fn find_hex_window() -> color_eyre::Result<u32> {
             )?
             .reply()?
             .value;
-        if title == b"HEX" {
+        let pid = connection
+            .get_property(
+                false,
+                window,
+                pid_atom,
+                x11rb::protocol::xproto::AtomEnum::CARDINAL,
+                0,
+                1,
+            )?
+            .reply()?;
+        if title == b"HEX"
+            && pid.value32().and_then(|mut values| values.next()) == Some(std::process::id())
+        {
             hex_window = Some(window);
             break;
         }
@@ -341,7 +379,12 @@ fn find_hex_window() -> color_eyre::Result<u32> {
     hex_window.ok_or_else(|| color_eyre::eyre::eyre!("HEX window not found"))
 }
 
-fn set_x11_window_mapped(window: u32, mapped: bool) {
+fn set_x11_window_mapped(cache: &Cell<Option<u32>>, mapped: bool) -> bool {
+    // Keep a successful lookup so an unmapped window can be reopened, but never cache
+    // failure: the WM may not have published its client list during login yet.
+    let Some(window) = cache.get().or_else(|| find_hex_window().ok()) else {
+        return false;
+    };
     let result = (|| -> color_eyre::Result<()> {
         let (connection, _) = x11rb::rust_connection::RustConnection::connect(None)?;
         if mapped {
@@ -352,82 +395,11 @@ fn set_x11_window_mapped(window: u32, mapped: bool) {
         connection.flush()?;
         Ok(())
     })();
-    if let Err(error) = result {
+    if let Err(error) = &result {
         tracing::warn!(%error, mapped, "could not change HEX window visibility");
     }
-}
-
-fn spawn_tray(commands: mpsc::Sender<TrayCommand>) -> Result<TrayRuntime> {
-    let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
-    let worker = std::thread::spawn(move || {
-        let result = (|| -> Result<()> {
-            gtk::init()?;
-            let menu = Menu::new();
-            let show = MenuItem::with_id("show", "Show HEX", true, None);
-            let toggle = MenuItem::with_id("toggle", "Start / Stop Listening", true, None);
-            let quit = MenuItem::with_id("quit", "Quit HEX", true, None);
-            menu.append(&show)?;
-            menu.append(&toggle)?;
-            menu.append(&quit)?;
-
-            let menu_commands = commands.clone();
-            MenuEvent::set_event_handler(Some(move |event: MenuEvent| {
-                let command = match event.id.as_ref() {
-                    "show" => Some(TrayCommand::Show),
-                    "toggle" => Some(TrayCommand::ToggleListening),
-                    "quit" => Some(TrayCommand::Quit),
-                    _ => None,
-                };
-                if let Some(command) = command {
-                    let _ = menu_commands.send(command);
-                }
-            }));
-            TrayIconEvent::set_event_handler(Some(move |event| {
-                if matches!(
-                    event,
-                    TrayIconEvent::Click {
-                        button: MouseButton::Left,
-                        button_state: MouseButtonState::Up,
-                        ..
-                    }
-                ) {
-                    let _ = commands.send(TrayCommand::Show);
-                }
-            }));
-
-            let _tray = TrayIconBuilder::new()
-                .with_tooltip("HEX Dictation")
-                .with_icon(tray_icon()?)
-                .with_menu(Box::new(menu))
-                .build()?;
-            let _ = ready_sender.send(Ok(()));
-            gtk::main();
-            Ok(())
-        })();
-        if let Err(error) = result {
-            let _ = ready_sender.try_send(Err(error));
-        }
-    });
-    ready_receiver
-        .recv_timeout(Duration::from_secs(2))
-        .map_err(|_| color_eyre::eyre::eyre!("timed out starting the system tray"))??;
-    Ok(TrayRuntime {
-        worker: Mutex::new(Some(worker)),
-    })
-}
-
-fn tray_icon() -> Result<Icon> {
-    const SIZE: u32 = 22;
-    let mut data = vec![0_u8; (SIZE * SIZE * 4) as usize];
-    for y in 3..19 {
-        for x in 4..18 {
-            if matches!(x, 4..=7 | 14..=17) || (9..=12).contains(&y) {
-                let index = ((y * SIZE + x) * 4) as usize;
-                data[index..index + 4].copy_from_slice(&[0xd9, 0xff, 0x68, 0xff]);
-            }
-        }
-    }
-    Ok(Icon::from_rgba(data, SIZE, SIZE)?)
+    cache.set(result.is_ok().then_some(window));
+    result.is_ok()
 }
 
 impl LinuxDesktopHost {
@@ -453,8 +425,10 @@ impl LinuxDesktopHost {
             listen_when_ready: false,
             status: "Ready".into(),
             error: None,
+            dismissed_failure_at: None,
             settings_error: error,
             settings,
+            settings_edit: None,
             prepared_transcriber: None,
             transcription_preparation: None,
             transcription_error: None,
@@ -463,6 +437,9 @@ impl LinuxDesktopHost {
     }
 
     fn start(&mut self) {
+        if self.settings_edit.is_some() {
+            return;
+        }
         self.listen_when_ready = true;
         if self.listener_result.is_some() || self.transcription_preparation.is_some() {
             return;
@@ -502,11 +479,14 @@ impl LinuxDesktopHost {
         self.session_before_start = self.activity.session_started_at;
         self.awaiting_session_start = true;
         self.status = "Starting".into();
-        self.error = None;
     }
 
     fn stop(&mut self) {
         self.listen_when_ready = false;
+        if let Some(edit) = &mut self.settings_edit {
+            edit.resume = false;
+            edit.canceled.store(true, Ordering::Release);
+        }
         if let Some(stop) = self
             .listener_stop
             .lock()
@@ -544,16 +524,22 @@ impl LinuxDesktopHost {
             };
         }
 
-        let transcription_result =
-            self.transcription_preparation
-                .as_ref()
-                .and_then(|preparation| match preparation.result.try_recv() {
-                    Ok(result) => Some(result),
-                    Err(TryRecvError::Disconnected) => {
-                        Some(Err("model preparation worker stopped unexpectedly".into()))
-                    }
-                    Err(TryRecvError::Empty) => None,
-                });
+        let transcription_result = self
+            .transcription_preparation
+            .as_ref()
+            .filter(|preparation| {
+                preparation
+                    .worker
+                    .as_ref()
+                    .is_none_or(JoinHandle::is_finished)
+            })
+            .and_then(|preparation| match preparation.result.try_recv() {
+                Ok(result) => Some(result),
+                Err(TryRecvError::Disconnected) => {
+                    Some(Err("model preparation worker stopped unexpectedly".into()))
+                }
+                Err(TryRecvError::Empty) => None,
+            });
         let mut start_listener = false;
         if let Some(result) = transcription_result {
             let mut preparation = self
@@ -597,39 +583,38 @@ impl LinuxDesktopHost {
             self.start();
         }
 
-        if let Some(receiver) = &self.listener_result {
-            match receiver.try_recv() {
-                Ok(Ok(())) => {
-                    self.status = "Ready".into();
-                    self.awaiting_session_start = false;
-                    self.listener_result = None;
-                    self.join_listener();
-                    self.listener_stop
-                        .lock()
-                        .unwrap_or_else(|error| error.into_inner())
-                        .take();
-                }
-                Ok(Err(error)) => {
-                    self.status = "Unavailable".into();
-                    self.awaiting_session_start = false;
-                    self.error = Some(error);
-                    self.listener_result = None;
-                    self.join_listener();
-                    self.listener_stop
-                        .lock()
-                        .unwrap_or_else(|error| error.into_inner())
-                        .take();
-                }
-                Err(TryRecvError::Empty) => {}
+        if self
+            .listener_worker
+            .as_ref()
+            .is_none_or(JoinHandle::is_finished)
+            && let Some(receiver) = &self.listener_result
+        {
+            let result = match receiver.try_recv() {
+                Ok(result) => Some(result),
+                Err(TryRecvError::Empty) => None,
                 Err(TryRecvError::Disconnected) => {
-                    self.status = "Unavailable".into();
-                    self.awaiting_session_start = false;
-                    self.error = Some("listener worker stopped unexpectedly".into());
-                    self.listener_result = None;
-                    self.join_listener();
+                    Some(Err("listener worker stopped unexpectedly".into()))
+                }
+            };
+            if let Some(result) = result {
+                self.awaiting_session_start = false;
+                self.listener_result = None;
+                self.join_listener();
+                self.listener_stop
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner())
+                    .take();
+                match result {
+                    Ok(()) => self.status = "Ready".into(),
+                    Err(error) => {
+                        self.status = "Unavailable".into();
+                        self.error = Some(error);
+                    }
                 }
             }
         }
+
+        self.refresh_settings_edit();
 
         self.activity.refresh(&mut self.event_reader);
         if self.awaiting_session_start
@@ -638,6 +623,7 @@ impl LinuxDesktopHost {
             self.awaiting_session_start = false;
         }
         if self.listener_result.is_some()
+            && self.listen_when_ready
             && !self.awaiting_session_start
             && let Some(status) = self.activity.state_label()
         {
@@ -650,16 +636,22 @@ impl LinuxDesktopHost {
     }
 
     fn join_listener(&mut self) {
-        if let Some(worker) = self.listener_worker.take() {
+        if self
+            .listener_worker
+            .as_ref()
+            .is_some_and(JoinHandle::is_finished)
+            && let Some(worker) = self.listener_worker.take()
+        {
             let _ = worker.join();
         }
     }
 
     fn set_dictation_hotkey(&mut self, shortcut: DesktopShortcut) -> Result<()> {
         if shortcut.function {
-            self.error = Some("The Fn modifier cannot be registered on X11".into());
+            self.error = Some("The Fn modifier cannot be registered on Linux".into());
+            self.cancel_settings_edit();
             return Err(color_eyre::eyre::eyre!(
-                "the Fn modifier cannot be registered on X11"
+                "the Fn modifier cannot be registered on Linux"
             ));
         }
         let binding = crate::linux_settings::LinuxHotkey {
@@ -673,22 +665,137 @@ impl LinuxDesktopHost {
                 shortcut.key.to_ascii_lowercase()
             },
         };
-        if let Err(error) = binding.validate().and_then(|()| {
-            crate::linux_input::X11HotkeyMonitor::start(binding.clone(), false).map(drop)
-        }) {
-            self.error = Some(format!("Could not register {}: {error:#}", binding.label()));
-            return Err(error);
+        if let Some(edit) = &mut self.settings_edit {
+            if matches!(edit.change, Some(SettingsChange::Capture)) && edit.worker.is_none() {
+                edit.change = Some(SettingsChange::Hotkey(binding));
+                edit.capturing = false;
+            }
+        } else {
+            self.begin_settings_edit(SettingsChange::Hotkey(binding));
         }
-        let mut candidate = self.settings.clone();
-        candidate.dictation_hotkey = binding;
-        if let Err(error) = candidate.save() {
-            self.error = Some(format!("Could not save shortcut: {error:#}"));
-            return Err(error);
-        }
-        self.settings = candidate;
-        self.error = None;
-        self.settings_error = None;
         Ok(())
+    }
+
+    fn begin_settings_edit(&mut self, change: SettingsChange) {
+        if self.settings_edit.is_some() {
+            return;
+        }
+        if self.transcription_preparation.is_some() {
+            self.error = Some("Wait for model preparation before editing shortcut settings".into());
+            return;
+        }
+        let resume = self.is_running() && self.listen_when_ready;
+        self.stop();
+        self.error = None;
+        self.settings_edit = Some(SettingsEdit {
+            capturing: matches!(change, SettingsChange::Capture),
+            change: Some(change),
+            resume,
+            canceled: Arc::new(AtomicBool::new(false)),
+            worker: None,
+        });
+    }
+
+    fn cancel_settings_edit(&mut self) {
+        if let Some(edit) = &self.settings_edit {
+            edit.canceled.store(true, Ordering::Release);
+        }
+    }
+
+    fn capturing_hotkey(&self) -> bool {
+        self.settings_edit
+            .as_ref()
+            .is_some_and(|edit| !edit.canceled.load(Ordering::Acquire) && edit.capturing)
+    }
+
+    fn has_pending_work(&self) -> bool {
+        self.is_running()
+            || self.settings_edit.is_some()
+            || self.transcription_preparation.is_some()
+    }
+
+    fn refresh_settings_edit(&mut self) {
+        if self.is_running() {
+            return;
+        }
+        let Some(edit) = &mut self.settings_edit else {
+            return;
+        };
+        if edit
+            .worker
+            .as_ref()
+            .is_some_and(|worker| !worker.is_finished())
+        {
+            return;
+        }
+        let canceled = edit.canceled.load(Ordering::Acquire);
+        if let Some(worker) = edit.worker.take() {
+            match worker.join() {
+                // Once persistence completed, keep the in-memory projection consistent even
+                // if Cancel raced with the final atomic save.
+                Ok(Ok(settings)) => {
+                    self.settings = settings;
+                    self.settings_error = None;
+                }
+                Ok(Err(error)) if !canceled => {
+                    self.error = Some(format!("Could not update dictation settings: {error:#}"));
+                }
+                Err(_) if !canceled => {
+                    self.error = Some("Settings worker stopped unexpectedly".into())
+                }
+                _ => {}
+            }
+        } else if !canceled {
+            let wayland = LinuxSession::detect().is_wayland();
+            if !wayland && matches!(edit.change, Some(SettingsChange::Capture)) {
+                // X11 uses focused GPUI keystrokes, never raw input-device access.
+                self.status = "Press a shortcut".into();
+                return;
+            }
+            let Some(change) = edit.change.take() else {
+                return;
+            };
+            let mut candidate = self.settings.clone();
+            let canceled = edit.canceled.clone();
+            edit.worker = Some(std::thread::spawn(move || {
+                let binding = match change {
+                    SettingsChange::Capture => {
+                        Some(crate::linux_input::capture_wayland_binding(&canceled)?)
+                    }
+                    SettingsChange::Hotkey(binding) => Some(binding),
+                    SettingsChange::DoubleTap(enabled) => {
+                        candidate.double_tap_lock = enabled;
+                        None
+                    }
+                    SettingsChange::PasteWithShift(enabled) => {
+                        candidate.paste_with_shift = enabled;
+                        None
+                    }
+                };
+                if let Some(binding) = binding {
+                    binding.validate()?;
+                    crate::linux_input::LinuxHotkeyMonitor::start(binding.clone(), false)?;
+                    candidate.dictation_hotkey = binding;
+                }
+                if canceled.load(Ordering::Acquire) {
+                    return Err(color_eyre::eyre::eyre!("Shortcut edit canceled"));
+                }
+                candidate.save()?;
+                Ok(candidate)
+            }));
+            self.status = if self.capturing_hotkey() {
+                "Press a shortcut"
+            } else {
+                "Saving settings"
+            }
+            .into();
+            return;
+        }
+        let resume = self.settings_edit.take().is_some_and(|edit| edit.resume);
+        self.status = "Ready".into();
+        if resume {
+            self.start();
+        }
     }
 
     fn restart_into_update(&self) -> Result<()> {
@@ -703,8 +810,8 @@ impl LinuxDesktopHost {
         model: crate::transcription_models::TranscriptionModelId,
         language: String,
     ) -> Result<()> {
-        if self.is_running() {
-            let error = "Stop listening before changing the transcription model".to_string();
+        if self.is_running() || self.settings_edit.is_some() {
+            let error = "Stop listening and finish shortcut editing before changing the transcription model".to_string();
             self.transcription_error = Some(error.clone());
             return Err(color_eyre::eyre::eyre!(error));
         }
@@ -775,13 +882,22 @@ impl LinuxDesktopHost {
 }
 
 impl LinuxApp {
+    fn request_quit(&mut self) {
+        self.quitting = true;
+        self.host.stop();
+        self.host.cancel_transcription_preparation();
+    }
+
     fn capture_hotkey(&mut self, keystroke: &Keystroke) -> bool {
-        if !self.capturing_hotkey {
+        if !self.host.capturing_hotkey() {
             return false;
         }
         if keystroke.key == "escape" {
-            self.capturing_hotkey = false;
+            self.host.cancel_settings_edit();
             return true;
+        }
+        if LinuxSession::detect().is_wayland() || self.host.is_running() {
+            return false;
         }
         let shortcut = DesktopShortcut {
             alt: keystroke.modifiers.alt,
@@ -791,13 +907,9 @@ impl LinuxApp {
             platform: keystroke.modifiers.platform,
             shift: keystroke.modifiers.shift,
         };
-        if self
+        let _ = self
             .host
-            .dispatch(DesktopAction::SetDictationShortcut(shortcut))
-            .is_ok()
-        {
-            self.capturing_hotkey = false;
-        }
+            .dispatch(DesktopAction::SetDictationShortcut(shortcut));
         true
     }
 }
@@ -813,18 +925,25 @@ fn start_update_check() -> Receiver<Result<Option<InstalledUpdate>, String>> {
 
 impl Drop for LinuxDesktopHost {
     fn drop(&mut self) {
+        self.stop();
         self.cancel_transcription_preparation();
-        if let Some(stop) = self
-            .listener_stop
+        self.listener_stop
             .lock()
             .unwrap_or_else(|error| error.into_inner())
-            .take()
-        {
-            stop.store(true, Ordering::Relaxed);
-        }
+            .take();
         self.join_listener();
-        if let Some(mut preparation) = self.transcription_preparation.take()
+        if let Some(preparation) = &mut self.transcription_preparation
+            && preparation
+                .worker
+                .as_ref()
+                .is_some_and(JoinHandle::is_finished)
             && let Some(worker) = preparation.worker.take()
+        {
+            let _ = worker.join();
+        }
+        if let Some(edit) = &mut self.settings_edit
+            && edit.worker.as_ref().is_some_and(JoinHandle::is_finished)
+            && let Some(worker) = edit.worker.take()
         {
             let _ = worker.join();
         }
@@ -855,7 +974,17 @@ impl DesktopHost for LinuxDesktopHost {
                 running: self.is_running(),
                 status: self.status.clone(),
             }),
-            operation_error: self.error.clone().or_else(|| self.settings_error.clone()),
+            operation_error: self
+                .error
+                .clone()
+                .or_else(|| self.settings_error.clone())
+                .or_else(|| {
+                    self.activity
+                        .last_failure
+                        .as_ref()
+                        .filter(|(at, _)| Some(*at) != self.dismissed_failure_at)
+                        .map(|(_, message)| message.clone())
+                }),
             observations_path: self.event_path.display().to_string(),
             transcription: DesktopTranscriptionSnapshot {
                 downloaded_bytes: self
@@ -880,7 +1009,11 @@ impl DesktopHost for LinuxDesktopHost {
 
     fn dispatch(&mut self, action: DesktopAction) -> Result<()> {
         match action {
-            DesktopAction::ClearError => self.error = None,
+            DesktopAction::ClearError => {
+                self.error = None;
+                self.settings_error = None;
+                self.dismissed_failure_at = self.activity.last_failure.as_ref().map(|(at, _)| *at);
+            }
             DesktopAction::RestartIntoUpdate => {
                 if let Err(error) = self.restart_into_update() {
                     self.error = Some(format!("Could not restart HEX: {error:#}"));
@@ -891,22 +1024,18 @@ impl DesktopHost for LinuxDesktopHost {
                 self.set_dictation_hotkey(shortcut)?;
             }
             DesktopAction::SetDoubleTapLock(enabled) => {
-                let mut candidate = self.settings.clone();
-                candidate.double_tap_lock = enabled;
-                if let Err(error) = candidate.save() {
-                    self.error = Some(format!("Could not save double-tap setting: {error:#}"));
-                    return Err(error);
-                }
-                self.settings = candidate;
-                self.error = None;
-                self.settings_error = None;
+                self.begin_settings_edit(SettingsChange::DoubleTap(enabled));
             }
             DesktopAction::SetDoubleTapOnly(_) => {
                 return Err(color_eyre::eyre::eyre!(
                     "double-tap-only is unavailable on X11"
                 ));
             }
-            DesktopAction::StartListening => self.start(),
+            DesktopAction::StartListening => {
+                self.error = None;
+                self.dismissed_failure_at = self.activity.last_failure.as_ref().map(|(at, _)| *at);
+                self.start();
+            }
             DesktopAction::StopListening => self.stop(),
         }
         Ok(())
@@ -941,7 +1070,9 @@ impl LinuxApp {
             .listener
             .as_ref()
             .is_some_and(|listener| listener.running);
-        let shortcut = if self.capturing_hotkey {
+        let editing = self.host.settings_edit.is_some();
+        let paste_with_shift = self.host.settings.paste_with_shift;
+        let shortcut = if self.host.capturing_hotkey() {
             div()
                 .w(px(180.0))
                 .h(px(34.0))
@@ -953,7 +1084,11 @@ impl LinuxApp {
                 .border_color(rgb(TEXT_SOFT))
                 .bg(rgb(SURFACE))
                 .text_size(px(11.0))
-                .child("Press a shortcut...")
+                .child(if running {
+                    "Stopping listener..."
+                } else {
+                    "Press a shortcut..."
+                })
                 .into_any_element()
         } else {
             hotkey_keycaps(snapshot.dictation_shortcut.clone(), 1.0)
@@ -973,7 +1108,7 @@ impl LinuxApp {
             .flex_col()
             .child(pane_header("Settings"))
             .child(
-                div()
+                pane_body().child(div()
                     .id("settings-scroll")
                     .flex_1()
                     .overflow_y_scroll()
@@ -982,10 +1117,50 @@ impl LinuxApp {
                     .pb_7()
                     .child(
                         div().w_full().flex().justify_center().child(
-                            div()
-                                .w_full()
-                                .max_w(px(788.0))
+                            pane_content()
                                 .relative()
+                                .child(settings_section_label("LISTENER"))
+                                .child(settings_panel().child(settings_row(
+                                    "Dictation",
+                                    "Global hotkey dictation",
+                                    div().flex().items_center().gap_3()
+                                        .child(div().text_size(px(12.0)).text_color(rgb(MUTED))
+                                            .child(snapshot.listener.as_ref().map_or_else(|| "Ready".to_string(), |listener| listener.status.clone())))
+                                        .child(compact_button(if running { "Stop" } else { "Start" })
+                                        .id("linux-listener-toggle")
+                                        .on_click(cx.listener(move |this, _, _, cx| {
+                                            if !this.quitting {
+                                                let _ = this.host.dispatch(if running {
+                                                    DesktopAction::StopListening
+                                                } else {
+                                                    DesktopAction::StartListening
+                                                });
+                                                cx.notify();
+                                            }
+                                        }))),
+                                )))
+                                .when_some(snapshot.operation_error.clone(), |content, error| {
+                                    content.child(
+                                        div().mt_3().p_3().rounded(px(6.0)).border_1().border_color(rgb(LINE))
+                                            .child(div().text_size(px(12.0)).child(error))
+                                            .child(div().mt_2().flex().gap_2()
+                                                .when(!running, |buttons| buttons.child(compact_button("Retry").id("linux-error-retry")
+                                                    .on_click(cx.listener(|this, _, _, cx| {
+                                                        if !this.quitting {
+                                                            let _ = this.host.dispatch(DesktopAction::StartListening);
+                                                            cx.notify();
+                                                        }
+                                                    }))))
+                                                .child(compact_button("Dismiss").id("linux-error-dismiss")
+                                                    .on_click(cx.listener(|this, _, _, cx| {
+                                                        let _ = this.host.dispatch(DesktopAction::ClearError);
+                                                        cx.notify();
+                                                    })))),
+                                    )
+                                })
+                                .when_some(crate::linux_desktop::hud_limitation(), |content, limitation| {
+                                    content.child(div().mt_3().text_size(px(12.0)).text_color(rgb(MUTED)).child(limitation))
+                                })
                                 .child(settings_section_label("DICTATION"))
                                 .child(
                                     settings_panel()
@@ -1015,20 +1190,28 @@ impl LinuxApp {
                                             )
                                             .border_b_0()
                                             .id("dictation-hotkey-setting")
-                                            .when(running, |row| row.opacity(0.5))
                                             .on_click(
                                                 cx.listener(move |this, _, _, cx| {
-                                                    if !running {
-                                                        this.capturing_hotkey =
-                                                            !this.capturing_hotkey;
-                                                        let _ = this
-                                                            .host
-                                                            .dispatch(DesktopAction::ClearError);
+                                                    if !this.quitting {
+                                                        if this.host.capturing_hotkey() {
+                                                            this.host.cancel_settings_edit();
+                                                        } else {
+                                                            this.host.begin_settings_edit(SettingsChange::Capture);
+                                                        }
                                                         cx.notify();
                                                     }
                                                 }),
                                             ),
-                                        ),
+                                        )
+                                        .when(editing, |panel| panel.child(settings_row(
+                                            "Updating shortcut settings",
+                                            "Listening resumes after the change if it was previously running.",
+                                            compact_button("Cancel").id("linux-cancel-shortcut")
+                                                .on_click(cx.listener(|this, _, _, cx| {
+                                                    this.host.cancel_settings_edit();
+                                                    cx.notify();
+                                                })),
+                                        ))),
                                 )
                                 .child(settings_section_label("BEHAVIOR"))
                                 .child(
@@ -1042,12 +1225,11 @@ impl LinuxApp {
                                                 0.0
                                             }),
                                         )
-                                        .border_b_0()
                                         .id("double-tap-setting")
-                                        .when(running, |row| row.opacity(0.5))
+                                        .when(editing, |row| row.opacity(0.5))
                                         .on_click(
                                             cx.listener(move |this, _, _, cx| {
-                                                if !running {
+                                                if !this.quitting && !editing {
                                                     let enabled =
                                                         !this.host.snapshot().double_tap_lock;
                                                     let _ = this.host.dispatch(
@@ -1057,6 +1239,21 @@ impl LinuxApp {
                                                 }
                                             }),
                                         ),
+                                    ).child(
+                                        settings_row(
+                                            "Terminal paste shortcut",
+                                            "Use Ctrl-Shift-V instead of Ctrl-V",
+                                            toggle(if paste_with_shift { 1.0 } else { 0.0 }),
+                                        )
+                                        .border_b_0()
+                                        .id("terminal-paste-setting")
+                                        .when(editing, |row| row.opacity(0.5))
+                                        .on_click(cx.listener(move |this, _, _, cx| {
+                                            if !this.quitting && !editing {
+                                                this.host.begin_settings_edit(SettingsChange::PasteWithShift(!paste_with_shift));
+                                                cx.notify();
+                                            }
+                                        })),
                                     ),
                                 )
                                 .child(settings_section_label("APPLICATION"))
@@ -1069,6 +1266,16 @@ impl LinuxApp {
                                                 format!("Version {}", env!("CARGO_PKG_VERSION")),
                                             ),
                                         ))
+                                        .child(settings_row(
+                                            "Quit HEX",
+                                            "Stop listening and close the application",
+                                            compact_button(if self.quitting { "Stopping..." } else { "Quit" })
+                                                .id("linux-quit")
+                                                .on_click(cx.listener(|this, _, _, cx| {
+                                                    this.request_quit();
+                                                    cx.notify();
+                                                })),
+                                        ))
                                         .when(update_ready, |panel| {
                                             panel.child(settings_row(
                                                 "Update ready",
@@ -1078,26 +1285,15 @@ impl LinuxApp {
                                                     .border_1()
                                                     .border_color(rgb(LINE))
                                                     .on_click(cx.listener(|this, _, _, cx| {
-                                                        if this
-                                                            .host
-                                                            .dispatch(
-                                                                DesktopAction::RestartIntoUpdate,
-                                                            )
-                                                            .is_ok()
-                                                        {
-                                                            let _ = this.host.dispatch(
-                                                                DesktopAction::StopListening,
-                                                            );
-                                                            cx.quit();
-                                                        } else {
-                                                            cx.notify();
-                                                        }
+                                                        this.restart_requested = true;
+                                                        this.request_quit();
+                                                        cx.notify();
                                                     })),
                                             ))
                                         }),
                                 ),
                         ),
-                    ),
+                    )),
             )
             .into_any_element()
     }
@@ -1177,6 +1373,9 @@ impl TranscriptionPickerDelegate for LinuxApp {
         language: String,
         _cx: &mut Context<Self>,
     ) {
+        if self.quitting {
+            return;
+        }
         if self
             .host
             .choose_transcription(model, language.clone())
@@ -1216,7 +1415,14 @@ impl Render for LinuxApp {
                 });
         window_frame()
             .child(self.render_shared_navigation())
-            .child(div().flex_1().h_full().overflow_hidden().child(content))
+            .child(
+                div()
+                    .flex_1()
+                    .min_w(px(0.0))
+                    .h_full()
+                    .overflow_hidden()
+                    .child(content),
+            )
             .children(model_picker)
     }
 }
@@ -1227,6 +1433,190 @@ mod tests {
     use crate::transcription_models::{
         ModelPreparationStage, TranscriptionModelId, TranscriptionSelection,
     };
+
+    fn host_for_edit(running: bool) -> LinuxDesktopHost {
+        let settings = crate::linux_settings::LinuxSettings {
+            transcription: TranscriptionSelection {
+                // Prevent the restart assertions from opening a real microphone.
+                model: TranscriptionModelId::AppleSpeech,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut host = LinuxDesktopHost::new(
+            PathBuf::new(),
+            Arc::new(Mutex::new(None)),
+            settings,
+            None,
+            UpdateState::Unmanaged,
+        );
+        if running {
+            let (_, result) = mpsc::channel();
+            host.listener_result = Some(result);
+            *host.listener_stop.lock().unwrap() = Some(Arc::new(AtomicBool::new(false)));
+            host.listen_when_ready = true;
+        }
+        host
+    }
+
+    fn set_finished_edit(
+        host: &mut LinuxDesktopHost,
+        result: Result<crate::linux_settings::LinuxSettings>,
+    ) {
+        let worker = std::thread::spawn(move || result);
+        while !worker.is_finished() {
+            std::thread::yield_now();
+        }
+        host.settings_edit.as_mut().unwrap().worker = Some(worker);
+    }
+
+    #[test]
+    fn preference_edits_wait_for_stop_and_only_restart_a_previously_running_listener() {
+        for (running, paste) in [(false, false), (true, false), (false, true), (true, true)] {
+            let mut host = host_for_edit(running);
+            let mut candidate = host.settings.clone();
+            if paste {
+                candidate.paste_with_shift = !candidate.paste_with_shift;
+                host.begin_settings_edit(SettingsChange::PasteWithShift(
+                    candidate.paste_with_shift,
+                ));
+            } else {
+                candidate.double_tap_lock = !candidate.double_tap_lock;
+                host.dispatch(DesktopAction::SetDoubleTapLock(candidate.double_tap_lock))
+                    .unwrap();
+            }
+            assert_eq!(host.settings_edit.as_ref().unwrap().resume, running);
+            if running {
+                host.refresh_settings_edit();
+                assert!(
+                    host.listener_stop
+                        .lock()
+                        .unwrap()
+                        .as_ref()
+                        .unwrap()
+                        .load(Ordering::Relaxed)
+                );
+                assert!(host.settings_edit.as_ref().unwrap().worker.is_none());
+                assert_ne!(host.settings, candidate);
+            }
+            host.listener_result = None;
+            host.listener_stop.lock().unwrap().take();
+            set_finished_edit(&mut host, Ok(candidate.clone()));
+            host.refresh_settings_edit();
+            assert_eq!(host.settings, candidate);
+            assert!(host.settings_edit.is_none());
+            assert_eq!(host.listen_when_ready, running);
+        }
+    }
+
+    #[test]
+    fn canceled_or_failed_capture_restores_prior_listening_without_changing_settings() {
+        for running in [false, true] {
+            for cancel in [false, true] {
+                let mut host = host_for_edit(running);
+                let original = host.settings.clone();
+                host.begin_settings_edit(SettingsChange::Capture);
+                host.listener_result = None;
+                host.listener_stop.lock().unwrap().take();
+                if cancel {
+                    host.cancel_settings_edit();
+                } else {
+                    set_finished_edit(
+                        &mut host,
+                        Err(color_eyre::eyre::eyre!("input permission denied")),
+                    );
+                }
+                host.refresh_settings_edit();
+                assert_eq!(host.settings, original);
+                assert_eq!(host.listen_when_ready, running);
+                assert_eq!(host.error.is_some(), !cancel);
+                assert!(host.settings_edit.is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn cancel_signals_worker_and_does_not_wait_or_restart_until_it_finishes() {
+        let mut host = host_for_edit(true);
+        host.begin_settings_edit(SettingsChange::Capture);
+        host.listener_result = None;
+        host.listener_stop.lock().unwrap().take();
+        let (release, held) = mpsc::channel();
+        host.settings_edit.as_mut().unwrap().worker = Some(std::thread::spawn(move || {
+            let _ = held.recv();
+            Err(color_eyre::eyre::eyre!("capture canceled"))
+        }));
+        host.cancel_settings_edit();
+        host.refresh_settings_edit();
+        let edit = host.settings_edit.as_mut().unwrap();
+        assert!(edit.canceled.load(Ordering::Acquire));
+        assert!(edit.worker.is_some());
+        assert!(!host.listen_when_ready);
+        release.send(()).unwrap();
+        let _ = host
+            .settings_edit
+            .as_mut()
+            .unwrap()
+            .worker
+            .take()
+            .unwrap()
+            .join()
+            .unwrap()
+            .unwrap_err();
+        host.refresh_settings_edit();
+        assert!(host.listen_when_ready);
+        assert!(host.settings_edit.is_none());
+    }
+
+    #[test]
+    fn quit_during_edit_cancels_capture_and_suppresses_restart() {
+        let mut app = LinuxApp {
+            host: host_for_edit(true),
+            quitting: false,
+            restart_requested: false,
+            transcription_picker: TranscriptionPickerState::Closed,
+        };
+        app.host.begin_settings_edit(SettingsChange::Capture);
+        app.request_quit();
+        assert!(app.quitting);
+        assert!(app.host.has_pending_work());
+        let edit = app.host.settings_edit.as_ref().unwrap();
+        assert!(!edit.resume);
+        assert!(edit.canceled.load(Ordering::Acquire));
+        app.host.listener_result = None;
+        app.host.listener_stop.lock().unwrap().take();
+        app.host.refresh_settings_edit();
+        assert!(!app.host.listen_when_ready);
+        assert!(!app.host.has_pending_work());
+    }
+
+    #[test]
+    fn dismiss_clears_operational_and_settings_errors() {
+        let mut host = host_for_edit(false);
+        host.error = Some("listener failed".into());
+        host.settings_error = Some("settings failed".into());
+        host.dispatch(DesktopAction::ClearError).unwrap();
+        assert!(host.snapshot().operation_error.is_none());
+    }
+
+    #[test]
+    fn output_failures_are_visible_and_dismissal_only_acknowledges_that_failure() {
+        let mut host = host_for_edit(false);
+        host.activity.last_failure = Some((10, "paste helper failed".into()));
+        assert_eq!(
+            host.snapshot().operation_error.as_deref(),
+            Some("paste helper failed")
+        );
+        host.dispatch(DesktopAction::ClearError).unwrap();
+        assert!(host.snapshot().operation_error.is_none());
+        host.activity.last_failure = Some((11, "paste helper failed".into()));
+        assert_eq!(
+            host.snapshot().operation_error.as_deref(),
+            Some("paste helper failed")
+        );
+        host.dispatch(DesktopAction::StartListening).unwrap();
+        assert!(host.snapshot().operation_error.is_none());
+    }
 
     #[test]
     fn start_during_preparation_defers_listening_and_stop_clears_the_request() {

--- a/src/linux_app.rs
+++ b/src/linux_app.rs
@@ -53,11 +53,11 @@ struct TranscriptionPreparation {
     canceled: Arc<AtomicBool>,
     model: crate::transcription_models::TranscriptionModelId,
     progress: Arc<AtomicU64>,
-    result: Receiver<PreparationResult>,
     stage: Arc<AtomicU8>,
-    worker: Option<JoinHandle<()>>,
+    worker: JoinHandle<PreparationResult>,
 }
 
+#[derive(Clone)]
 enum SettingsChange {
     Capture,
     Hotkey(crate::linux_settings::LinuxHotkey),
@@ -66,8 +66,7 @@ enum SettingsChange {
 }
 
 struct SettingsEdit {
-    change: Option<SettingsChange>,
-    capturing: bool,
+    change: SettingsChange,
     resume: bool,
     canceled: Arc<AtomicBool>,
     worker: Option<JoinHandle<Result<crate::linux_settings::LinuxSettings>>>,
@@ -78,8 +77,7 @@ struct LinuxDesktopHost {
     event_reader: EventReader,
     activity: DesktopActivity,
     listener_stop: Arc<Mutex<Option<Arc<AtomicBool>>>>,
-    listener_result: Option<Receiver<ListenerResult>>,
-    listener_worker: Option<JoinHandle<()>>,
+    listener_worker: Option<JoinHandle<ListenerResult>>,
     session_before_start: Option<u64>,
     awaiting_session_start: bool,
     listen_when_ready: bool,
@@ -418,7 +416,6 @@ impl LinuxDesktopHost {
             event_path,
             activity,
             listener_stop,
-            listener_result: None,
             listener_worker: None,
             session_before_start: None,
             awaiting_session_start: false,
@@ -441,7 +438,7 @@ impl LinuxDesktopHost {
             return;
         }
         self.listen_when_ready = true;
-        if self.listener_result.is_some() || self.transcription_preparation.is_some() {
+        if self.is_running() || self.transcription_preparation.is_some() {
             return;
         }
         let model = crate::transcription_models::definition(self.settings.transcription.model);
@@ -455,7 +452,6 @@ impl LinuxDesktopHost {
             .listener_stop
             .lock()
             .unwrap_or_else(|error| error.into_inner()) = Some(stop.clone());
-        let (result_sender, result_receiver) = mpsc::channel();
         let event_path = self.event_path.clone();
         let prepared_transcriber = self.prepared_transcriber.take();
         let worker = std::thread::spawn(move || {
@@ -471,11 +467,9 @@ impl LinuxDesktopHost {
                     crate::linux_dictation::run(&event_path, None, &stop)
                 }
             });
-            let result = result.map_err(|error| format!("{error:#}"));
-            let _ = result_sender.send(result);
+            result.map_err(|error| format!("{error:#}"))
         });
         self.listener_worker = Some(worker);
-        self.listener_result = Some(result_receiver);
         self.session_before_start = self.activity.session_started_at;
         self.awaiting_session_start = true;
         self.status = "Starting".into();
@@ -524,32 +518,18 @@ impl LinuxDesktopHost {
             };
         }
 
-        let transcription_result = self
+        let mut start_listener = false;
+        if self
             .transcription_preparation
             .as_ref()
-            .filter(|preparation| {
-                preparation
-                    .worker
-                    .as_ref()
-                    .is_none_or(JoinHandle::is_finished)
-            })
-            .and_then(|preparation| match preparation.result.try_recv() {
-                Ok(result) => Some(result),
-                Err(TryRecvError::Disconnected) => {
-                    Some(Err("model preparation worker stopped unexpectedly".into()))
-                }
-                Err(TryRecvError::Empty) => None,
-            });
-        let mut start_listener = false;
-        if let Some(result) = transcription_result {
-            let mut preparation = self
-                .transcription_preparation
-                .take()
-                .expect("completed transcription preparation exists");
+            .is_some_and(|preparation| preparation.worker.is_finished())
+            && let Some(preparation) = self.transcription_preparation.take()
+        {
             let was_canceled = preparation.canceled.load(Ordering::Relaxed);
-            if let Some(worker) = preparation.worker.take() {
-                let _ = worker.join();
-            }
+            let result = preparation
+                .worker
+                .join()
+                .unwrap_or_else(|_| Err("model preparation worker stopped unexpectedly".into()));
             if was_canceled {
                 self.transcription_error = None;
             } else {
@@ -586,30 +566,22 @@ impl LinuxDesktopHost {
         if self
             .listener_worker
             .as_ref()
-            .is_none_or(JoinHandle::is_finished)
-            && let Some(receiver) = &self.listener_result
+            .is_some_and(JoinHandle::is_finished)
+            && let Some(worker) = self.listener_worker.take()
         {
-            let result = match receiver.try_recv() {
-                Ok(result) => Some(result),
-                Err(TryRecvError::Empty) => None,
-                Err(TryRecvError::Disconnected) => {
-                    Some(Err("listener worker stopped unexpectedly".into()))
-                }
-            };
-            if let Some(result) = result {
-                self.awaiting_session_start = false;
-                self.listener_result = None;
-                self.join_listener();
-                self.listener_stop
-                    .lock()
-                    .unwrap_or_else(|error| error.into_inner())
-                    .take();
-                match result {
-                    Ok(()) => self.status = "Ready".into(),
-                    Err(error) => {
-                        self.status = "Unavailable".into();
-                        self.error = Some(error);
-                    }
+            let result = worker
+                .join()
+                .unwrap_or_else(|_| Err("listener worker stopped unexpectedly".into()));
+            self.awaiting_session_start = false;
+            self.listener_stop
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .take();
+            match result {
+                Ok(()) => self.status = "Ready".into(),
+                Err(error) => {
+                    self.status = "Unavailable".into();
+                    self.error = Some(error);
                 }
             }
         }
@@ -622,7 +594,7 @@ impl LinuxDesktopHost {
         {
             self.awaiting_session_start = false;
         }
-        if self.listener_result.is_some()
+        if self.is_running()
             && self.listen_when_ready
             && !self.awaiting_session_start
             && let Some(status) = self.activity.state_label()
@@ -632,18 +604,7 @@ impl LinuxDesktopHost {
     }
 
     fn is_running(&self) -> bool {
-        self.listener_result.is_some()
-    }
-
-    fn join_listener(&mut self) {
-        if self
-            .listener_worker
-            .as_ref()
-            .is_some_and(JoinHandle::is_finished)
-            && let Some(worker) = self.listener_worker.take()
-        {
-            let _ = worker.join();
-        }
+        self.listener_worker.is_some()
     }
 
     fn set_dictation_hotkey(&mut self, shortcut: DesktopShortcut) -> Result<()> {
@@ -666,9 +627,8 @@ impl LinuxDesktopHost {
             },
         };
         if let Some(edit) = &mut self.settings_edit {
-            if matches!(edit.change, Some(SettingsChange::Capture)) && edit.worker.is_none() {
-                edit.change = Some(SettingsChange::Hotkey(binding));
-                edit.capturing = false;
+            if matches!(edit.change, SettingsChange::Capture) && edit.worker.is_none() {
+                edit.change = SettingsChange::Hotkey(binding);
             }
         } else {
             self.begin_settings_edit(SettingsChange::Hotkey(binding));
@@ -688,8 +648,7 @@ impl LinuxDesktopHost {
         self.stop();
         self.error = None;
         self.settings_edit = Some(SettingsEdit {
-            capturing: matches!(change, SettingsChange::Capture),
-            change: Some(change),
+            change,
             resume,
             canceled: Arc::new(AtomicBool::new(false)),
             worker: None,
@@ -703,9 +662,9 @@ impl LinuxDesktopHost {
     }
 
     fn capturing_hotkey(&self) -> bool {
-        self.settings_edit
-            .as_ref()
-            .is_some_and(|edit| !edit.canceled.load(Ordering::Acquire) && edit.capturing)
+        self.settings_edit.as_ref().is_some_and(|edit| {
+            !edit.canceled.load(Ordering::Acquire) && matches!(edit.change, SettingsChange::Capture)
+        })
     }
 
     fn has_pending_work(&self) -> bool {
@@ -747,14 +706,12 @@ impl LinuxDesktopHost {
             }
         } else if !canceled {
             let wayland = LinuxSession::detect().is_wayland();
-            if !wayland && matches!(edit.change, Some(SettingsChange::Capture)) {
+            if !wayland && matches!(edit.change, SettingsChange::Capture) {
                 // X11 uses focused GPUI keystrokes, never raw input-device access.
                 self.status = "Press a shortcut".into();
                 return;
             }
-            let Some(change) = edit.change.take() else {
-                return;
-            };
+            let change = edit.change.clone();
             let mut candidate = self.settings.clone();
             let canceled = edit.canceled.clone();
             edit.worker = Some(std::thread::spawn(move || {
@@ -836,9 +793,8 @@ impl LinuxDesktopHost {
         let worker_canceled = canceled.clone();
         let worker_progress = progress.clone();
         let worker_stage = stage.clone();
-        let (sender, receiver) = mpsc::sync_channel(1);
         let worker = std::thread::spawn(move || {
-            let result = (|| {
+            (|| {
                 crate::transcription_models::download_with_stage_progress(
                     definition,
                     &worker_canceled,
@@ -858,16 +814,14 @@ impl LinuxDesktopHost {
                     transcriber,
                 })
             })()
-            .map_err(|error| format!("{error:#}"));
-            let _ = sender.send(result);
+            .map_err(|error| format!("{error:#}"))
         });
         self.transcription_preparation = Some(TranscriptionPreparation {
             canceled,
             model,
             progress,
-            result: receiver,
             stage,
-            worker: Some(worker),
+            worker,
         });
         self.transcription_error = None;
         Ok(())
@@ -931,15 +885,21 @@ impl Drop for LinuxDesktopHost {
             .lock()
             .unwrap_or_else(|error| error.into_inner())
             .take();
-        self.join_listener();
-        if let Some(preparation) = &mut self.transcription_preparation
-            && preparation
-                .worker
-                .as_ref()
-                .is_some_and(JoinHandle::is_finished)
-            && let Some(worker) = preparation.worker.take()
+        if self
+            .listener_worker
+            .as_ref()
+            .is_some_and(JoinHandle::is_finished)
+            && let Some(worker) = self.listener_worker.take()
         {
             let _ = worker.join();
+        }
+        if self
+            .transcription_preparation
+            .as_ref()
+            .is_some_and(|preparation| preparation.worker.is_finished())
+            && let Some(preparation) = self.transcription_preparation.take()
+        {
+            let _ = preparation.worker.join();
         }
         if let Some(edit) = &mut self.settings_edit
             && edit.worker.as_ref().is_some_and(JoinHandle::is_finished)
@@ -1451,8 +1411,7 @@ mod tests {
             UpdateState::Unmanaged,
         );
         if running {
-            let (_, result) = mpsc::channel();
-            host.listener_result = Some(result);
+            host.listener_worker = Some(std::thread::spawn(|| Ok(())));
             *host.listener_stop.lock().unwrap() = Some(Arc::new(AtomicBool::new(false)));
             host.listen_when_ready = true;
         }
@@ -1468,6 +1427,89 @@ mod tests {
             std::thread::yield_now();
         }
         host.settings_edit.as_mut().unwrap().worker = Some(worker);
+    }
+
+    #[test]
+    fn listener_completion_waits_for_the_worker_and_preserves_errors() {
+        for outcome in [Some(Ok(())), Some(Err("listener failed".into())), None] {
+            let expected = outcome
+                .clone()
+                .unwrap_or_else(|| Err("listener worker stopped unexpectedly".into()))
+                .err();
+            let mut host = host_for_edit(true);
+            let (release, held) = mpsc::channel();
+            host.listener_worker = Some(std::thread::spawn(move || {
+                held.recv_timeout(Duration::from_secs(5)).unwrap();
+                outcome.expect("fixture listener panic")
+            }));
+            host.refresh();
+            assert!(host.is_running());
+            assert!(host.listener_stop.lock().unwrap().is_some());
+            release.send(()).unwrap();
+            while !host.listener_worker.as_ref().unwrap().is_finished() {
+                std::thread::yield_now();
+            }
+            host.refresh();
+            assert!(!host.is_running());
+            assert!(host.listener_stop.lock().unwrap().is_none());
+            assert_eq!(host.error, expected);
+            assert_eq!(
+                host.status,
+                if expected.is_some() {
+                    "Unavailable"
+                } else {
+                    "Ready"
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn preparation_completion_preserves_selection_and_honors_cancellation() {
+        for (canceled, panics) in [(false, false), (false, true), (true, false), (true, true)] {
+            let mut host = host_for_edit(false);
+            let original = host.settings.clone();
+            let (release, held) = mpsc::channel();
+            host.transcription_preparation = Some(TranscriptionPreparation {
+                canceled: Arc::new(AtomicBool::new(false)),
+                model: TranscriptionModelId::default(),
+                progress: Arc::new(AtomicU64::new(0)),
+                stage: Arc::new(AtomicU8::new(ModelPreparationStage::Loading as u8)),
+                worker: std::thread::spawn(move || {
+                    held.recv_timeout(Duration::from_secs(5)).unwrap();
+                    assert!(!panics, "fixture preparation panic");
+                    Err("model unavailable".into())
+                }),
+            });
+            if canceled {
+                host.cancel_transcription_preparation();
+            }
+            host.refresh();
+            assert!(host.has_pending_work());
+            release.send(()).unwrap();
+            while !host
+                .transcription_preparation
+                .as_ref()
+                .unwrap()
+                .worker
+                .is_finished()
+            {
+                std::thread::yield_now();
+            }
+            host.refresh();
+            assert!(!host.has_pending_work());
+            assert_eq!(host.settings, original);
+            assert_eq!(
+                host.transcription_error.as_deref(),
+                if canceled {
+                    None
+                } else if panics {
+                    Some("model preparation worker stopped unexpectedly")
+                } else {
+                    Some("model unavailable")
+                }
+            );
+        }
     }
 
     #[test]
@@ -1499,7 +1541,7 @@ mod tests {
                 assert!(host.settings_edit.as_ref().unwrap().worker.is_none());
                 assert_ne!(host.settings, candidate);
             }
-            host.listener_result = None;
+            host.listener_worker = None;
             host.listener_stop.lock().unwrap().take();
             set_finished_edit(&mut host, Ok(candidate.clone()));
             host.refresh_settings_edit();
@@ -1516,7 +1558,8 @@ mod tests {
                 let mut host = host_for_edit(running);
                 let original = host.settings.clone();
                 host.begin_settings_edit(SettingsChange::Capture);
-                host.listener_result = None;
+                assert!(host.capturing_hotkey());
+                host.listener_worker = None;
                 host.listener_stop.lock().unwrap().take();
                 if cancel {
                     host.cancel_settings_edit();
@@ -1531,6 +1574,7 @@ mod tests {
                 assert_eq!(host.listen_when_ready, running);
                 assert_eq!(host.error.is_some(), !cancel);
                 assert!(host.settings_edit.is_none());
+                assert!(!host.capturing_hotkey());
             }
         }
     }
@@ -1539,7 +1583,7 @@ mod tests {
     fn cancel_signals_worker_and_does_not_wait_or_restart_until_it_finishes() {
         let mut host = host_for_edit(true);
         host.begin_settings_edit(SettingsChange::Capture);
-        host.listener_result = None;
+        host.listener_worker = None;
         host.listener_stop.lock().unwrap().take();
         let (release, held) = mpsc::channel();
         host.settings_edit.as_mut().unwrap().worker = Some(std::thread::spawn(move || {
@@ -1583,7 +1627,7 @@ mod tests {
         let edit = app.host.settings_edit.as_ref().unwrap();
         assert!(!edit.resume);
         assert!(edit.canceled.load(Ordering::Acquire));
-        app.host.listener_result = None;
+        app.host.listener_worker = None;
         app.host.listener_stop.lock().unwrap().take();
         app.host.refresh_settings_edit();
         assert!(!app.host.listen_when_ready);
@@ -1635,14 +1679,12 @@ mod tests {
             None,
             UpdateState::Unmanaged,
         );
-        let (_sender, result) = mpsc::sync_channel(1);
         host.transcription_preparation = Some(TranscriptionPreparation {
             canceled: Arc::new(AtomicBool::new(false)),
             model: TranscriptionModelId::default(),
             progress: Arc::new(AtomicU64::new(0)),
-            result,
             stage: Arc::new(AtomicU8::new(ModelPreparationStage::Downloading as u8)),
-            worker: None,
+            worker: std::thread::spawn(|| Err("fixture preparation".into())),
         });
 
         host.dispatch(DesktopAction::StartListening).unwrap();

--- a/src/linux_desktop.rs
+++ b/src/linux_desktop.rs
@@ -1,0 +1,501 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Sender};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use color_eyre::eyre::{Result, eyre};
+use gtk::prelude::*;
+use gtk_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
+use tray_icon::menu::{Menu, MenuEvent, MenuItem};
+use tray_icon::{Icon, MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
+
+use crate::linux_session::LinuxSession;
+
+const TICK: Duration = Duration::from_millis(16);
+
+#[derive(Clone, Copy)]
+pub(crate) enum TrayCommand {
+    Show,
+    ToggleListening,
+    Quit,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum IndicatorState {
+    #[default]
+    Hidden,
+    Recording,
+    Processing,
+}
+
+impl IndicatorState {
+    fn for_capture(recording: bool, pending: usize) -> Self {
+        if recording {
+            Self::Recording
+        } else if pending > 0 {
+            Self::Processing
+        } else {
+            Self::Hidden
+        }
+    }
+}
+
+#[derive(Default)]
+struct IndicatorSlot {
+    generation: u64,
+    state: IndicatorState,
+}
+
+impl IndicatorSlot {
+    fn acquire(&mut self) -> u64 {
+        self.generation += 1;
+        self.state = IndicatorState::Hidden;
+        self.generation
+    }
+
+    fn set(&mut self, generation: u64, state: IndicatorState) {
+        if self.generation == generation {
+            self.state = state;
+        }
+    }
+}
+
+struct TrayRequest {
+    commands: Sender<TrayCommand>,
+    canceled: Arc<AtomicBool>,
+    ready: mpsc::SyncSender<Result<(), String>>,
+}
+
+#[derive(Default)]
+struct State {
+    indicator: IndicatorSlot,
+    tray: Option<TrayRequest>,
+    tray_available: bool,
+    initialized: bool,
+    limitation: Option<String>,
+}
+
+struct Runtime {
+    state: Arc<Mutex<State>>,
+    stop: Arc<AtomicBool>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+}
+
+static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+
+fn runtime() -> &'static Runtime {
+    RUNTIME.get_or_init(|| {
+        let state = Arc::new(Mutex::new(State::default()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let owner_state = state.clone();
+        let owner_stop = stop.clone();
+        let worker = std::thread::spawn(move || {
+            let result = std::panic::catch_unwind(|| run(&owner_state, &owner_stop));
+            let error = match result {
+                Ok(Ok(())) => None,
+                Ok(Err(error)) => Some(format!("Linux desktop integration unavailable: {error:#}")),
+                Err(_) => Some("Linux desktop integration stopped unexpectedly".into()),
+            };
+            if let Some(error) = error {
+                tracing::warn!(%error);
+                let mut state = owner_state
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner());
+                state.initialized = true;
+                state.tray_available = false;
+                state.limitation = Some(error.clone());
+                if let Some(request) = state.tray.take() {
+                    let _ = request.ready.try_send(Err(error));
+                }
+            }
+        });
+        Runtime {
+            state,
+            stop,
+            worker: Mutex::new(Some(worker)),
+        }
+    })
+}
+
+pub(crate) fn start_tray(commands: Sender<TrayCommand>) -> Result<()> {
+    let runtime = runtime();
+    let canceled = Arc::new(AtomicBool::new(false));
+    let (ready, receiver) = mpsc::sync_channel(1);
+    {
+        let mut state = runtime
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if let Some(error) = &state.limitation {
+            return Err(eyre!(error.clone()));
+        }
+        state.tray = Some(TrayRequest {
+            commands,
+            canceled: canceled.clone(),
+            ready,
+        });
+    }
+    match receiver.recv_timeout(Duration::from_secs(2)) {
+        Ok(result) => result.map_err(|error| eyre!(error)),
+        Err(_) => {
+            // A late initialization must not install a tray after the caller chose trayless mode.
+            canceled.store(true, Ordering::Release);
+            Err(eyre!("timed out starting the system tray"))
+        }
+    }
+}
+
+pub(crate) fn hud_limitation() -> Option<String> {
+    if !LinuxSession::detect().is_wayland() {
+        return None;
+    }
+    RUNTIME.get().and_then(|runtime| {
+        let state = runtime
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if state.initialized {
+            state.limitation.clone()
+        } else {
+            Some("Recording HUD is starting; it may be unavailable on this compositor.".into())
+        }
+    })
+}
+
+pub(crate) fn tray_available() -> bool {
+    RUNTIME.get().is_some_and(|runtime| {
+        runtime
+            .state
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .tray_available
+    })
+}
+
+/// Only the process owner shuts GTK down, never an individual listener or HUD.
+pub(crate) fn shutdown() {
+    if let Some(runtime) = RUNTIME.get() {
+        runtime.stop.store(true, Ordering::Release);
+        let mut worker = runtime
+            .worker
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if worker.as_ref().is_some_and(JoinHandle::is_finished)
+            && let Some(worker) = worker.take()
+        {
+            let _ = worker.join();
+        }
+    }
+}
+
+pub(crate) struct LinuxIndicator {
+    generation: Option<u64>,
+}
+
+impl LinuxIndicator {
+    pub(crate) fn new() -> Self {
+        let generation = LinuxSession::detect().is_wayland().then(|| {
+            runtime()
+                .state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .indicator
+                .acquire()
+        });
+        Self { generation }
+    }
+
+    pub(crate) fn update(&self, recording: bool, pending: usize) {
+        if let Some(generation) = self.generation {
+            runtime()
+                .state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .indicator
+                .set(generation, IndicatorState::for_capture(recording, pending));
+        }
+    }
+}
+
+impl Drop for LinuxIndicator {
+    fn drop(&mut self) {
+        self.update(false, 0);
+    }
+}
+
+fn run(state: &Mutex<State>, stop: &AtomicBool) -> Result<()> {
+    // All GTK objects and event dispatch stay on this one process-lifetime thread.
+    // MainContext::invoke is unsuitable: it may execute immediately on its caller.
+    gtk::init()?;
+    let wayland = LinuxSession::detect().is_wayland();
+    let indicator = if wayland && gtk_layer_shell::is_supported() {
+        Some(create_indicator()?)
+    } else {
+        None
+    };
+    {
+        let mut state = state.lock().unwrap_or_else(|error| error.into_inner());
+        state.initialized = true;
+        if wayland && indicator.is_none() {
+            let limitation = "Recording HUD unavailable: this compositor does not support Wayland layer-shell. Dictation still works.";
+            tracing::warn!("{limitation}");
+            state.limitation = Some(limitation.into());
+        }
+    }
+    let context = gtk::glib::MainContext::default();
+    let mut tray: Option<(TrayIcon, Arc<AtomicBool>)> = None;
+    let mut check_tray_at = Instant::now();
+    let mut displayed = IndicatorState::Hidden;
+    while !stop.load(Ordering::Acquire) {
+        let (request, desired) = {
+            let mut state = state.lock().unwrap_or_else(|error| error.into_inner());
+            (state.tray.take(), state.indicator.state)
+        };
+        if let Some(request) = request
+            && !request.canceled.load(Ordering::Acquire)
+        {
+            match create_tray(request.commands) {
+                Ok(icon) => {
+                    if request.ready.try_send(Ok(())).is_ok() {
+                        tray = Some((icon, request.canceled));
+                        state
+                            .lock()
+                            .unwrap_or_else(|error| error.into_inner())
+                            .tray_available = true;
+                        check_tray_at = Instant::now() + Duration::from_secs(2);
+                    }
+                }
+                Err(error) => {
+                    let _ = request.ready.try_send(Err(format!("{error:#}")));
+                }
+            }
+        }
+        if tray
+            .as_ref()
+            .is_some_and(|(_, canceled)| canceled.load(Ordering::Acquire))
+        {
+            tray = None;
+            state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .tray_available = false;
+        }
+        if tray.is_some() && Instant::now() >= check_tray_at {
+            let available = tray_host_available();
+            state
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .tray_available = available;
+            check_tray_at = Instant::now() + Duration::from_secs(2);
+        }
+        if desired != displayed {
+            if let Some((window, label)) = &indicator {
+                match desired {
+                    IndicatorState::Hidden => window.hide(),
+                    IndicatorState::Recording | IndicatorState::Processing => {
+                        label.set_text(if desired == IndicatorState::Recording {
+                            "Recording"
+                        } else {
+                            "Transcribing"
+                        });
+                        window.show_all();
+                    }
+                }
+            }
+            displayed = desired;
+        }
+        // Bounded, nonblocking dispatch makes shutdown independent of pending GTK sources.
+        for _ in 0..32 {
+            if !context.iteration(false) {
+                break;
+            }
+        }
+        std::thread::sleep(TICK);
+    }
+    if let Some((window, _)) = indicator {
+        window.close();
+    }
+    drop(tray);
+    state
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .tray_available = false;
+    Ok(())
+}
+
+fn create_indicator() -> Result<(gtk::Window, gtk::Label)> {
+    let window = gtk::Window::new(gtk::WindowType::Toplevel);
+    window.set_decorated(false);
+    window.set_accept_focus(false);
+    window.set_focus_on_map(false);
+    window.set_skip_taskbar_hint(true);
+    window.set_skip_pager_hint(true);
+    window.set_app_paintable(true);
+    if let Some(screen) = GtkWindowExt::screen(&window)
+        && let Some(visual) = screen.rgba_visual()
+    {
+        window.set_visual(Some(&visual));
+    }
+    window.init_layer_shell();
+    window.set_layer(Layer::Overlay);
+    window.set_keyboard_mode(KeyboardMode::None);
+    window.set_exclusive_zone(0);
+    window.set_anchor(Edge::Top, true);
+    window.set_layer_shell_margin(Edge::Top, 16);
+    window.style_context().add_class("hex-hud");
+
+    let css = gtk::CssProvider::new();
+    css.load_from_data(b"window.hex-hud { background: transparent; } .hex-hud label { background: #20221f; color: #d9ff68; border: 1px solid #44483b; border-radius: 18px; padding: 9px 18px; font: 13px sans-serif; }")?;
+    if let Some(screen) = GtkWindowExt::screen(&window) {
+        gtk::StyleContext::add_provider_for_screen(
+            &screen,
+            &css,
+            gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
+        );
+    }
+    let label = gtk::Label::new(None);
+    window.add(&label);
+    window.connect_realize(|window| {
+        if let Some(surface) = window.window() {
+            surface.set_pass_through(true);
+            surface.input_shape_combine_region(&gtk::cairo::Region::create(), 0, 0);
+        }
+    });
+    Ok((window, label))
+}
+
+fn create_tray(commands: Sender<TrayCommand>) -> Result<TrayIcon> {
+    if !tray_host_available() {
+        return Err(eyre!("no system tray host is available"));
+    }
+    let menu = Menu::new();
+    menu.append(&MenuItem::with_id("show", "Show HEX", true, None))?;
+    menu.append(&MenuItem::with_id(
+        "toggle",
+        "Start / Stop Listening",
+        true,
+        None,
+    ))?;
+    menu.append(&MenuItem::with_id("quit", "Quit HEX", true, None))?;
+    let menu_commands = commands.clone();
+    MenuEvent::set_event_handler(Some(move |event: MenuEvent| {
+        let command = match event.id.as_ref() {
+            "show" => Some(TrayCommand::Show),
+            "toggle" => Some(TrayCommand::ToggleListening),
+            "quit" => Some(TrayCommand::Quit),
+            _ => None,
+        };
+        if let Some(command) = command {
+            let _ = menu_commands.send(command);
+        }
+    }));
+    TrayIconEvent::set_event_handler(Some(move |event| {
+        if matches!(
+            event,
+            TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            }
+        ) {
+            let _ = commands.send(TrayCommand::Show);
+        }
+    }));
+    const SIZE: u32 = 22;
+    let mut data = vec![0_u8; (SIZE * SIZE * 4) as usize];
+    for y in 3..19 {
+        for x in 4..18 {
+            if matches!(x, 4..=7 | 14..=17) || (9..=12).contains(&y) {
+                let index = ((y * SIZE + x) * 4) as usize;
+                data[index..index + 4].copy_from_slice(&[0xd9, 0xff, 0x68, 0xff]);
+            }
+        }
+    }
+    Ok(TrayIconBuilder::new()
+        .with_tooltip("HEX Dictation")
+        .with_icon(Icon::from_rgba(data, SIZE, SIZE)?)
+        .with_menu(Box::new(menu))
+        .build()?)
+}
+
+fn tray_host_available() -> bool {
+    // Successful AppIndicator construction alone does not mean a panel can display it.
+    // Without a host, close-to-tray would leave the listener impossible to reopen.
+    use gtk::glib::variant::ToVariant;
+    if let Ok(bus) = gtk::gio::bus_get_sync(gtk::gio::BusType::Session, gtk::gio::Cancellable::NONE)
+    {
+        for name in [
+            "org.kde.StatusNotifierWatcher",
+            "org.freedesktop.StatusNotifierWatcher",
+        ] {
+            if let Ok(reply) = bus.call_sync(
+                Some(name),
+                "/StatusNotifierWatcher",
+                "org.freedesktop.DBus.Properties",
+                "Get",
+                Some(&(name, "IsStatusNotifierHostRegistered").to_variant()),
+                None,
+                gtk::gio::DBusCallFlags::NO_AUTO_START,
+                250,
+                gtk::gio::Cancellable::NONE,
+            ) && reply
+                .child_value(0)
+                .as_variant()
+                .and_then(|value| value.get::<bool>())
+                == Some(true)
+            {
+                return true;
+            }
+        }
+    }
+    use x11rb::protocol::xproto::ConnectionExt;
+    let legacy_host = (|| -> Result<bool> {
+        let (connection, screen) = x11rb::rust_connection::RustConnection::connect(None)?;
+        let selection = connection
+            .intern_atom(false, format!("_NET_SYSTEM_TRAY_S{screen}").as_bytes())?
+            .reply()?
+            .atom;
+        Ok(connection.get_selection_owner(selection)?.reply()?.owner != 0)
+    })();
+    legacy_host.unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hud_remains_visible_until_all_output_finishes() {
+        assert_eq!(
+            IndicatorState::for_capture(true, 2),
+            IndicatorState::Recording
+        );
+        assert_eq!(
+            IndicatorState::for_capture(false, 2),
+            IndicatorState::Processing
+        );
+        assert_eq!(
+            IndicatorState::for_capture(false, 1),
+            IndicatorState::Processing
+        );
+        assert_eq!(
+            IndicatorState::for_capture(false, 0),
+            IndicatorState::Hidden
+        );
+    }
+
+    #[test]
+    fn old_listener_cannot_hide_or_update_a_restarted_hud() {
+        let mut slot = IndicatorSlot::default();
+        let old = slot.acquire();
+        slot.set(old, IndicatorState::Processing);
+        let current = slot.acquire();
+        assert_eq!(slot.state, IndicatorState::Hidden);
+        slot.set(current, IndicatorState::Recording);
+        slot.set(old, IndicatorState::Hidden);
+        assert_eq!(slot.state, IndicatorState::Recording);
+        slot.set(current, IndicatorState::Hidden);
+        assert_eq!(slot.state, IndicatorState::Hidden);
+    }
+}

--- a/src/linux_dictation.rs
+++ b/src/linux_dictation.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, SyncSender, TrySendError};
 use std::thread;
@@ -10,8 +11,9 @@ use color_eyre::eyre::eyre;
 use crate::audio::{AudioInput, AudioInputEvent, CaptureInstant};
 use crate::dictation::{DictationCapture, Finish};
 use crate::events::{DictationPhase, EventLog, TranscriptPhase, VoiceEvent, VoiceState, now_ms};
-use crate::linux_input::{HotkeyEvent, X11HotkeyMonitor};
-use crate::linux_paste::X11Paster;
+use crate::linux_desktop::LinuxIndicator;
+use crate::linux_input::{HotkeyEvent, LinuxHotkeyMonitor};
+use crate::linux_paste::LinuxPaster;
 use crate::linux_transcriber::LinuxTranscriber;
 
 const UPDATE_INTERVAL: Duration = Duration::from_millis(20);
@@ -24,6 +26,20 @@ struct Job {
 struct JobResult {
     text: Option<String>,
     result: Result<(), String>,
+}
+
+struct OutputWorker {
+    stop: Arc<AtomicBool>,
+    worker: Option<thread::JoinHandle<()>>,
+}
+
+impl Drop for OutputWorker {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
 }
 
 pub fn run(event_path: &Path, device: Option<&str>, shutdown: &AtomicBool) -> Result<()> {
@@ -49,18 +65,29 @@ fn run_with_settings(
     settings: crate::linux_settings::LinuxSettings,
     transcriber: LinuxTranscriber,
 ) -> Result<()> {
+    // Drop audio/hotkeys and close the job queue before joining slow output on
+    // every exit, including failures during startup or recording.
+    let mut output = OutputWorker {
+        stop: Arc::new(AtomicBool::new(false)),
+        worker: None,
+    };
     let input = match device {
         Some(name) => AudioInput::open_matching(name)?,
         None => AudioInput::open(&[])?,
     };
     let hotkey_label = settings.dictation_hotkey.label();
-    let hotkey = X11HotkeyMonitor::start(settings.dictation_hotkey, settings.double_tap_lock)?;
+    let hotkey = LinuxHotkeyMonitor::start(settings.dictation_hotkey, settings.double_tap_lock)?;
+    let indicator = LinuxIndicator::new();
     let (jobs, job_receiver) = mpsc::sync_channel::<Job>(2);
     let (result_sender, results) = mpsc::channel();
-    let worker = thread::spawn(move || {
+    let worker_stop = output.stop.clone();
+    output.worker = Some(thread::spawn(move || {
         let mut transcriber = transcriber;
-        let mut paster = X11Paster::new();
+        let mut paster = LinuxPaster::new(worker_stop.clone(), settings.paste_with_shift);
         while let Ok(job) = job_receiver.recv() {
+            if worker_stop.load(Ordering::Acquire) {
+                break;
+            }
             let started = Instant::now();
             let result = transcriber
                 .transcribe(&job.samples)
@@ -96,7 +123,7 @@ fn run_with_settings(
                 break;
             }
         }
-    });
+    }));
 
     let mut events = EventLog::create(event_path)?;
     let mut capture = DictationCapture::new(input.sample_rate);
@@ -114,7 +141,7 @@ fn run_with_settings(
 
     while !shutdown.load(Ordering::Relaxed) {
         if let Ok(error) = hotkey.errors.try_recv() {
-            return Err(eyre!("X11 hotkey monitor stopped: {error}"));
+            return Err(eyre!("Linux hotkey monitor stopped: {error}"));
         }
         while let Ok(action) = hotkey.events.try_recv() {
             match action {
@@ -180,6 +207,7 @@ fn run_with_settings(
             )?;
         }
 
+        indicator.update(recording, pending);
         let chunk = match input.recv_timeout(UPDATE_INTERVAL) {
             AudioInputEvent::Chunk {
                 samples,
@@ -201,9 +229,19 @@ fn run_with_settings(
         }
     }
 
+    indicator.update(false, pending);
     emit_state(&mut events, VoiceState::Stopping, &input.device_name)?;
+    output.stop.store(true, Ordering::Release);
+    drop(hotkey);
+    drop(input);
     drop(jobs);
-    if worker.join().is_err() {
+    if output
+        .worker
+        .take()
+        .expect("dictation output worker exists")
+        .join()
+        .is_err()
+    {
         return Err(eyre!("Linux dictation worker panicked"));
     }
     println!("Stopped.");
@@ -248,4 +286,36 @@ fn emit_state(events: &mut EventLog, state: VoiceState, device: &str) -> Result<
         device: device.into(),
     })?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_guard_cancels_and_joins_even_on_listener_error() {
+        let stopped = Arc::new(AtomicBool::new(false));
+        let finished = Arc::new(AtomicBool::new(false));
+        let result: Result<()> = {
+            let mut output = OutputWorker {
+                stop: stopped.clone(),
+                worker: None,
+            };
+            let (_jobs, receiver) = mpsc::channel::<()>();
+            let stop = stopped.clone();
+            let completed = finished.clone();
+            output.worker = Some(thread::spawn(move || {
+                // The sender must close before the guard joins this worker.
+                assert!(receiver.recv().is_err());
+                while !stop.load(Ordering::Acquire) {
+                    thread::yield_now();
+                }
+                completed.store(true, Ordering::Release);
+            }));
+            Err(eyre!("listener failure"))
+        };
+        assert!(result.is_err());
+        assert!(stopped.load(Ordering::Acquire));
+        assert!(finished.load(Ordering::Acquire));
+    }
 }

--- a/src/linux_dictation.rs
+++ b/src/linux_dictation.rs
@@ -23,11 +23,6 @@ struct Job {
     audio_ms: u64,
 }
 
-struct JobResult {
-    text: Option<String>,
-    result: Result<(), String>,
-}
-
 struct OutputWorker {
     stop: Arc<AtomicBool>,
     worker: Option<thread::JoinHandle<()>>,
@@ -109,17 +104,7 @@ fn run_with_settings(
                 elapsed_ms = started.elapsed().as_millis(),
                 "completed Linux dictation job"
             );
-            let event = match result {
-                Ok(text) => JobResult {
-                    text: Some(text),
-                    result: Ok(()),
-                },
-                Err(error) => JobResult {
-                    text: None,
-                    result: Err(error),
-                },
-            };
-            if result_sender.send(event).is_err() {
+            if result_sender.send(result).is_err() {
                 break;
             }
         }
@@ -181,9 +166,8 @@ fn run_with_settings(
         }
         while let Ok(result) = results.try_recv() {
             pending = pending.saturating_sub(1);
-            match result.result {
-                Ok(()) => {
-                    let text = result.text.unwrap_or_default();
+            match result {
+                Ok(text) => {
                     events.emit(&VoiceEvent::Transcript {
                         timestamp_ms: now_ms(),
                         phase: TranscriptPhase::Completed,

--- a/src/linux_dictation.rs
+++ b/src/linux_dictation.rs
@@ -162,11 +162,7 @@ fn run_with_settings(
                     )?;
                     emit_state(
                         &mut events,
-                        if pending > 0 {
-                            VoiceState::Transcribing
-                        } else {
-                            VoiceState::Listening
-                        },
+                        active_state(recording, pending),
                         &input.device_name,
                     )?;
                 }
@@ -174,7 +170,11 @@ fn run_with_settings(
                     capture.cancel();
                     recording = false;
                     events.dictation(DictationPhase::Cancelled, "")?;
-                    emit_state(&mut events, VoiceState::Listening, &input.device_name)?;
+                    emit_state(
+                        &mut events,
+                        active_state(recording, pending),
+                        &input.device_name,
+                    )?;
                 }
                 _ => {}
             }
@@ -196,13 +196,7 @@ fn run_with_settings(
             }
             emit_state(
                 &mut events,
-                if recording {
-                    VoiceState::Dictating
-                } else if pending > 0 {
-                    VoiceState::Transcribing
-                } else {
-                    VoiceState::Listening
-                },
+                active_state(recording, pending),
                 &input.device_name,
             )?;
         }
@@ -279,6 +273,16 @@ fn submit_capture(
     Ok(())
 }
 
+fn active_state(recording: bool, pending: usize) -> VoiceState {
+    if recording {
+        VoiceState::Dictating
+    } else if pending > 0 {
+        VoiceState::Transcribing
+    } else {
+        VoiceState::Listening
+    }
+}
+
 fn emit_state(events: &mut EventLog, state: VoiceState, device: &str) -> Result<()> {
     events.emit(&VoiceEvent::State {
         timestamp_ms: now_ms(),
@@ -291,6 +295,15 @@ fn emit_state(events: &mut EventLog, state: VoiceState, device: &str) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cancelled_capture_keeps_pending_output_visible() {
+        assert_eq!(active_state(true, 2), VoiceState::Dictating);
+        assert_eq!(active_state(false, 2), VoiceState::Transcribing);
+        assert_eq!(active_state(false, 1), VoiceState::Transcribing);
+        assert_eq!(active_state(false, 0), VoiceState::Listening);
+        assert_eq!(active_state(true, 0), VoiceState::Dictating);
+    }
 
     #[test]
     fn output_guard_cancels_and_joins_even_on_listener_error() {

--- a/src/linux_input.rs
+++ b/src/linux_input.rs
@@ -10,7 +10,10 @@ use x11rb::protocol::Event;
 use x11rb::protocol::xproto::{ConnectionExt, GrabMode, ModMask, Window};
 use x11rb::rust_connection::RustConnection;
 
+use crate::linux_session::LinuxSession;
 use crate::linux_settings::LinuxHotkey;
+
+pub(crate) use crate::linux_wayland_input::{capture_wayland_binding, wayland_modifiers_held};
 
 const XK_SPACE: u32 = 0x20;
 const XK_ESCAPE: u32 = 0xff1b;
@@ -18,7 +21,7 @@ pub(crate) const XK_ALT_L: u32 = 0xffe9;
 pub(crate) const XK_ALT_R: u32 = 0xffea;
 const XK_NUM_LOCK: u32 = 0xff7f;
 const RELEASE_GRACE: Duration = Duration::from_millis(50);
-const DOUBLE_TAP_WINDOW: Duration = Duration::from_millis(300);
+pub(crate) const DOUBLE_TAP_WINDOW: Duration = Duration::from_millis(300);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum HotkeyEvent {
@@ -27,15 +30,23 @@ pub enum HotkeyEvent {
     Cancel,
 }
 
-pub struct X11HotkeyMonitor {
+pub struct LinuxHotkeyMonitor {
     pub events: Receiver<HotkeyEvent>,
     pub errors: Receiver<String>,
     stop: Arc<AtomicBool>,
     worker: Option<JoinHandle<()>>,
 }
 
-impl X11HotkeyMonitor {
+impl LinuxHotkeyMonitor {
     pub fn start(binding: LinuxHotkey, double_tap_enabled: bool) -> Result<Self> {
+        Self::start_for(binding, double_tap_enabled, LinuxSession::detect())
+    }
+
+    fn start_for(
+        binding: LinuxHotkey,
+        double_tap_enabled: bool,
+        session: LinuxSession,
+    ) -> Result<Self> {
         let (events_sender, events) = mpsc::sync_channel(16);
         let (error_sender, errors) = mpsc::channel();
         let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
@@ -44,7 +55,11 @@ impl X11HotkeyMonitor {
         let worker_stop = stop.clone();
         let worker_started = started.clone();
         let worker = thread::spawn(move || {
-            let result = run(
+            let run_backend = match session {
+                LinuxSession::X11 => run,
+                LinuxSession::Wayland => crate::linux_wayland_input::run,
+            };
+            let result = run_backend(
                 events_sender,
                 worker_stop,
                 ready_sender.clone(),
@@ -57,23 +72,25 @@ impl X11HotkeyMonitor {
                 if worker_started.load(Ordering::Acquire) {
                     let _ = error_sender.send(message);
                 } else {
-                    let _ = ready_sender.send(Err(eyre!(message)));
+                    let _ = ready_sender.try_send(Err(eyre!(message)));
                 }
             }
         });
-        ready_receiver
-            .recv_timeout(Duration::from_secs(2))
-            .map_err(|_| eyre!("timed out registering Alt+Space with X11"))??;
-        Ok(Self {
+        // Own the worker before waiting so every startup failure stops and joins it.
+        let monitor = Self {
             events,
             errors,
             stop,
             worker: Some(worker),
-        })
+        };
+        ready_receiver
+            .recv_timeout(Duration::from_secs(2))
+            .map_err(|_| eyre!("timed out registering the Linux dictation shortcut"))??;
+        Ok(monitor)
     }
 }
 
-impl Drop for X11HotkeyMonitor {
+impl Drop for LinuxHotkeyMonitor {
     fn drop(&mut self) {
         self.stop.store(true, Ordering::Release);
         if let Some(worker) = self.worker.take() {
@@ -108,8 +125,8 @@ fn run(
         )
     })?;
     connection.flush()?;
-    ready.send(Ok(())).ok();
     started.store(true, Ordering::Release);
+    ready.try_send(Ok(())).ok();
 
     let mut active = false;
     let mut second_tap = false;
@@ -209,10 +226,10 @@ fn run(
     Ok(())
 }
 
-fn send_event(sender: &SyncSender<HotkeyEvent>, event: HotkeyEvent) -> Result<bool> {
+pub(crate) fn send_event(sender: &SyncSender<HotkeyEvent>, event: HotkeyEvent) -> Result<bool> {
     match sender.try_send(event) {
         Ok(()) => Ok(true),
-        Err(TrySendError::Full(_)) => Err(eyre!("X11 hotkey event queue overflow")),
+        Err(TrySendError::Full(_)) => Err(eyre!("Linux hotkey event queue overflow")),
         Err(TrySendError::Disconnected(_)) => Ok(false),
     }
 }
@@ -374,12 +391,46 @@ mod tests {
     }
 
     #[test]
+    fn full_event_queue_returns_an_error_instead_of_blocking_the_worker() {
+        let (sender, receiver) = mpsc::sync_channel(1);
+        assert!(send_event(&sender, HotkeyEvent::Start).unwrap());
+        assert!(send_event(&sender, HotkeyEvent::Finish).is_err());
+        assert_eq!(receiver.try_recv().unwrap(), HotkeyEvent::Start);
+        drop(receiver);
+        assert!(!send_event(&sender, HotkeyEvent::Cancel).unwrap());
+    }
+
+    #[test]
+    fn dropping_a_monitor_stops_and_joins_its_worker() {
+        let (_, events) = mpsc::sync_channel(1);
+        let (_, errors) = mpsc::channel();
+        let stop = Arc::new(AtomicBool::new(false));
+        let stopped = Arc::new(AtomicBool::new(false));
+        let worker_stop = stop.clone();
+        let worker_stopped = stopped.clone();
+        let worker = thread::spawn(move || {
+            while !worker_stop.load(Ordering::Acquire) {
+                thread::yield_now();
+            }
+            worker_stopped.store(true, Ordering::Release);
+        });
+        drop(LinuxHotkeyMonitor {
+            events,
+            errors,
+            stop,
+            worker: Some(worker),
+        });
+        assert!(stopped.load(Ordering::Acquire));
+    }
+
+    #[test]
     #[ignore = "requires the active X11 desktop"]
     fn grabbed_alt_space_delivers_press_and_release() {
         let _guard = X11_TEST_LOCK
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        let monitor = X11HotkeyMonitor::start(LinuxHotkey::default(), true).unwrap();
+        let monitor =
+            LinuxHotkeyMonitor::start_for(LinuxHotkey::default(), true, LinuxSession::X11).unwrap();
         let (connection, screen) = RustConnection::connect(None).unwrap();
         let root = connection.setup().roots[screen].root;
         let keymap = Keymap::read(&connection).unwrap();
@@ -409,7 +460,8 @@ mod tests {
         let _guard = X11_TEST_LOCK
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        let monitor = X11HotkeyMonitor::start(LinuxHotkey::default(), true).unwrap();
+        let monitor =
+            LinuxHotkeyMonitor::start_for(LinuxHotkey::default(), true, LinuxSession::X11).unwrap();
         let (connection, screen) = RustConnection::connect(None).unwrap();
         let root = connection.setup().roots[screen].root;
         let keymap = Keymap::read(&connection).unwrap();
@@ -460,7 +512,7 @@ mod tests {
             key: "f24".into(),
             ..LinuxHotkey::default()
         };
-        let monitor = X11HotkeyMonitor::start(binding, false).unwrap();
+        let monitor = LinuxHotkeyMonitor::start_for(binding, false, LinuxSession::X11).unwrap();
         let (connection, screen) = RustConnection::connect(None).unwrap();
         let root = connection.setup().roots[screen].root;
         let trigger = Keymap::read(&connection)

--- a/src/linux_paste.rs
+++ b/src/linux_paste.rs
@@ -1,3 +1,9 @@
+use std::io::{ErrorKind, Write};
+use std::os::fd::AsRawFd;
+use std::os::unix::process::CommandExt;
+use std::process::{Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -9,14 +15,73 @@ use x11rb::protocol::xtest;
 use x11rb::rust_connection::RustConnection;
 
 use crate::linux_input::Keymap;
+use crate::linux_session::LinuxSession;
 
 const XK_CONTROL_L: u32 = 0xffe3;
 const XK_SHIFT_L: u32 = 0xffe1;
 const XK_V: u32 = 0x76;
 const KEY_PRESS: u8 = 2;
 const KEY_RELEASE: u8 = 3;
+const HELPER_TIMEOUT: Duration = Duration::from_secs(3);
+const PASTE_SETTLE: Duration = Duration::from_millis(100);
 
-pub struct X11Paster {
+pub struct LinuxPaster {
+    backend: Backend,
+    stop: Arc<AtomicBool>,
+    paste_with_shift: bool,
+}
+
+enum Backend {
+    X11(Box<X11Paster>),
+    Wayland,
+}
+
+impl LinuxPaster {
+    pub fn new(stop: Arc<AtomicBool>, paste_with_shift: bool) -> Result<Self> {
+        let backend = match LinuxSession::detect() {
+            LinuxSession::X11 => Backend::X11(Box::new(X11Paster::new()?)),
+            LinuxSession::Wayland => Backend::Wayland,
+        };
+        Ok(Self {
+            backend,
+            stop,
+            paste_with_shift,
+        })
+    }
+
+    pub fn paste(&mut self, text: &str) -> Result<()> {
+        if text.trim().is_empty() {
+            return Err(eyre!("refusing to paste an empty transcript"));
+        }
+        match &mut self.backend {
+            Backend::X11(paster) => paster.paste(text, &self.stop, self.paste_with_shift)?,
+            Backend::Wayland => {
+                wait_for_modifiers(&self.stop, || {
+                    crate::linux_input::wayland_modifiers_held(&self.stop)
+                })?;
+                let mut copy = Command::new("wl-copy");
+                copy.args(["--type", "text/plain;charset=utf-8"]);
+                run_helper(copy, text.as_bytes(), &self.stop, HELPER_TIMEOUT)
+                    .wrap_err("could not own the Wayland clipboard; install wl-clipboard and check compositor support")?;
+                // wl-copy's parent exits only after the selection is installed.
+                // Never read a pipe inherited by its clipboard-serving daemon.
+                wait_for_modifiers(&self.stop, || {
+                    crate::linux_input::wayland_modifiers_held(&self.stop)
+                })?;
+                let mut keys = Command::new("wtype");
+                keys.args(paste_keys(self.paste_with_shift));
+                run_helper(keys, &[], &self.stop, HELPER_TIMEOUT)
+                    .wrap_err("could not send the Wayland paste shortcut; install wtype and use a compositor supporting virtual keyboards")?;
+            }
+        }
+        // Give the target time to request the selection before the next queued
+        // transcript replaces it. This is a bounded settling policy, not an ACK.
+        thread::sleep(PASTE_SETTLE);
+        Ok(())
+    }
+}
+
+struct X11Paster {
     clipboard: Clipboard,
     connection: RustConnection,
     root: u32,
@@ -42,11 +107,8 @@ impl X11Paster {
         })
     }
 
-    pub fn paste(&mut self, text: &str) -> Result<()> {
-        if text.trim().is_empty() {
-            return Err(eyre!("refusing to paste an empty transcript"));
-        }
-        self.wait_for_modifier_release()?;
+    fn paste(&mut self, text: &str, stop: &AtomicBool, paste_with_shift: bool) -> Result<()> {
+        self.wait_for_modifier_release(stop)?;
         let atoms = &self.clipboard.getter.atoms;
         self.clipboard
             .store(atoms.clipboard, atoms.utf8_string, text.as_bytes())
@@ -60,25 +122,284 @@ impl X11Paster {
             (KEY_RELEASE, self.shift),
             (KEY_RELEASE, self.control),
         ] {
+            if key == self.shift && !paste_with_shift {
+                continue;
+            }
             xtest::fake_input(&self.connection, type_, key, 0, self.root, 0, 0, 0)?.check()?;
         }
         self.connection.flush()?;
         Ok(())
     }
 
-    fn wait_for_modifier_release(&self) -> Result<()> {
-        let deadline = Instant::now() + Duration::from_millis(500);
-        while Instant::now() < deadline {
+    fn wait_for_modifier_release(&self, stop: &AtomicBool) -> Result<()> {
+        wait_for_modifiers(stop, || {
             let mask = self.connection.query_pointer(self.root)?.reply()?.mask;
             let held = mask
                 & (KeyButMask::SHIFT | KeyButMask::CONTROL | KeyButMask::MOD1 | KeyButMask::MOD4);
-            if held == KeyButMask::default() {
-                return Ok(());
+            Ok(held != KeyButMask::default())
+        })
+    }
+}
+
+fn paste_keys(with_shift: bool) -> &'static [&'static str] {
+    // GTK 3's reverse keymap lookup skips the final keycode. Keep V before a
+    // neutral VoidSymbol release so its shortcut remains discoverable (#28).
+    if with_shift {
+        &[
+            "-M",
+            "ctrl",
+            "-M",
+            "shift",
+            "-k",
+            "v",
+            "-m",
+            "shift",
+            "-m",
+            "ctrl",
+            "-p",
+            "VoidSymbol",
+        ]
+    } else {
+        &["-M", "ctrl", "-k", "v", "-m", "ctrl", "-p", "VoidSymbol"]
+    }
+}
+
+fn wait_for_modifiers(stop: &AtomicBool, mut held: impl FnMut() -> Result<bool>) -> Result<()> {
+    loop {
+        if stop.load(Ordering::Acquire) {
+            return Err(eyre!("paste cancelled while stopping the listener"));
+        }
+        if !held()? {
+            return Ok(());
+        }
+        // Another capture may own these modifiers. Keep its predecessor queued
+        // instead of throwing away accepted output after an arbitrary timeout.
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn run_helper(
+    mut command: Command,
+    input: &[u8],
+    stop: &AtomicBool,
+    timeout: Duration,
+) -> Result<()> {
+    if stop.load(Ordering::Acquire) {
+        return Err(eyre!("paste cancelled before starting a helper"));
+    }
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .process_group(0)
+        .spawn()
+        .wrap_err("could not start the paste helper")?;
+    let process_group = child.id();
+    let result = (|| {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| eyre!("missing helper stdin"))?;
+        let fd = stdin.as_raw_fd();
+        // Nonblocking writes keep a stalled helper from bypassing cancellation
+        // or the deadline when a long transcript fills its stdin pipe.
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+        let deadline = Instant::now() + timeout;
+        let mut remaining = input;
+        while !remaining.is_empty() {
+            if stop.load(Ordering::Acquire) || Instant::now() >= deadline {
+                return Err(eyre!("paste helper cancelled or timed out"));
+            }
+            match stdin.write(remaining) {
+                Ok(0) => return Err(eyre!("paste helper stopped reading its input")),
+                Ok(written) => remaining = &remaining[written..],
+                Err(error) if error.kind() == ErrorKind::Interrupted => continue,
+                Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+        drop(stdin);
+        loop {
+            if stop.load(Ordering::Acquire) || Instant::now() >= deadline {
+                return Err(eyre!("paste helper cancelled or timed out"));
+            }
+            if let Some(status) = child.try_wait()? {
+                return if status.success() {
+                    Ok(())
+                } else {
+                    Err(eyre!("paste helper failed with {status}"))
+                };
             }
             thread::sleep(Duration::from_millis(10));
         }
-        Err(eyre!(
-            "release the dictation shortcut before HEX inserts the transcript"
-        ))
+    })();
+    if result.is_err() {
+        // Terminate descendants too: a failed wl-copy must not claim the
+        // clipboard later, after this request has been reported as cancelled.
+        unsafe { libc::kill(-(process_group as i32), libc::SIGKILL) };
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shell(script: &str) -> Command {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", script]);
+        command
+    }
+
+    #[test]
+    fn helper_failure_is_not_reported_as_a_successful_paste() {
+        assert!(
+            run_helper(
+                shell("exit 7"),
+                &[],
+                &AtomicBool::new(false),
+                HELPER_TIMEOUT
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn standard_and_terminal_paste_balance_their_modifiers() {
+        assert_eq!(
+            paste_keys(false),
+            ["-M", "ctrl", "-k", "v", "-m", "ctrl", "-p", "VoidSymbol"]
+        );
+        assert_eq!(
+            paste_keys(true),
+            [
+                "-M",
+                "ctrl",
+                "-M",
+                "shift",
+                "-k",
+                "v",
+                "-m",
+                "shift",
+                "-m",
+                "ctrl",
+                "-p",
+                "VoidSymbol"
+            ]
+        );
+    }
+
+    #[test]
+    fn helper_can_read_a_large_transcript_without_argv_or_files() {
+        let text = b"--help\nplain text\n".repeat(32_768);
+        let mut command = shell("test \"$(wc -c)\" -eq \"$1\"");
+        command.args(["hex-paste-test", &text.len().to_string()]);
+        assert!(run_helper(command, &text, &AtomicBool::new(false), HELPER_TIMEOUT).is_ok());
+    }
+
+    #[test]
+    fn helper_timeout_includes_a_full_stdin_pipe() {
+        let start = Instant::now();
+        assert!(
+            run_helper(
+                shell("sleep 10"),
+                &vec![b'x'; 1_048_576],
+                &AtomicBool::new(false),
+                Duration::from_millis(100),
+            )
+            .is_err()
+        );
+        assert!(start.elapsed() < Duration::from_secs(3));
+    }
+
+    #[test]
+    fn stop_cancels_a_helper_that_never_finishes() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let cancel = stop.clone();
+        let worker = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(50));
+            cancel.store(true, Ordering::Release);
+        });
+        let start = Instant::now();
+        let result = run_helper(shell("sleep 10"), &[], &stop, HELPER_TIMEOUT);
+        worker.join().unwrap();
+        assert!(result.is_err());
+        assert!(start.elapsed() < Duration::from_secs(3));
+    }
+
+    #[test]
+    fn a_clipboard_daemon_inheriting_stderr_does_not_block_parent_completion() {
+        let path = std::env::temp_dir().join(format!("hex-paste-daemon-{}", std::process::id()));
+        let mut command = shell("cat >/dev/null; sleep 10 >&2 & echo $! >\"$1\"");
+        command.arg("hex-paste-test").arg(&path);
+        let result = run_helper(
+            command,
+            b"example",
+            &AtomicBool::new(false),
+            Duration::from_secs(2),
+        );
+        if let Ok(pid) = std::fs::read_to_string(&path) {
+            if let Ok(pid) = pid.trim().parse::<i32>() {
+                unsafe { libc::kill(pid, libc::SIGKILL) };
+            }
+            let _ = std::fs::remove_file(path);
+        }
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn accepted_output_waits_through_another_capture() {
+        let start = Instant::now();
+        let mut checks = 0;
+        wait_for_modifiers(&AtomicBool::new(false), || {
+            checks += 1;
+            Ok(start.elapsed() < Duration::from_millis(550))
+        })
+        .unwrap();
+        assert!(checks > 1);
+    }
+
+    #[test]
+    fn stopping_breaks_the_modifier_wait_without_checking_the_keyboard() {
+        assert!(
+            wait_for_modifiers(&AtomicBool::new(true), || panic!("should not read devices"))
+                .is_err()
+        );
+        assert!(run_helper(shell("exit 0"), &[], &AtomicBool::new(true), HELPER_TIMEOUT).is_err());
+    }
+
+    #[test]
+    #[ignore = "run scripts/test-wayland-paste.sh with the compiled test executable"]
+    fn native_wayland_clipboard_shortcut() {
+        assert!(LinuxSession::detect().is_wayland());
+        let path = std::env::var_os("HEX_WAYLAND_PASTE_OUTPUT")
+            .expect("the isolated Wayland test runner must supply its output file");
+        let expected = "Example dictation: --flags, punctuation, \u{6f22}\u{5b57}.\nSecond line.";
+        let stop = AtomicBool::new(false);
+        let mut copy = Command::new("wl-copy");
+        copy.args(["--type", "text/plain;charset=utf-8"]);
+        run_helper(copy, expected.as_bytes(), &stop, HELPER_TIMEOUT).unwrap();
+        let mut keys = Command::new("wtype");
+        keys.args(paste_keys(false));
+        run_helper(keys, &[], &stop, HELPER_TIMEOUT).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            let actual = std::fs::read_to_string(&path).unwrap_or_default();
+            if actual == expected {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "GTK did not receive the transcript: {actual:?}"
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
     }
 }

--- a/src/linux_session.rs
+++ b/src/linux_session.rs
@@ -1,0 +1,54 @@
+use std::ffi::OsStr;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LinuxSession {
+    X11,
+    Wayland,
+}
+
+impl LinuxSession {
+    pub fn detect() -> Self {
+        Self::from_wayland_display(std::env::var_os("WAYLAND_DISPLAY").as_deref())
+    }
+
+    fn from_wayland_display(display: Option<&OsStr>) -> Self {
+        // Match GPUI's backend selection, including Wayland with XWayland present.
+        if display.is_some_and(|display| !display.is_empty()) {
+            Self::Wayland
+        } else {
+            Self::X11
+        }
+    }
+
+    pub fn is_wayland(self) -> bool {
+        self == Self::Wayland
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::X11 => "x11",
+            Self::Wayland => "wayland",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_selection_matches_gpui_without_mutating_the_environment() {
+        for display in [None, Some(OsStr::new(""))] {
+            assert_eq!(
+                LinuxSession::from_wayland_display(display),
+                LinuxSession::X11
+            );
+        }
+        for display in ["wayland-0", "/run/user/1000/wayland-1"] {
+            assert_eq!(
+                LinuxSession::from_wayland_display(Some(OsStr::new(display))),
+                LinuxSession::Wayland
+            );
+        }
+    }
+}

--- a/src/linux_settings.rs
+++ b/src/linux_settings.rs
@@ -13,9 +13,10 @@ use crate::linux_input::{Keymap, XK_ALT_L, XK_ALT_R};
 #[serde(default)]
 pub struct LinuxSettings {
     pub schema_version: u32,
-    pub platform: String,
     pub dictation_hotkey: LinuxHotkey,
     pub double_tap_lock: bool,
+    #[serde(default = "legacy_paste_with_shift")]
+    pub paste_with_shift: bool,
     pub transcription: crate::transcription_models::TranscriptionSelection,
 }
 
@@ -33,12 +34,17 @@ impl Default for LinuxSettings {
     fn default() -> Self {
         Self {
             schema_version: 1,
-            platform: "x11".into(),
             dictation_hotkey: LinuxHotkey::default(),
             double_tap_lock: true,
+            paste_with_shift: false,
             transcription: crate::transcription_models::TranscriptionSelection::default(),
         }
     }
+}
+
+fn legacy_paste_with_shift() -> bool {
+    // Existing X11 settings predate this preference and always used Ctrl-Shift-V.
+    true
 }
 
 impl Default for LinuxHotkey {
@@ -61,12 +67,6 @@ impl LinuxSettings {
         }
         let settings: Self = serde_json::from_slice(&fs::read(&path)?)
             .wrap_err_with(|| format!("could not parse {}", path.display()))?;
-        if settings.platform != "x11" {
-            return Err(eyre!(
-                "unsupported Linux settings platform: {}",
-                settings.platform
-            ));
-        }
         settings.dictation_hotkey.validate()?;
         crate::transcription_models::validate(&settings.transcription)?;
         Ok(settings)
@@ -202,5 +202,33 @@ mod tests {
             settings.transcription,
             crate::transcription_models::TranscriptionSelection::default()
         );
+    }
+
+    #[test]
+    fn legacy_settings_are_shared_between_display_sessions() {
+        let legacy = r#"{"platform":"x11","double_tap_lock":false}"#;
+        let settings: LinuxSettings = serde_json::from_str(legacy).unwrap();
+        assert!(!settings.double_tap_lock);
+        assert!(settings.paste_with_shift);
+        // Display selection is runtime state, not a preference that survives logout.
+        let saved = serde_json::to_value(&settings).unwrap();
+        assert!(saved.get("platform").is_none());
+        assert_eq!(
+            serde_json::from_value::<LinuxSettings>(saved).unwrap(),
+            settings
+        );
+    }
+
+    #[test]
+    fn fresh_settings_use_standard_paste_and_preserve_an_explicit_choice() {
+        let settings = LinuxSettings::default();
+        assert!(!settings.paste_with_shift);
+        let saved = serde_json::to_value(&settings).unwrap();
+        assert_eq!(
+            serde_json::from_value::<LinuxSettings>(saved).unwrap(),
+            settings
+        );
+        let legacy: LinuxSettings = serde_json::from_str(r#"{"paste_with_shift":false}"#).unwrap();
+        assert!(!legacy.paste_with_shift);
     }
 }

--- a/src/linux_wayland_input.rs
+++ b/src/linux_wayland_input.rs
@@ -1,0 +1,1076 @@
+use std::collections::{HashMap, HashSet};
+use std::fs::{self, OpenOptions};
+use std::io::ErrorKind;
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::SyncSender;
+use std::thread;
+use std::time::{Duration, Instant, SystemTime};
+
+use color_eyre::eyre::{Result, WrapErr, eyre};
+use evdev::raw_stream::RawDevice;
+use evdev::{EventType, KeyCode, SynchronizationCode};
+
+use crate::linux_input::{DOUBLE_TAP_WINDOW, HotkeyEvent, send_event};
+use crate::linux_session::LinuxSession;
+use crate::linux_settings::LinuxHotkey;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(5);
+const RESCAN_INTERVAL: Duration = Duration::from_secs(1);
+
+// Physical evdev keys, not layout-dependent characters. Use this same table in both directions.
+const KEYS: &[(&str, KeyCode)] = &[
+    ("space", KeyCode::KEY_SPACE),
+    ("enter", KeyCode::KEY_ENTER),
+    ("tab", KeyCode::KEY_TAB),
+    ("backspace", KeyCode::KEY_BACKSPACE),
+    ("a", KeyCode::KEY_A),
+    ("b", KeyCode::KEY_B),
+    ("c", KeyCode::KEY_C),
+    ("d", KeyCode::KEY_D),
+    ("e", KeyCode::KEY_E),
+    ("f", KeyCode::KEY_F),
+    ("g", KeyCode::KEY_G),
+    ("h", KeyCode::KEY_H),
+    ("i", KeyCode::KEY_I),
+    ("j", KeyCode::KEY_J),
+    ("k", KeyCode::KEY_K),
+    ("l", KeyCode::KEY_L),
+    ("m", KeyCode::KEY_M),
+    ("n", KeyCode::KEY_N),
+    ("o", KeyCode::KEY_O),
+    ("p", KeyCode::KEY_P),
+    ("q", KeyCode::KEY_Q),
+    ("r", KeyCode::KEY_R),
+    ("s", KeyCode::KEY_S),
+    ("t", KeyCode::KEY_T),
+    ("u", KeyCode::KEY_U),
+    ("v", KeyCode::KEY_V),
+    ("w", KeyCode::KEY_W),
+    ("x", KeyCode::KEY_X),
+    ("y", KeyCode::KEY_Y),
+    ("z", KeyCode::KEY_Z),
+    ("0", KeyCode::KEY_0),
+    ("1", KeyCode::KEY_1),
+    ("2", KeyCode::KEY_2),
+    ("3", KeyCode::KEY_3),
+    ("4", KeyCode::KEY_4),
+    ("5", KeyCode::KEY_5),
+    ("6", KeyCode::KEY_6),
+    ("7", KeyCode::KEY_7),
+    ("8", KeyCode::KEY_8),
+    ("9", KeyCode::KEY_9),
+    ("f1", KeyCode::KEY_F1),
+    ("f2", KeyCode::KEY_F2),
+    ("f3", KeyCode::KEY_F3),
+    ("f4", KeyCode::KEY_F4),
+    ("f5", KeyCode::KEY_F5),
+    ("f6", KeyCode::KEY_F6),
+    ("f7", KeyCode::KEY_F7),
+    ("f8", KeyCode::KEY_F8),
+    ("f9", KeyCode::KEY_F9),
+    ("f10", KeyCode::KEY_F10),
+    ("f11", KeyCode::KEY_F11),
+    ("f12", KeyCode::KEY_F12),
+    ("f13", KeyCode::KEY_F13),
+    ("f14", KeyCode::KEY_F14),
+    ("f15", KeyCode::KEY_F15),
+    ("f16", KeyCode::KEY_F16),
+    ("f17", KeyCode::KEY_F17),
+    ("f18", KeyCode::KEY_F18),
+    ("f19", KeyCode::KEY_F19),
+    ("f20", KeyCode::KEY_F20),
+    ("f21", KeyCode::KEY_F21),
+    ("f22", KeyCode::KEY_F22),
+    ("f23", KeyCode::KEY_F23),
+    ("f24", KeyCode::KEY_F24),
+    ("-", KeyCode::KEY_MINUS),
+    ("=", KeyCode::KEY_EQUAL),
+    ("[", KeyCode::KEY_LEFTBRACE),
+    ("]", KeyCode::KEY_RIGHTBRACE),
+    (";", KeyCode::KEY_SEMICOLON),
+    ("'", KeyCode::KEY_APOSTROPHE),
+    ("`", KeyCode::KEY_GRAVE),
+    ("\\", KeyCode::KEY_BACKSLASH),
+    (",", KeyCode::KEY_COMMA),
+    (".", KeyCode::KEY_DOT),
+    ("/", KeyCode::KEY_SLASH),
+];
+
+const MODIFIERS: [[KeyCode; 2]; 4] = [
+    [KeyCode::KEY_LEFTCTRL, KeyCode::KEY_RIGHTCTRL],
+    [KeyCode::KEY_LEFTALT, KeyCode::KEY_RIGHTALT],
+    [KeyCode::KEY_LEFTSHIFT, KeyCode::KEY_RIGHTSHIFT],
+    [KeyCode::KEY_LEFTMETA, KeyCode::KEY_RIGHTMETA],
+];
+
+fn key_code(name: &str) -> Result<KeyCode> {
+    let name = name.to_ascii_lowercase();
+    let name = if name == "return" { "enter" } else { &name };
+    KEYS.iter()
+        .find_map(|(key, code)| (*key == name).then_some(*code))
+        .ok_or_else(|| eyre!("unsupported Wayland physical hotkey key: {name}"))
+}
+
+enum Input {
+    Connected(PathBuf, HashSet<KeyCode>),
+    Disconnected(PathBuf),
+    Key(PathBuf, KeyCode, i32),
+}
+
+#[derive(Default)]
+struct Pressed(HashMap<PathBuf, HashSet<KeyCode>>);
+
+impl Pressed {
+    fn contains(&self, key: KeyCode) -> bool {
+        self.0.values().any(|keys| keys.contains(&key))
+    }
+
+    fn modifiers(&self) -> [bool; 4] {
+        MODIFIERS.map(|pair| pair.into_iter().any(|key| self.contains(key)))
+    }
+
+    // Emit only aggregate edges: a key stays down until every keyboard releases it.
+    fn update(&mut self, input: Input) -> Option<(KeyCode, bool)> {
+        match input {
+            Input::Connected(path, keys) => {
+                self.0.insert(path, keys);
+            }
+            Input::Disconnected(path) => {
+                self.0.remove(&path);
+            }
+            Input::Key(path, key, value @ (0 | 1)) => {
+                let before = self.contains(key);
+                let keys = self.0.get_mut(&path)?;
+                if value == 1 {
+                    keys.insert(key);
+                } else {
+                    keys.remove(&key);
+                }
+                let after = self.contains(key);
+                return (before != after).then_some((key, after));
+            }
+            Input::Key(..) => {}
+        }
+        None
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Capture {
+    Idle,
+    Held { second_tap: bool },
+    Locked,
+}
+
+struct HotkeyState {
+    pressed: Pressed,
+    trigger: KeyCode,
+    required: [bool; 4],
+    double_tap: bool,
+    capture: Capture,
+    last_release: Option<Instant>,
+}
+
+impl HotkeyState {
+    fn new(binding: &LinuxHotkey, double_tap: bool) -> Result<Self> {
+        Ok(Self {
+            pressed: Pressed::default(),
+            trigger: key_code(&binding.key)?,
+            required: [
+                binding.control,
+                binding.alt,
+                binding.shift,
+                binding.super_key,
+            ],
+            double_tap,
+            capture: Capture::Idle,
+            last_release: None,
+        })
+    }
+
+    fn cancel(&mut self) -> Option<HotkeyEvent> {
+        let active = self.capture != Capture::Idle;
+        self.capture = Capture::Idle;
+        self.last_release = None;
+        active.then_some(HotkeyEvent::Cancel)
+    }
+
+    fn update(&mut self, input: Input, now: Instant) -> Option<HotkeyEvent> {
+        if matches!(input, Input::Connected(..) | Input::Disconnected(..)) {
+            self.pressed.update(input);
+            // Never infer presses or releases from a device snapshot or lost event stream.
+            return self.cancel();
+        }
+        let (key, down) = self.pressed.update(input)?;
+        if key == KeyCode::KEY_ESC && down {
+            return self.cancel();
+        }
+        let modifiers = self.pressed.modifiers();
+        if let Capture::Held { second_tap } = self.capture {
+            if modifiers
+                .iter()
+                .zip(self.required)
+                .any(|(held, required)| *held && !required)
+            {
+                return self.cancel();
+            }
+            // Releasing a required modifier first ends the hold just like releasing the trigger.
+            if !self.pressed.contains(self.trigger) || modifiers != self.required {
+                if second_tap {
+                    self.capture = Capture::Locked;
+                    self.last_release = None;
+                    return None;
+                }
+                self.capture = Capture::Idle;
+                self.last_release = self.double_tap.then_some(now);
+                return Some(HotkeyEvent::Finish);
+            }
+        }
+        if key != self.trigger || !down {
+            return None;
+        }
+        if modifiers != self.required || self.pressed.contains(KeyCode::KEY_ESC) {
+            self.last_release = None;
+            return None;
+        }
+        match self.capture {
+            Capture::Locked => {
+                self.capture = Capture::Idle;
+                self.last_release = None;
+                Some(HotkeyEvent::Finish)
+            }
+            Capture::Idle => {
+                let second_tap = self.last_release.take().is_some_and(|released| {
+                    now.checked_duration_since(released)
+                        .is_some_and(|gap| gap < DOUBLE_TAP_WINDOW)
+                });
+                self.capture = Capture::Held { second_tap };
+                Some(HotkeyEvent::Start)
+            }
+            Capture::Held { .. } => None,
+        }
+    }
+
+    fn dispatch(
+        &mut self,
+        batch: Result<Vec<(Instant, Input)>>,
+        sender: &SyncSender<HotkeyEvent>,
+        stop: &AtomicBool,
+    ) -> Result<bool> {
+        let inputs = match batch {
+            Ok(inputs) => inputs,
+            Err(error) => {
+                if let Some(event) = self.cancel() {
+                    let _ = send_event(sender, event);
+                }
+                return Err(error);
+            }
+        };
+        for (at, input) in inputs {
+            if stop.load(Ordering::Acquire) {
+                return Ok(false);
+            }
+            if let Some(event) = self.update(input, at)
+                && !send_event(sender, event)?
+            {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+}
+
+struct EventClock {
+    monotonic: Duration,
+    instant: Instant,
+}
+
+impl EventClock {
+    fn new() -> Result<Self> {
+        let instant = Instant::now();
+        let mut time = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        // Sample the same clock selected on every evdev descriptor, once per monitor.
+        if unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut time) } < 0 {
+            return Err(std::io::Error::last_os_error())
+                .wrap_err("could not read the input event clock");
+        }
+        Ok(Self {
+            monotonic: Duration::new(time.tv_sec as u64, time.tv_nsec as u32),
+            instant,
+        })
+    }
+
+    fn at(&self, timestamp: SystemTime) -> Result<Instant> {
+        // evdev wraps timeval in SystemTime even when EVIOCSCLOCKID selects monotonic time.
+        let time = timestamp.duration_since(SystemTime::UNIX_EPOCH)?;
+        if time >= self.monotonic {
+            self.instant.checked_add(time - self.monotonic)
+        } else {
+            self.instant.checked_sub(self.monotonic - time)
+        }
+        .ok_or_else(|| eyre!("input event timestamp is outside the monotonic clock range"))
+    }
+}
+
+fn check_device_error(path: &Path, error: std::io::Error) -> Result<()> {
+    if matches!(error.raw_os_error(), Some(libc::ENOENT | libc::ENODEV)) {
+        return Ok(());
+    }
+    Err(error).wrap_err_with(|| format!(
+        "Wayland input requires read access to every /dev/input/event* node to check modifier state safely; could not inspect {}. An unreadable device cannot be classified as a keyboard or ruled out. Configure system input permissions (often the input group); this grants access to all keystrokes, not just HEX shortcuts",
+        path.display()
+    ))
+}
+
+struct Keyboard {
+    path: PathBuf,
+    device: RawDevice,
+}
+
+struct Keyboards {
+    devices: Vec<Keyboard>,
+    next_scan: Instant,
+    clock: EventClock,
+}
+
+impl Keyboards {
+    fn open(stop: &AtomicBool) -> Result<(Self, Vec<Input>)> {
+        if stop.load(Ordering::Acquire) {
+            return Err(eyre!("keyboard monitoring canceled"));
+        }
+        let mut keyboards = Self {
+            devices: Vec::new(),
+            next_scan: Instant::now(),
+            clock: EventClock::new()?,
+        };
+        let initial = keyboards.scan(stop)?;
+        if stop.load(Ordering::Acquire) {
+            return Err(eyre!("keyboard monitoring canceled"));
+        }
+        if keyboards.devices.is_empty() {
+            return Err(eyre!(
+                "no keyboard event devices with supported shortcut keys found in /dev/input"
+            ));
+        }
+        Ok((keyboards, initial))
+    }
+
+    fn scan(&mut self, stop: &AtomicBool) -> Result<Vec<Input>> {
+        self.next_scan = Instant::now() + RESCAN_INTERVAL;
+        let mut connected = Vec::new();
+        let directory = Path::new("/dev/input");
+        let entries = match fs::read_dir(directory) {
+            Ok(entries) => entries,
+            Err(error) => {
+                check_device_error(directory, error)?;
+                return Ok(connected);
+            }
+        };
+        for entry in entries {
+            if stop.load(Ordering::Acquire) {
+                break;
+            }
+            let path = match entry {
+                Ok(entry) => entry.path(),
+                Err(error) => {
+                    check_device_error(directory, error)?;
+                    continue;
+                }
+            };
+            if !path
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with("event"))
+                || self.devices.iter().any(|keyboard| keyboard.path == path)
+            {
+                continue;
+            }
+            let opened = (|| -> std::io::Result<_> {
+                // Open read-only and nonblocking from the outset; never grab or inject input.
+                let file = OpenOptions::new()
+                    .read(true)
+                    .custom_flags(libc::O_NONBLOCK | libc::O_CLOEXEC)
+                    .open(&path)?;
+                let device = RawDevice::from_fd(file.into())?;
+                if !device.supported_keys().is_some_and(|keys| {
+                    keys.contains(KeyCode::KEY_ESC)
+                        || KEYS.iter().any(|(_, key)| keys.contains(*key))
+                        || MODIFIERS.iter().flatten().any(|key| keys.contains(*key))
+                }) {
+                    return Ok(None);
+                }
+                let clock = libc::CLOCK_MONOTONIC;
+                // EVIOCSCLOCKID takes a pointer to an int and changes only this reader's clock.
+                if unsafe {
+                    libc::ioctl(
+                        device.as_raw_fd(),
+                        libc::_IOW::<libc::c_int>(b'E'.into(), 0xa0),
+                        &clock,
+                    )
+                } < 0
+                {
+                    return Err(std::io::Error::last_os_error());
+                }
+                let pressed = device.get_key_state()?.iter().collect();
+                Ok(Some((device, pressed)))
+            })();
+            match opened {
+                Ok(Some((device, pressed))) => {
+                    connected.push(Input::Connected(path.clone(), pressed));
+                    self.devices.push(Keyboard { path, device });
+                }
+                Ok(None) => {}
+                Err(error) => check_device_error(&path, error)?,
+            }
+        }
+        Ok(connected)
+    }
+
+    fn poll(&mut self, stop: &AtomicBool) -> Result<Vec<(Instant, Input)>> {
+        let mut changes = Vec::new();
+        if Instant::now() >= self.next_scan {
+            changes.extend(self.scan(stop)?);
+        }
+        let mut pending = Vec::new();
+        self.devices.retain_mut(|keyboard| {
+            if stop.load(Ordering::Acquire) {
+                return true;
+            }
+            let events = match keyboard.device.fetch_events() {
+                Ok(events) => events.collect::<Vec<_>>(),
+                Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::Interrupted) => {
+                    return true;
+                }
+                Err(error) => {
+                    tracing::warn!(path = %keyboard.path.display(), %error, "keyboard disconnected; retrying discovery");
+                    changes.push(Input::Disconnected(keyboard.path.clone()));
+                    return false;
+                }
+            };
+            if events.iter().any(|event| {
+                event.event_type() == EventType::SYNCHRONIZATION
+                    && event.code() == SynchronizationCode::SYN_DROPPED.0
+            }) {
+                // Reopen instead of treating evdev's synthetic resync edges as real shortcuts.
+                tracing::warn!(path = %keyboard.path.display(), "keyboard events lost; canceling capture and reopening");
+                changes.push(Input::Disconnected(keyboard.path.clone()));
+                return false;
+            }
+            pending.extend(events.into_iter().filter(|event| event.event_type() == EventType::KEY)
+                .map(|event| (event.timestamp(), Input::Key(keyboard.path.clone(), KeyCode::new(event.code()), event.value()))));
+            true
+        });
+        // Modifiers may be on a different keyboard from the trigger.
+        pending.sort_by_key(|(time, _)| *time);
+        let now = Instant::now();
+        let mut inputs = changes
+            .into_iter()
+            .map(|input| (now, input))
+            .collect::<Vec<_>>();
+        for (time, input) in pending {
+            inputs.push((self.clock.at(time)?, input));
+        }
+        Ok(inputs)
+    }
+}
+
+pub(crate) fn run(
+    sender: SyncSender<HotkeyEvent>,
+    stop: Arc<AtomicBool>,
+    ready: SyncSender<Result<()>>,
+    binding: LinuxHotkey,
+    double_tap_enabled: bool,
+    started: Arc<AtomicBool>,
+) -> Result<()> {
+    let mut state = HotkeyState::new(&binding, double_tap_enabled)?;
+    let (mut keyboards, initial) = Keyboards::open(&stop)?;
+    for input in initial {
+        state.update(input, Instant::now());
+    }
+    started.store(true, Ordering::Release);
+    if stop.load(Ordering::Acquire) || ready.try_send(Ok(())).is_err() {
+        return Ok(());
+    }
+    while !stop.load(Ordering::Acquire) {
+        if !state.dispatch(keyboards.poll(&stop), &sender, &stop)? {
+            return Ok(());
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+    Ok(())
+}
+
+fn capture_binding(pressed: &mut Pressed, input: Input) -> Result<Option<LinuxHotkey>> {
+    if matches!(input, Input::Disconnected(..)) {
+        return Err(eyre!(
+            "keyboard disconnected or events were lost during shortcut capture; try again"
+        ));
+    }
+    let Some((key, true)) = pressed.update(input) else {
+        return Ok(None);
+    };
+    if key == KeyCode::KEY_ESC {
+        return Err(eyre!("shortcut capture canceled"));
+    }
+    let Some((name, _)) = KEYS.iter().find(|(_, code)| *code == key) else {
+        return Ok(None);
+    };
+    let [control, alt, shift, super_key] = pressed.modifiers();
+    Ok(Some(LinuxHotkey {
+        control,
+        alt,
+        shift,
+        super_key,
+        key: (*name).into(),
+    }))
+}
+
+pub(crate) fn capture_wayland_binding(stop: &AtomicBool) -> Result<LinuxHotkey> {
+    if !LinuxSession::detect().is_wayland() {
+        return Err(eyre!(
+            "raw keyboard shortcut capture is only available on Wayland"
+        ));
+    }
+    let deadline = Instant::now() + Duration::from_secs(8);
+    let mut pressed = Pressed::default();
+    let (mut keyboards, initial) = Keyboards::open(stop)?;
+    for input in initial {
+        capture_binding(&mut pressed, input)?;
+    }
+    loop {
+        if stop.load(Ordering::Acquire) {
+            return Err(eyre!("shortcut capture canceled"));
+        }
+        if Instant::now() >= deadline {
+            return Err(eyre!("timed out waiting for a shortcut"));
+        }
+        for (_, input) in keyboards.poll(stop)? {
+            if stop.load(Ordering::Acquire) {
+                return Err(eyre!("shortcut capture canceled"));
+            }
+            if let Some(binding) = capture_binding(&mut pressed, input)? {
+                return Ok(binding);
+            }
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+pub(crate) fn wayland_modifiers_held(stop: &AtomicBool) -> Result<bool> {
+    if !LinuxSession::detect().is_wayland() {
+        return Err(eyre!(
+            "raw keyboard modifier checks are only available on Wayland"
+        ));
+    }
+    // Use the same fail-closed permissions check as monitor startup, not a weaker paste-only view.
+    let (_keyboards, initial) = Keyboards::open(stop)?;
+    let mut pressed = Pressed::default();
+    for input in initial {
+        pressed.update(input);
+    }
+    Ok(pressed.modifiers().into_iter().any(|held| held))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use HotkeyEvent::{Cancel, Finish, Start};
+
+    struct Test {
+        state: HotkeyState,
+        now: Instant,
+        events: Vec<HotkeyEvent>,
+    }
+
+    impl Test {
+        fn new(double_tap: bool) -> Self {
+            let mut test = Self {
+                state: HotkeyState::new(&LinuxHotkey::default(), double_tap).unwrap(),
+                now: Instant::now(),
+                events: Vec::new(),
+            };
+            test.input(Input::Connected("keyboard".into(), HashSet::new()));
+            test
+        }
+
+        fn input(&mut self, input: Input) {
+            if let Some(event) = self.state.update(input, self.now) {
+                self.events.push(event);
+            }
+        }
+
+        fn key(&mut self, key: KeyCode, value: i32) {
+            self.input(Input::Key("keyboard".into(), key, value));
+        }
+
+        fn tap(&mut self) {
+            self.key(KeyCode::KEY_LEFTALT, 1);
+            self.key(KeyCode::KEY_SPACE, 1);
+            self.key(KeyCode::KEY_SPACE, 0);
+            self.key(KeyCode::KEY_LEFTALT, 0);
+        }
+
+        fn lock(&mut self) {
+            self.tap();
+            self.now += Duration::from_millis(20);
+            self.tap();
+            assert_eq!(self.events, [Start, Finish, Start]);
+            assert!(self.state.capture == Capture::Locked);
+            self.events.clear();
+        }
+    }
+
+    #[test]
+    fn every_supported_key_round_trips_through_capture() {
+        let mut names = HashSet::new();
+        let mut codes = HashSet::new();
+        for &(name, code) in KEYS {
+            assert!(names.insert(name));
+            assert!(codes.insert(code));
+            assert_eq!(key_code(name).unwrap(), code);
+            let mut pressed = Pressed::default();
+            pressed.update(Input::Connected("keyboard".into(), HashSet::new()));
+            let captured = capture_binding(&mut pressed, Input::Key("keyboard".into(), code, 1))
+                .unwrap()
+                .unwrap();
+            assert_eq!(captured.key, name);
+            assert_eq!(key_code(&captured.key).unwrap(), code);
+        }
+        for (name, code) in [
+            ("s", KeyCode::KEY_S),
+            ("q", KeyCode::KEY_Q),
+            ("z", KeyCode::KEY_Z),
+            ("0", KeyCode::KEY_0),
+            ("1", KeyCode::KEY_1),
+            ("9", KeyCode::KEY_9),
+            ("f11", KeyCode::KEY_F11),
+            ("f13", KeyCode::KEY_F13),
+        ] {
+            assert_eq!(key_code(name).unwrap(), code);
+        }
+        assert_eq!(key_code("RETURN").unwrap(), KeyCode::KEY_ENTER);
+        assert!(key_code("f25").is_err());
+        assert!(key_code("escape").is_err());
+    }
+
+    #[test]
+    fn quick_release_and_repress_never_coalesce_without_locking() {
+        let mut test = Test::new(false);
+        test.key(KeyCode::KEY_LEFTALT, 1);
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.now += Duration::from_millis(500);
+        test.key(KeyCode::KEY_SPACE, 0);
+        test.now += Duration::from_millis(20);
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.now += Duration::from_secs(1);
+        test.key(KeyCode::KEY_SPACE, 0);
+        assert_eq!(test.events, [Start, Finish, Start, Finish]);
+    }
+
+    #[test]
+    fn repeats_and_duplicate_edges_do_not_start_finish_or_lock() {
+        let mut test = Test::new(true);
+        test.key(KeyCode::KEY_LEFTALT, 1);
+        test.key(KeyCode::KEY_SPACE, 2);
+        assert!(test.events.is_empty());
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.key(KeyCode::KEY_SPACE, 2);
+        test.key(KeyCode::KEY_SPACE, 0);
+        test.key(KeyCode::KEY_SPACE, 0);
+        assert_eq!(test.events, [Start, Finish]);
+    }
+
+    #[test]
+    fn escape_from_locked_capture_does_not_swallow_the_next_shortcut() {
+        let mut test = Test::new(true);
+        test.lock();
+        test.key(KeyCode::KEY_ESC, 1);
+        test.key(KeyCode::KEY_ESC, 0);
+        test.tap();
+        assert_eq!(test.events, [Cancel, Start, Finish]);
+    }
+
+    #[test]
+    fn escape_during_hold_suppresses_remaining_releases_and_repeat() {
+        let mut test = Test::new(true);
+        test.key(KeyCode::KEY_LEFTALT, 1);
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.key(KeyCode::KEY_ESC, 1);
+        test.key(KeyCode::KEY_ESC, 0);
+        test.key(KeyCode::KEY_SPACE, 2);
+        test.key(KeyCode::KEY_SPACE, 0);
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.key(KeyCode::KEY_SPACE, 0);
+        assert_eq!(test.events, [Start, Cancel, Start, Finish]);
+    }
+
+    #[test]
+    fn held_escape_does_not_allow_a_new_capture() {
+        let mut test = Test::new(false);
+        test.key(KeyCode::KEY_ESC, 1);
+        test.tap();
+        assert!(test.events.is_empty());
+        test.key(KeyCode::KEY_ESC, 0);
+        test.tap();
+        assert_eq!(test.events, [Start, Finish]);
+    }
+
+    #[test]
+    fn only_the_exact_chord_stops_locked_recording() {
+        let mut test = Test::new(true);
+        test.lock();
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.key(KeyCode::KEY_SPACE, 0);
+        test.key(KeyCode::KEY_LEFTCTRL, 1);
+        test.tap();
+        test.key(KeyCode::KEY_LEFTCTRL, 0);
+        assert!(test.events.is_empty());
+        test.tap();
+        assert_eq!(test.events, [Finish]);
+        test.tap();
+        assert_eq!(test.events, [Finish, Start, Finish]);
+    }
+
+    #[test]
+    fn modifier_first_release_finishes_once_and_requires_a_fresh_trigger() {
+        let mut test = Test::new(false);
+        test.key(KeyCode::KEY_LEFTALT, 1);
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.key(KeyCode::KEY_LEFTALT, 0);
+        assert_eq!(test.events, [Start, Finish]);
+        test.key(KeyCode::KEY_LEFTALT, 1);
+        test.key(KeyCode::KEY_SPACE, 2);
+        test.key(KeyCode::KEY_SPACE, 0);
+        assert_eq!(test.events, [Start, Finish]);
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.key(KeyCode::KEY_SPACE, 0);
+        assert_eq!(test.events, [Start, Finish, Start, Finish]);
+    }
+
+    #[test]
+    fn modifier_first_release_can_lock_the_second_tap() {
+        let mut test = Test::new(true);
+        test.tap();
+        test.key(KeyCode::KEY_LEFTALT, 1);
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.key(KeyCode::KEY_LEFTALT, 0);
+        test.key(KeyCode::KEY_SPACE, 0);
+        assert_eq!(test.events, [Start, Finish, Start]);
+        assert!(test.state.capture == Capture::Locked);
+        test.tap();
+        assert_eq!(test.events, [Start, Finish, Start, Finish]);
+    }
+
+    #[test]
+    fn extra_modifiers_prevent_start_and_cancel_an_existing_hold() {
+        let mut test = Test::new(true);
+        test.key(KeyCode::KEY_LEFTSHIFT, 1);
+        test.tap();
+        assert!(test.events.is_empty());
+        test.key(KeyCode::KEY_LEFTSHIFT, 0);
+        test.key(KeyCode::KEY_LEFTALT, 1);
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.key(KeyCode::KEY_LEFTSHIFT, 1);
+        test.key(KeyCode::KEY_LEFTSHIFT, 0);
+        test.key(KeyCode::KEY_SPACE, 0);
+        test.tap();
+        assert_eq!(test.events, [Start, Cancel, Start, Finish]);
+    }
+
+    #[test]
+    fn double_tap_window_has_an_explicit_boundary() {
+        for (delay, expected) in [
+            (299, vec![Start, Finish, Start]),
+            (300, vec![Start, Finish, Start, Finish]),
+        ] {
+            let mut test = Test::new(true);
+            test.tap();
+            test.now += Duration::from_millis(delay);
+            test.tap();
+            assert_eq!(test.events, expected);
+        }
+    }
+
+    #[test]
+    fn buffered_taps_use_physical_time_not_the_time_the_batch_is_replayed() {
+        for (gap_ms, expected) in [
+            (200, vec![Start, Finish, Start]),
+            (500, vec![Start, Finish, Start, Finish]),
+        ] {
+            let mut test = Test::new(true);
+            let clock = EventClock {
+                monotonic: Duration::from_secs(100),
+                instant: test.now,
+            };
+            let replayed_at = test.now + Duration::from_secs(10);
+            let batch = [
+                (100, KeyCode::KEY_LEFTALT, 1),
+                (110, KeyCode::KEY_SPACE, 1),
+                (120, KeyCode::KEY_SPACE, 0),
+                (120 + gap_ms, KeyCode::KEY_SPACE, 1),
+                (130 + gap_ms, KeyCode::KEY_SPACE, 0),
+            ]
+            .into_iter()
+            .map(|(millis, key, value)| {
+                let timestamp =
+                    SystemTime::UNIX_EPOCH + clock.monotonic + Duration::from_millis(millis);
+                let at = clock.at(timestamp).unwrap();
+                assert!(at < replayed_at);
+                (at, Input::Key("keyboard".into(), key, value))
+            })
+            .collect();
+            let (sender, receiver) = std::sync::mpsc::sync_channel(16);
+            assert!(
+                test.state
+                    .dispatch(Ok(batch), &sender, &AtomicBool::new(false))
+                    .unwrap()
+            );
+            assert_eq!(receiver.try_iter().collect::<Vec<_>>(), expected);
+        }
+    }
+
+    #[test]
+    fn newly_unreadable_devices_cancel_capture_and_surface_the_permission_error() {
+        for locked in [false, true] {
+            let mut test = Test::new(true);
+            if locked {
+                test.lock();
+            } else {
+                test.key(KeyCode::KEY_LEFTALT, 1);
+                test.key(KeyCode::KEY_SPACE, 1);
+            }
+            let batch = check_device_error(
+                Path::new("/dev/input/event99"),
+                std::io::Error::from_raw_os_error(libc::EACCES),
+            )
+            .map(|()| Vec::new());
+            let (sender, receiver) = std::sync::mpsc::sync_channel(16);
+            let error = test
+                .state
+                .dispatch(batch, &sender, &AtomicBool::new(false))
+                .unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("read access to every /dev/input/event* node")
+            );
+            assert!(error.to_string().contains("/dev/input/event99"));
+            assert_eq!(receiver.try_iter().collect::<Vec<_>>(), [Cancel]);
+            assert!(test.state.capture == Capture::Idle);
+            assert!(test.state.last_release.is_none());
+        }
+    }
+
+    #[test]
+    fn device_removal_races_are_retryable_but_other_inspection_errors_are_not() {
+        for code in [libc::ENOENT, libc::ENODEV] {
+            let mut test = Test::new(true);
+            test.lock();
+            let batch = check_device_error(
+                Path::new("/dev/input/event99"),
+                std::io::Error::from_raw_os_error(code),
+            )
+            .map(|()| Vec::new());
+            let (sender, receiver) = std::sync::mpsc::sync_channel(16);
+            assert!(
+                test.state
+                    .dispatch(batch, &sender, &AtomicBool::new(false))
+                    .unwrap()
+            );
+            assert!(receiver.try_iter().next().is_none());
+            assert!(test.state.capture == Capture::Locked);
+        }
+        for code in [libc::EACCES, libc::EPERM, libc::EIO] {
+            assert!(
+                check_device_error(
+                    Path::new("/dev/input/event99"),
+                    std::io::Error::from_raw_os_error(code),
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn trigger_held_on_open_does_not_start_until_released_and_repressed() {
+        let mut test = Test::new(false);
+        test.input(Input::Connected(
+            "keyboard".into(),
+            HashSet::from([KeyCode::KEY_LEFTALT, KeyCode::KEY_SPACE]),
+        ));
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.key(KeyCode::KEY_SPACE, 2);
+        test.key(KeyCode::KEY_SPACE, 0);
+        assert!(test.events.is_empty());
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.key(KeyCode::KEY_SPACE, 0);
+        assert_eq!(test.events, [Start, Finish]);
+    }
+
+    #[test]
+    fn held_initial_modifiers_are_used_for_a_fresh_trigger() {
+        let mut test = Test::new(false);
+        test.input(Input::Connected(
+            "keyboard".into(),
+            HashSet::from([KeyCode::KEY_RIGHTALT]),
+        ));
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.key(KeyCode::KEY_SPACE, 0);
+        assert_eq!(test.events, [Start, Finish]);
+    }
+
+    #[test]
+    fn multi_keyboard_modifiers_and_trigger_remain_held_until_all_release() {
+        let mut test = Test::new(false);
+        test.input(Input::Connected("other".into(), HashSet::new()));
+        test.input(Input::Key("other".into(), KeyCode::KEY_LEFTALT, 1));
+        test.key(KeyCode::KEY_LEFTALT, 1);
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.input(Input::Key("other".into(), KeyCode::KEY_SPACE, 1));
+        test.key(KeyCode::KEY_LEFTALT, 0);
+        test.key(KeyCode::KEY_SPACE, 0);
+        assert_eq!(test.events, [Start]);
+        test.input(Input::Key("other".into(), KeyCode::KEY_SPACE, 0));
+        test.input(Input::Key("other".into(), KeyCode::KEY_LEFTALT, 0));
+        assert_eq!(test.events, [Start, Finish]);
+    }
+
+    #[test]
+    fn lost_keyboard_cancels_and_reconnect_resets_held_keys_and_taps() {
+        for locked in [false, true] {
+            let mut test = Test::new(true);
+            if locked {
+                test.lock();
+            } else {
+                test.key(KeyCode::KEY_LEFTALT, 1);
+                test.key(KeyCode::KEY_SPACE, 1);
+                test.events.clear();
+            }
+            test.input(Input::Disconnected("keyboard".into()));
+            assert_eq!(test.events, [Cancel]);
+            assert!(!test.state.pressed.contains(KeyCode::KEY_LEFTALT));
+            assert!(!test.state.pressed.contains(KeyCode::KEY_SPACE));
+            // Reuse of the same event path is a new keyboard, not a continuation of its old keys.
+            test.input(Input::Connected("keyboard".into(), HashSet::new()));
+            test.key(KeyCode::KEY_SPACE, 1);
+            test.key(KeyCode::KEY_SPACE, 0);
+            assert_eq!(test.events, [Cancel]);
+            test.tap();
+            assert_eq!(test.events, [Cancel, Start, Finish]);
+        }
+    }
+
+    #[test]
+    fn reconnect_with_trigger_down_does_not_resume_canceled_recording() {
+        let mut test = Test::new(false);
+        test.key(KeyCode::KEY_LEFTALT, 1);
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.input(Input::Disconnected("keyboard".into()));
+        test.input(Input::Connected(
+            "keyboard".into(),
+            HashSet::from([KeyCode::KEY_LEFTALT, KeyCode::KEY_SPACE]),
+        ));
+        test.key(KeyCode::KEY_SPACE, 2);
+        test.key(KeyCode::KEY_SPACE, 0);
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.key(KeyCode::KEY_SPACE, 0);
+        assert_eq!(test.events, [Start, Cancel, Start, Finish]);
+    }
+
+    #[test]
+    fn losing_one_keyboard_preserves_the_other_keyboards_modifiers() {
+        let mut test = Test::new(false);
+        test.input(Input::Connected(
+            "other".into(),
+            HashSet::from([KeyCode::KEY_RIGHTALT]),
+        ));
+        test.key(KeyCode::KEY_LEFTALT, 1);
+        test.key(KeyCode::KEY_SPACE, 1);
+        test.input(Input::Disconnected("keyboard".into()));
+        test.input(Input::Key("other".into(), KeyCode::KEY_SPACE, 1));
+        test.input(Input::Key("other".into(), KeyCode::KEY_SPACE, 0));
+        assert_eq!(test.events, [Start, Cancel, Start, Finish]);
+    }
+
+    #[test]
+    fn standalone_function_key_uses_the_same_state_machine() {
+        let mut test = Test::new(false);
+        test.state.trigger = key_code("f13").unwrap();
+        test.state.required = [false; 4];
+        test.key(KeyCode::KEY_F13, 1);
+        test.key(KeyCode::KEY_F13, 0);
+        test.key(KeyCode::KEY_LEFTALT, 1);
+        test.key(KeyCode::KEY_F13, 1);
+        test.key(KeyCode::KEY_F13, 0);
+        assert_eq!(test.events, [Start, Finish]);
+    }
+
+    #[test]
+    fn binding_capture_uses_initial_and_multi_keyboard_modifiers() {
+        let mut pressed = Pressed::default();
+        capture_binding(
+            &mut pressed,
+            Input::Connected(
+                "one".into(),
+                HashSet::from([KeyCode::KEY_RIGHTALT, KeyCode::KEY_RIGHTCTRL]),
+            ),
+        )
+        .unwrap();
+        capture_binding(
+            &mut pressed,
+            Input::Connected(
+                "two".into(),
+                HashSet::from([
+                    KeyCode::KEY_RIGHTSHIFT,
+                    KeyCode::KEY_RIGHTMETA,
+                    KeyCode::KEY_S,
+                ]),
+            ),
+        )
+        .unwrap();
+        assert!(
+            capture_binding(&mut pressed, Input::Key("two".into(), KeyCode::KEY_S, 2))
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            capture_binding(&mut pressed, Input::Key("two".into(), KeyCode::KEY_S, 0))
+                .unwrap()
+                .is_none()
+        );
+        let binding = capture_binding(&mut pressed, Input::Key("two".into(), KeyCode::KEY_Q, 1))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            binding,
+            LinuxHotkey {
+                control: true,
+                alt: true,
+                shift: true,
+                super_key: true,
+                key: "q".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn binding_capture_cancels_on_escape_or_device_loss() {
+        let mut pressed = Pressed::default();
+        pressed.update(Input::Connected("keyboard".into(), HashSet::new()));
+        assert!(
+            capture_binding(
+                &mut pressed,
+                Input::Key("keyboard".into(), KeyCode::KEY_ESC, 1)
+            )
+            .is_err()
+        );
+        assert!(capture_binding(&mut pressed, Input::Disconnected("keyboard".into())).is_err());
+    }
+}

--- a/src/linux_wayland_input.rs
+++ b/src/linux_wayland_input.rs
@@ -462,7 +462,7 @@ impl Keyboards {
                 changes.push(Input::Disconnected(keyboard.path.clone()));
                 return false;
             }
-            pending.extend(events.into_iter().filter(|event| event.event_type() == EventType::KEY)
+            pending.extend(events.into_iter().filter(|event| event.event_type() == EventType::KEY && matches!(event.value(), 0 | 1))
                 .map(|event| (event.timestamp(), Input::Key(keyboard.path.clone(), KeyCode::new(event.code()), event.value()))));
             true
         });
@@ -570,11 +570,9 @@ pub(crate) fn wayland_modifiers_held(stop: &AtomicBool) -> Result<bool> {
     }
     // Use the same fail-closed permissions check as monitor startup, not a weaker paste-only view.
     let (_keyboards, initial) = Keyboards::open(stop)?;
-    let mut pressed = Pressed::default();
-    for input in initial {
-        pressed.update(input);
-    }
-    Ok(pressed.modifiers().into_iter().any(|held| held))
+    Ok(initial.iter().any(|input| {
+        matches!(input, Input::Connected(_, keys) if MODIFIERS.iter().flatten().any(|key| keys.contains(key)))
+    }))
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #[cfg(target_os = "macos")]
 mod accessibility;
+#[cfg_attr(target_os = "linux", allow(dead_code))]
 mod app_paths;
 #[cfg(target_os = "macos")]
 mod app_settings;
@@ -24,10 +25,12 @@ mod dashboard;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 mod desktop_activity;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg_attr(target_os = "linux", allow(dead_code))]
 mod desktop_host;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 mod desktop_transcription_picker;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg_attr(target_os = "linux", allow(dead_code))]
 mod desktop_ui;
 #[cfg(target_os = "macos")]
 mod developer_control;
@@ -45,6 +48,7 @@ pub mod dictation_processor;
 mod events;
 #[cfg(target_os = "macos")]
 mod feedback;
+#[cfg_attr(target_os = "linux", allow(dead_code))]
 mod history;
 mod instance;
 #[cfg(target_os = "macos")]
@@ -54,17 +58,23 @@ mod linux;
 #[cfg(target_os = "linux")]
 mod linux_app;
 #[cfg(target_os = "linux")]
+mod linux_desktop;
+#[cfg(target_os = "linux")]
 mod linux_dictation;
 #[cfg(target_os = "linux")]
 mod linux_input;
 #[cfg(target_os = "linux")]
 mod linux_paste;
 #[cfg(target_os = "linux")]
+mod linux_session;
+#[cfg(target_os = "linux")]
 mod linux_settings;
 #[cfg(target_os = "linux")]
 mod linux_transcriber;
 #[cfg(target_os = "linux")]
 mod linux_updater;
+#[cfg(target_os = "linux")]
+mod linux_wayland_input;
 #[cfg(target_os = "macos")]
 mod local_api;
 #[cfg(target_os = "macos")]

--- a/tests/fixtures/wayland-paste-target.c
+++ b/tests/fixtures/wayland-paste-target.c
@@ -1,0 +1,33 @@
+#include <gtk/gtk.h>
+
+static void changed(GtkTextBuffer *buffer, gpointer path) {
+    GtkTextIter start, end;
+    gtk_text_buffer_get_bounds(buffer, &start, &end);
+    gchar *text = gtk_text_buffer_get_text(buffer, &start, &end, FALSE);
+    g_file_set_contents(path, text, -1, NULL);
+    g_free(text);
+}
+
+static gboolean focused(GtkWidget *widget, GdkEventFocus *event, gpointer path) {
+    gchar *ready = g_strconcat(path, ".ready", NULL);
+    g_file_set_contents(ready, "ready", -1, NULL);
+    g_free(ready);
+    return FALSE;
+}
+
+int main(int argc, char **argv) {
+    gtk_init(&argc, &argv);
+    if (argc != 2) return 2;
+    GtkWidget *window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_title(GTK_WINDOW(window), "Hex Wayland Test");
+    gtk_window_set_default_size(GTK_WINDOW(window), 640, 320);
+    GtkWidget *view = gtk_text_view_new();
+    gtk_container_add(GTK_CONTAINER(window), view);
+    g_signal_connect(gtk_text_view_get_buffer(GTK_TEXT_VIEW(view)), "changed", G_CALLBACK(changed), argv[1]);
+    g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
+    g_signal_connect(window, "focus-in-event", G_CALLBACK(focused), argv[1]);
+    gtk_widget_show_all(window);
+    gtk_widget_grab_focus(view);
+    gtk_main();
+    return 0;
+}

--- a/tests/fixtures/wayland-paste.conf
+++ b/tests/fixtures/wayland-paste.conf
@@ -1,0 +1,5 @@
+xwayland disable
+output HEADLESS-1 mode 1280x900
+seat seat0 fallback true
+focus_follows_mouse no
+exec "$HEX_WAYLAND_TEST_SCRIPT" --inside


### PR DESCRIPTION
## Why

The Linux app only supports X11 today. Native Wayland needs explicit input and insertion behavior, and Nix users need a package and development shell that supply the same native dependencies.

This rebuilds the proposals in #28 and #29 with stricter lifecycle, permission, and paste handling. Automated native x86_64 and Nix validation pass. This merges Linux beta source support; physical supported-desktop validation remains a gate before publishing a Linux release.

## What Changes

| Case | Behavior |
| --- | --- |
| Nonempty `WAYLAND_DISPLAY` | GPUI, GTK, input, and paste use native Wayland, even when XWayland is also available |
| Compatible wlroots compositor | Read-only evdev hotkeys, `wl-copy` clipboard insertion, `wtype` paste shortcuts, and a click-through layer-shell HUD |
| Unreadable event device | Fail explicitly instead of claiming readiness with incomplete modifier state |
| Keyboard disappears or loses events | Cancel active capture and require a fresh trigger after rediscovery |
| No usable tray | Keep Settings visible; closing it stops the listener and drains workers rather than leaving an invisible microphone |
| Shortcut edit or cancellation | Restore the previous running state without losing the old binding on cancellation |
| Cancel a new recording with older output pending | Settings remains Transcribing, consistent with the HUD |
| Nix installation | Nix owns updates; optional Home Manager autostart follows the graphical session |

New installations paste with Ctrl-V. Existing persisted X11 settings retain Ctrl-Shift-V until changed. Helper input stays off argv, helper I/O is bounded, and modifier waiting can be cancelled at shutdown. Native inference already in progress must finish before exit.

The final cleanup gives worker completion and results one owner, derives shortcut-capture state from the pending edit, and removes redundant output wrapping and Wayland input aggregation. Tests cover nonblocking completion, returned errors, panics, and cancellation.

## Demo

Actual current-branch GPUI Settings under isolated headless Sway, with a fresh data directory and no microphone/model. The branch includes main's 2.1.2 fixes. The same smoke test repeats GTK clipboard insertion while this Settings window remains open, then verifies clean tray-less close.

![Linux Settings under Sway](https://github.com/user-attachments/assets/2195abe8-e27e-4082-bbbf-5e33aca0af48)

## Scope

The contract is x86_64 Linux, X11 or compatible wlroots Wayland. It requires deliberate read access to all `/dev/input/event*` nodes, exposing broad input access to the user account. HEX does not grant permissions, suppress Wayland keys, use privileged injection, or silently fall back to XWayland. GNOME/KDE, Linux commands, and meetings are not included. Clipboard MIME restoration is not implemented.

Nix includes a package, matching shell, overlay, NixOS module, optional Home Manager service, and readiness checks. A full Nix build with Rust tests and installed-wrapper smoke is included in CI, not just flake evaluation.

## Verification

```sh
cargo fmt --all --check
cargo test --locked --bin voice-control
cargo clippy --locked --bin voice-control --tests -- -D warnings
scripts/test-wayland-paste.sh /path/to/test-binary /path/to/voice-control
scripts/test-linux-dictation.sh /path/to/voice-control /path/to/model.gguf /path/to/jfk.wav
scripts/test-install-linux-release.sh
nix flake check --all-systems --no-build
nix build .#checks.x86_64-linux.package
git diff --check
```

The native arm64 Linux suite passes 121 tests with 7 ignored, Clippy/build pass, and three ignored X11 tests pass under Xvfb. The extended Wayland paste/Settings coexistence check also passes against the rebuilt app. macOS passes 355 tests with 9 ignored and all-targets/all-features Clippy. Formatting, lockfile metadata, shell syntax, and macOS identity guards pass.

The virtual-microphone end-to-end check passed against both the CLI and the rebuilt desktop app. ALSA captured a public JFK speech sample, the real default model transcribed it on CPU, and the real X11 shortcut path pasted the expected sentences into a focused GTK editor. Settings stayed visible despite `--hidden` because no tray was available. SIGTERM exited cleanly and PulseAudio confirmed no capture clients remained. A failed-listener fixture also verifies process cleanup. CI runs this check with the checksum-verified model and pinned public sample, alongside signed installer/tamper tests.

[Final native x86_64 CI](https://github.com/anomalyco/hex/actions/runs/33184782936) is fully green at `9ffcfb0`: 121 Rust tests, all three X11 tests, Wayland paste/app checks, the full desktop virtual-microphone check, signed installer/tamper checks, and Clippy. An earlier installer test exposed inherited XDG config paths; that test-isolation bug was reproduced failing and fixed on native x86_64 Linux.

The full native x86_64 Nix package build passed on the final commit, including 121 Rust tests, installed `hex --version`, and fresh-home `hex model status`. Nix module, shell-environment, session-readiness, and dev-shell environment checks also pass. GitHub-only Nix caching is enabled for later runs, without FlakeHub publication. The old emulated 2.1.0 build remains paused with its cache preserved and is not used as validation evidence.

Physical evdev discovery/hotplug, real microphone capture, HUD focus/click-through, terminal/editor insertion, and close during active inference still require a supported Linux desktop. This PR does not publish a Linux binary or change the macOS/Swift update feeds.
