### PR TITLE
fix(voice-action): require explicit shortcut opt-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ runtime settings persist in Application Support.
 
 The distributed release starts in hotkey-dictation-only mode. Voice commands and
 their catalog remain available as a persisted opt-in that defaults off.
+Voice Action also requires its own persisted opt-in, defaulting off even for
+existing settings without an explicit enabled flag.
 `DEVELOPER_FEATURES_ENABLED` keeps meetings and their UI/CLI surfaces available
 only in debug builds.
 
@@ -207,8 +209,11 @@ CoreAudio formats, AppleScript details, or event serialization.
   `NotRegistered` and `NotFound` as disabled before registration, represent
   `RequiresApproval` with a link to Login Items settings, and poll macOS as the
   source of truth instead of persisting a parallel Boolean.
-- Voice Action is an explicit second capture target, defaulting to
-  Option-Command. Promoting an active Option capture preserves all recorded
+- Voice Action is an optional second capture target. Its saved shortcut defaults
+  to Option-Command, but no shortcut is active or reserved until the user enables
+  Voice Action. Disabling it cancels its active capture, not accepted jobs, and
+  preserves the saved shortcut and model. The toggle remains reachable when
+  OpenCode is unavailable. Promoting an active Option capture preserves all recorded
   audio. Selected text is optional prompt context; inaccessible or empty
   selections act as no selection. Use the dedicated OpenCode model and deadline,
   return only paste-ready text, and paste at the current focus. Failed, empty,
@@ -339,7 +344,8 @@ cargo run -- preview transcription-picker --language zh --model-state installed
 ./scripts/capture-preview.sh /tmp/hex-modes-collapsed.png modes --collapse-mode-processing
 ./scripts/capture-preview.sh /tmp/hex-modes-picker.png modes --collapse-mode-processing --open-transformation-picker
 ./scripts/capture-preview.sh /tmp/hex-modes-global.png modes --collapse-mode-processing --select-global-mode
-./scripts/capture-preview.sh /tmp/hex-voice-action-unavailable.png voice-action --opencode-unavailable
+./scripts/capture-preview.sh /tmp/hex-voice-action-off.png voice-action
+./scripts/capture-preview.sh /tmp/hex-voice-action-unavailable.png voice-action --voice-action-enabled --opencode-unavailable
 HEX_PREVIEW_SKIP_BUILD=1 ./scripts/capture-preview.sh /tmp/hex-modes.png modes
 ./scripts/install-app.sh
 cargo fmt --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8677,7 +8677,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voice-control"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice-control"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 default-run = "voice-control"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ pasted.
 [OpenCode](https://v2.opencode.ai/) is optional. Ordinary dictation does not
 require it.
 
-- **Voice Action:** hold **Option-Command** and describe what you want. HEX sends
+- **Voice Action:** enable it in the Voice Action pane, then hold
+  **Option-Command** and describe what you want. It defaults off, independently
+  of your dictation shortcut. HEX sends
   that instruction, selected text when Accessibility makes it available, and
   the foreground application and Brave website hostname. It pastes the result
   at the current focus.

--- a/docs/releases/2.1.3.md
+++ b/docs/releases/2.1.3.md
@@ -1,0 +1,17 @@
+## Hex 2.1.3
+
+- Voice Action now requires an explicit opt-in. It starts off for new installs
+  and when upgrading from earlier versions, even if a model was previously
+  selected. Enable it in the Voice Action pane when you want to use it.
+- Your saved Voice Action shortcut, model, and other configuration are preserved.
+  While the feature is off, its shortcut is inactive and does not reserve keys.
+- Command-Option no longer unexpectedly starts Voice Action after rebinding the
+  separate dictation shortcut. The enable/disable control stays available even
+  when OpenCode is missing or unavailable.
+- Enabling rejects shortcut conflicts instead of silently changing a binding.
+  Live toggling handles held keys, repeats, and release events safely; disabling
+  cancels an active Voice Action capture without cancelling already-submitted work.
+
+This macOS release uses build 20103 and retains the existing app identity,
+permissions, settings location, and Rust update feed. The legacy Swift app and
+its separate feed are unchanged. No Linux binary is published with this release.

--- a/src/app_settings.rs
+++ b/src/app_settings.rs
@@ -387,7 +387,7 @@ fn side_from_flags(flags: u64, general: u64, left: u64, right: u64) -> Option<Mo
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RuntimeHotkeys {
     pub dictation: RuntimeHotkey,
-    pub edit: RuntimeHotkey,
+    pub edit: Option<RuntimeHotkey>,
     pub paste_last: Option<RuntimeHotkey>,
     pub paste_meeting: Option<RuntimeHotkey>,
 }
@@ -396,7 +396,7 @@ impl Default for RuntimeHotkeys {
     fn default() -> Self {
         Self {
             dictation: HotkeyBinding::default().runtime(),
-            edit: HotkeyBinding::edit_default().runtime(),
+            edit: None,
             paste_last: Some(HotkeyBinding::paste_last_default().runtime()),
             paste_meeting: crate::DEVELOPER_FEATURES_ENABLED
                 .then(|| HotkeyBinding::paste_meeting_default().runtime()),
@@ -456,6 +456,7 @@ pub struct DictationPostProcessing {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct VoiceActionSettings {
+    pub enabled: bool,
     pub model: Option<String>,
     pub variant: Option<String>,
     pub deadline_seconds: u64,
@@ -464,6 +465,7 @@ pub struct VoiceActionSettings {
 impl Default for VoiceActionSettings {
     fn default() -> Self {
         Self {
+            enabled: false,
             model: None,
             variant: None,
             deadline_seconds: 60,
@@ -713,13 +715,7 @@ impl AppSettings {
         *HOTKEYS
             .get_or_init(Default::default)
             .write()
-            .unwrap_or_else(|error| error.into_inner()) = RuntimeHotkeys {
-            dictation: self.dictation_hotkey.runtime(),
-            edit: self.edit_hotkey.runtime(),
-            paste_last: self.paste_last_hotkey.as_ref().map(HotkeyBinding::runtime),
-            paste_meeting: crate::DEVELOPER_FEATURES_ENABLED
-                .then(|| HotkeyBinding::paste_meeting_default().runtime()),
-        };
+            .unwrap_or_else(|error| error.into_inner()) = self.runtime_hotkeys();
         set_transcription_selection(&self.transcription);
         set_microphone_selection(self.microphone.as_deref());
         crate::config::update_dictation_profiles(&self.dictation_processing);
@@ -761,8 +757,23 @@ impl AppSettings {
         true
     }
 
+    pub fn runtime_hotkeys(&self) -> RuntimeHotkeys {
+        RuntimeHotkeys {
+            dictation: self.dictation_hotkey.runtime(),
+            edit: self
+                .voice_action
+                .enabled
+                .then(|| self.edit_hotkey.runtime()),
+            paste_last: self.paste_last_hotkey.as_ref().map(HotkeyBinding::runtime),
+            paste_meeting: crate::DEVELOPER_FEATURES_ENABLED
+                .then(|| HotkeyBinding::paste_meeting_default().runtime()),
+        }
+    }
+
     fn repair_hotkey_conflict(&mut self) {
-        if !hotkeys_conflict(&self.dictation_hotkey, &self.edit_hotkey) {
+        if !self.voice_action.enabled
+            || !hotkeys_conflict(&self.dictation_hotkey, &self.edit_hotkey)
+        {
             return;
         }
         let edit_with_key = crate::keyboard::key_code_for('e')
@@ -894,7 +905,7 @@ pub fn dictation_hotkey() -> RuntimeHotkey {
     runtime_hotkeys().dictation
 }
 
-pub fn edit_hotkey() -> RuntimeHotkey {
+pub fn edit_hotkey() -> Option<RuntimeHotkey> {
     runtime_hotkeys().edit
 }
 
@@ -1172,9 +1183,23 @@ mod tests {
     }
 
     #[test]
+    fn voice_action_requires_explicit_opt_in_for_new_and_existing_settings() {
+        for json in [
+            r#"{}"#,
+            r#"{"voice_action":{"model":"example/model-a","variant":"fast"}}"#,
+        ] {
+            let settings: AppSettings = serde_json::from_str(json).unwrap();
+            assert!(settings.runtime_hotkeys().edit.is_none());
+            let saved = serde_json::to_value(settings).unwrap();
+            assert_eq!(saved["voice_action"]["enabled"], false);
+        }
+    }
+
+    #[test]
     fn voice_action_settings_round_trip() {
         let settings = AppSettings {
             voice_action: VoiceActionSettings {
+                enabled: true,
                 model: Some("example/rewrite-model".into()),
                 variant: Some("fast".into()),
                 deadline_seconds: 12,
@@ -1185,6 +1210,11 @@ mod tests {
         let encoded = serde_json::to_string(&settings).unwrap();
         let decoded: AppSettings = serde_json::from_str(&encoded).unwrap();
 
+        assert!(decoded.voice_action.enabled);
+        assert_eq!(
+            decoded.runtime_hotkeys().edit,
+            Some(decoded.edit_hotkey.runtime())
+        );
         assert_eq!(decoded.voice_action.model, settings.voice_action.model);
         assert_eq!(decoded.voice_action.variant, settings.voice_action.variant);
         assert_eq!(decoded.voice_action.deadline_seconds, 12);
@@ -1383,6 +1413,7 @@ mod tests {
             edit_hotkey: HotkeyBinding::edit_default(),
             ..Default::default()
         };
+        settings.voice_action.enabled = true;
 
         settings.repair_hotkey_conflict();
 
@@ -1390,5 +1421,25 @@ mod tests {
             &settings.dictation_hotkey,
             &settings.edit_hotkey
         ));
+    }
+
+    #[test]
+    fn disabled_voice_action_preserves_its_binding_without_reserving_it() {
+        let mut settings = AppSettings {
+            dictation_hotkey: HotkeyBinding::edit_default(),
+            ..Default::default()
+        };
+        let saved_binding = settings.edit_hotkey.clone();
+        settings.repair_hotkey_conflict();
+        assert_eq!(settings.edit_hotkey, saved_binding);
+        assert!(settings.runtime_hotkeys().edit.is_none());
+        settings.voice_action.enabled = true;
+        assert_eq!(
+            settings.runtime_hotkeys().edit,
+            Some(saved_binding.runtime())
+        );
+        settings.voice_action.enabled = false;
+        assert!(settings.runtime_hotkeys().edit.is_none());
+        assert_eq!(settings.edit_hotkey, saved_binding);
     }
 }

--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -249,6 +249,7 @@ pub struct AppWindowPreview {
     pub collapse_mode_processing: bool,
     pub open_transformation_picker: bool,
     pub select_global_mode: bool,
+    pub voice_action_enabled: bool,
     pub opencode_unavailable: bool,
     pub permissions_missing: bool,
     pub model_missing: bool,
@@ -476,6 +477,8 @@ struct ProcessingInputs {
 
 struct VoiceActionInputs {
     model: ProcessingInput,
+    enabled_toggle: ToggleSpring,
+    error: Option<String>,
 }
 
 struct ReplacementInputs {
@@ -924,6 +927,7 @@ impl AppWindow {
                 commands_enabled: preview.command_model_missing,
                 ..AppSettings::default()
             };
+            settings.voice_action.enabled = preview.voice_action_enabled;
             if let Some((language, _)) = &preview.transcription_picker
                 && let Some(choice) = preview_choices(language).first()
             {
@@ -2622,6 +2626,9 @@ impl AppWindow {
                                         return;
                                     };
                                     *binding = candidate;
+                                    if kind == HotkeyKind::Edit {
+                                        this.voice_action_inputs.error = None;
+                                    }
                                     this.hotkey_side_selection_springs[hotkey_kind_index(kind)]
                                         .set_target(index as f32);
                                     this.save_settings(cx);
@@ -2791,7 +2798,10 @@ impl AppWindow {
             .set_target(hotkey_saved_width(binding.keycaps().len()));
         match kind {
             HotkeyKind::Dictation => self.settings.dictation_hotkey = binding,
-            HotkeyKind::Edit => self.settings.edit_hotkey = binding,
+            HotkeyKind::Edit => {
+                self.settings.edit_hotkey = binding;
+                self.voice_action_inputs.error = None;
+            }
             HotkeyKind::PasteLast => self.settings.paste_last_hotkey = Some(binding),
         }
         if kind == HotkeyKind::Dictation && !key_based {
@@ -3790,7 +3800,47 @@ impl AppWindow {
     }
 
     fn render_voice_action(&mut self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
-        if let Some(copy) = opencode_unavailable_copy(&self.model_catalog) {
+        let enabled = self.settings.voice_action.enabled;
+        let compact = window.viewport_size().width < px(980.0);
+        let (status, description) = voice_action_status_copy(enabled);
+        let position = self
+            .voice_action_inputs
+            .enabled_toggle
+            .render_position(window);
+        let enabled_control = div()
+            .id("voice-action-enabled")
+            .flex()
+            .items_center()
+            .gap_3()
+            .child(
+                div()
+                    .text_size(px(11.0))
+                    .text_color(rgb(MUTED))
+                    .child(status),
+            )
+            .child(toggle(position))
+            .on_click(cx.listener(|this, _, _, cx| {
+                this.cancel_hotkey_capture(cx);
+                let enabled = !this.settings.voice_action.enabled;
+                let result = set_voice_action_enabled(&mut this.settings, enabled)
+                    .map_err(|message| color_eyre::eyre::eyre!(message))
+                    .and_then(|()| this.persist_settings());
+                match result {
+                    Ok(()) => {
+                        this.voice_action_inputs.enabled_toggle.set_enabled(enabled);
+                        this.voice_action_inputs.error = None;
+                    }
+                    Err(error) => {
+                        this.settings.voice_action.enabled = !enabled;
+                        this.voice_action_inputs.error = Some(error.to_string());
+                    }
+                }
+                cx.notify();
+            }));
+        let hotkey = self.render_hotkey_setting_control(HotkeyKind::Edit, window, cx);
+        let processing = if !enabled {
+            None
+        } else if let Some(copy) = opencode_unavailable_copy(&self.model_catalog) {
             let error = copy.error.map(str::to_owned);
             let show_actions = copy.can_retry || copy.can_open_setup;
             let retry_label = copy.retry_label;
@@ -3813,60 +3863,40 @@ impl AppWindow {
                             .on_click(|_, _, _| open_opencode_beta_docs()),
                     )
                 });
-            return div()
-                .size_full()
-                .flex()
-                .flex_col()
-                .child(pane_header("Voice Action"))
-                .child(
-                    div().flex_1().flex().items_center().justify_center().child(
-                        div()
-                            .w(px(420.0))
-                            .p_5()
-                            .rounded_md()
-                            .border_1()
-                            .border_color(rgb(LINE))
-                            .bg(rgb(SURFACE))
-                            .child(settings_copy(copy.title, copy.description))
-                            .when_some(error, |card, error| {
-                                card.child(
-                                    div()
-                                        .mt_3()
-                                        .rounded_sm()
-                                        .border_1()
-                                        .border_color(rgb(0x613b3b))
-                                        .bg(rgb(0x271b1b))
-                                        .child(error_message("OpenCode reported:", error)),
-                                )
-                            })
-                            .when(show_actions, |card| card.child(actions)),
-                    ),
-                )
-                .into_any_element();
-        }
-        let compact = window.viewport_size().width < px(980.0);
-        let hotkey = self.render_hotkey_setting_control(HotkeyKind::Edit, window, cx);
-        let processing = self.render_voice_action_processing(window, cx);
+            Some(
+                compact_panel()
+                    .p_5()
+                    .child(settings_copy(copy.title, copy.description))
+                    .when_some(error, |card, error| {
+                        card.child(
+                            div()
+                                .mt_3()
+                                .rounded_sm()
+                                .border_1()
+                                .border_color(rgb(0x613b3b))
+                                .bg(rgb(0x271b1b))
+                                .child(error_message("OpenCode reported:", error)),
+                        )
+                    })
+                    .when(show_actions, |card| card.child(actions))
+                    .into_any_element(),
+            )
+        } else {
+            Some(self.render_voice_action_processing(window, cx))
+        };
         div()
             .size_full()
             .flex()
             .flex_col()
             .child(pane_header("Voice Action"))
             .child(
-                div()
-                    .id("voice-action-scroll")
-                    .flex_1()
-                    .overflow_y_scroll()
+                pane_body()
                     .px(if compact { px(20.0) } else { px(32.0) })
                     .py(px(22.0))
-                    .flex()
-                    .justify_center()
                     .child(
-                        div()
-                            .w_full()
-                            .max_w(px(PANE_CONTENT_WIDTH))
-                            .flex()
-                            .flex_col()
+                        pane_content()
+                            .id("voice-action-scroll")
+                            .overflow_y_scroll()
                             .gap(px(18.0))
                             .child(
                                 div()
@@ -3876,12 +3906,23 @@ impl AppWindow {
                                     .line_height(px(17.0))
                                     .text_color(rgb(MUTED))
                                     .child(
-                                        "Hold the shortcut and speak an instruction. HEX sends \
-                                         it, along with any text you have selected, to the model \
-                                         below and pastes the reply at your cursor. If the model \
-                                         returns nothing, nothing is pasted.",
+                                        "Voice Action is an optional OpenCode feature, separate \
+                                         from dictation. Speak an instruction, optionally with \
+                                         text selected, and HEX pastes the model's reply at your \
+                                         cursor. The default shortcut is Command-Option. Changing \
+                                         your dictation shortcut does not change this shortcut.",
                                     ),
                             )
+                            .child(compact_panel().child(voice_action_setting_row(
+                                "Enable Voice Action",
+                                description,
+                                enabled_control,
+                                false,
+                                compact,
+                            )))
+                            .when_some(self.voice_action_inputs.error.clone(), |column, error| {
+                                column.child(error_message("Could not update Voice Action:", error))
+                            })
                             .child(
                                 div()
                                     .flex()
@@ -3892,7 +3933,11 @@ impl AppWindow {
                                         compact_panel().child(
                                             voice_action_setting_row(
                                                 "Shortcut",
-                                                "Hold to speak; selected text is included automatically",
+                                                if enabled {
+                                                    "Hold to speak; selected text is included automatically."
+                                                } else {
+                                                    "Saved for when Voice Action is enabled."
+                                                },
                                                 hotkey,
                                                 false,
                                                 compact,
@@ -3901,14 +3946,14 @@ impl AppWindow {
                                         ),
                                     ),
                             )
-                            .child(
+                            .when_some(processing, |column, processing| column.child(
                                 div()
                                     .flex()
                                     .flex_col()
                                     .gap_2()
                                     .child(compact_section_label("PROCESSING"))
                                     .child(processing),
-                            ),
+                            )),
                     ),
             )
             .into_any_element()
@@ -3991,7 +4036,11 @@ impl AppWindow {
             settings.voice_action.model.as_deref().unwrap_or_default(),
             cx,
         );
-        VoiceActionInputs { model }
+        VoiceActionInputs {
+            model,
+            enabled_toggle: ToggleSpring::new(settings.voice_action.enabled),
+            error: None,
+        }
     }
 
     fn synchronized_processing_input(
@@ -7182,14 +7231,7 @@ impl DesktopHost for AppWindow {
                 {
                     return Err(color_eyre::eyre::eyre!("shortcut requires a modifier"));
                 }
-                let mut others = vec![self.settings.edit_hotkey.clone()];
-                if let Some(paste) = &self.settings.paste_last_hotkey {
-                    others.push(paste.clone());
-                }
-                if crate::DEVELOPER_FEATURES_ENABLED {
-                    others.push(HotkeyBinding::paste_meeting_default());
-                }
-                if crate::app_settings::hotkey_conflicts(&binding, others) {
+                if hotkey_binding_conflicts(&self.settings, HotkeyKind::Dictation, &binding) {
                     return Err(color_eyre::eyre::eyre!("shortcut is already in use"));
                 }
                 let mut candidate = self.settings.clone();
@@ -7397,6 +7439,30 @@ fn preview_history() -> Option<History> {
     Some(History::new(store))
 }
 
+fn voice_action_status_copy(enabled: bool) -> (&'static str, &'static str) {
+    if enabled {
+        (
+            "Enabled",
+            "Use the shortcut below with OpenCode to run spoken instructions.",
+        )
+    } else {
+        (
+            "Off",
+            "Off by default. Its saved shortcut is not reserved until you enable Voice Action.",
+        )
+    }
+}
+
+fn set_voice_action_enabled(settings: &mut AppSettings, enabled: bool) -> Result<(), &'static str> {
+    if enabled && hotkey_binding_conflicts(settings, HotkeyKind::Edit, &settings.edit_hotkey) {
+        return Err(
+            "The Voice Action shortcut is already in use. Change it below or change the other shortcut before enabling Voice Action.",
+        );
+    }
+    settings.voice_action.enabled = enabled;
+    Ok(())
+}
+
 fn voice_action_setting_row(
     title: &'static str,
     description: impl Into<SharedString>,
@@ -7416,6 +7482,7 @@ fn voice_action_setting_row(
         .child(
             div()
                 .min_w(px(0.0))
+                .when(!compact, |copy| copy.flex_1())
                 .flex()
                 .flex_col()
                 .gap_1()
@@ -7495,13 +7562,12 @@ fn hotkey_binding_conflicts(
     binding: &HotkeyBinding,
 ) -> bool {
     let mut others = match kind {
-        HotkeyKind::Dictation => vec![settings.edit_hotkey.clone()],
-        HotkeyKind::Edit => vec![settings.dictation_hotkey.clone()],
-        HotkeyKind::PasteLast => vec![
-            settings.dictation_hotkey.clone(),
-            settings.edit_hotkey.clone(),
-        ],
+        HotkeyKind::Dictation => Vec::new(),
+        HotkeyKind::Edit | HotkeyKind::PasteLast => vec![settings.dictation_hotkey.clone()],
     };
+    if kind != HotkeyKind::Edit && settings.voice_action.enabled {
+        others.push(settings.edit_hotkey.clone());
+    }
     if kind != HotkeyKind::PasteLast
         && let Some(paste) = &settings.paste_last_hotkey
     {
@@ -8579,8 +8645,95 @@ mod tests {
     }
 
     #[test]
+    fn voice_action_defaults_off_and_explains_its_inactive_shortcut() {
+        let settings = AppSettings::default();
+        assert!(!settings.voice_action.enabled);
+        let (status, description) = voice_action_status_copy(settings.voice_action.enabled);
+        assert_eq!(status, "Off");
+        assert!(description.contains("Off by default"));
+        assert!(description.contains("not reserved"));
+
+        let (status, description) = voice_action_status_copy(true);
+        assert_eq!(status, "Enabled");
+        assert!(description.contains("OpenCode"));
+        assert!(!description.contains("not reserved"));
+    }
+
+    #[test]
+    fn disabled_voice_action_does_not_reserve_its_shortcut() {
+        let mut settings = AppSettings::default();
+        for enabled in [false, true] {
+            settings.voice_action.enabled = enabled;
+            for kind in [HotkeyKind::Dictation, HotkeyKind::PasteLast] {
+                assert_eq!(
+                    hotkey_binding_conflicts(&settings, kind, &settings.edit_hotkey),
+                    enabled,
+                );
+            }
+        }
+        settings.voice_action.enabled = false;
+        assert!(hotkey_binding_conflicts(
+            &settings,
+            HotkeyKind::Edit,
+            &settings.dictation_hotkey,
+        ));
+    }
+
+    #[test]
+    fn voice_action_opt_in_rejects_active_conflicts_without_rebinding() {
+        let defaults = AppSettings::default();
+        let mut active = vec![
+            defaults.dictation_hotkey,
+            defaults.paste_last_hotkey.unwrap(),
+        ];
+        if crate::DEVELOPER_FEATURES_ENABLED {
+            active.push(HotkeyBinding::paste_meeting_default());
+        }
+        for binding in active {
+            let mut settings = AppSettings {
+                edit_hotkey: binding,
+                ..AppSettings::default()
+            };
+            let before = serde_json::to_value(&settings).unwrap();
+            let error = set_voice_action_enabled(&mut settings, true).unwrap_err();
+
+            assert!(error.contains("already in use"));
+            assert!(error.contains("Change it below"));
+            assert_eq!(serde_json::to_value(&settings).unwrap(), before);
+        }
+    }
+
+    #[test]
+    fn voice_action_toggle_preserves_configuration_and_can_always_disable() {
+        let mut settings: AppSettings = serde_json::from_value(serde_json::json!({
+            "voice_action": {
+                "model": "example/saved-model",
+                "variant": "high",
+                "deadline_seconds": 45
+            },
+            "edit_hotkey": {
+                "modifiers": { "control": "left" }
+            }
+        }))
+        .unwrap();
+        assert!(!settings.voice_action.enabled);
+        let mut expected = serde_json::to_value(&settings).unwrap();
+        for enabled in [true, false] {
+            set_voice_action_enabled(&mut settings, enabled).unwrap();
+            expected["voice_action"]["enabled"] = serde_json::json!(enabled);
+            assert_eq!(serde_json::to_value(&settings).unwrap(), expected);
+        }
+
+        set_voice_action_enabled(&mut settings, true).unwrap();
+        settings.dictation_hotkey = settings.edit_hotkey.clone();
+        set_voice_action_enabled(&mut settings, false).unwrap();
+        assert!(!settings.voice_action.enabled);
+    }
+
+    #[test]
     fn shortcut_side_changes_reject_overlap_without_changing_the_saved_binding() {
         let mut settings = AppSettings::default();
+        settings.voice_action.enabled = true;
         settings.dictation_hotkey.modifiers.option = Some(ModifierSide::Left);
         settings.edit_hotkey = HotkeyBinding {
             modifiers: HotkeyModifiers {

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,9 @@ enum Command {
         /// Select the Global row in the representative Modes preview.
         #[arg(long)]
         select_global_mode: bool,
+        /// Enable Voice Action in the preview; it is off by default.
+        #[arg(long)]
+        voice_action_enabled: bool,
         /// Preview OpenCode-dependent controls without an available installation.
         #[arg(long)]
         opencode_unavailable: bool,
@@ -453,6 +456,7 @@ fn main() -> Result<()> {
             collapse_mode_processing,
             open_transformation_picker,
             select_global_mode,
+            voice_action_enabled,
             opencode_unavailable,
             permissions_missing,
             model_missing,
@@ -499,6 +503,7 @@ fn main() -> Result<()> {
                     collapse_mode_processing,
                     open_transformation_picker,
                     select_global_mode,
+                    voice_action_enabled,
                     opencode_unavailable,
                     permissions_missing,
                     model_missing,
@@ -712,7 +717,38 @@ fn is_bundled_app_executable(name: Option<&std::ffi::OsStr>) -> bool {
 
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
-    use super::is_bundled_app_executable;
+    use super::{Cli, Command, is_bundled_app_executable};
+    use clap::Parser;
+
+    #[test]
+    fn voice_action_preview_requires_explicit_opt_in() {
+        let cli = Cli::try_parse_from(["hex", "preview", "voice-action"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Preview {
+                voice_action_enabled: false,
+                opencode_unavailable: false,
+                ..
+            })
+        ));
+
+        let cli = Cli::try_parse_from([
+            "hex",
+            "preview",
+            "voice-action",
+            "--voice-action-enabled",
+            "--opencode-unavailable",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Preview {
+                voice_action_enabled: true,
+                opencode_unavailable: true,
+                ..
+            })
+        ));
+    }
 
     #[test]
     fn both_packaged_executable_names_launch_the_app() {

--- a/src/recognition.rs
+++ b/src/recognition.rs
@@ -216,11 +216,13 @@ pub fn listen(
         crate::app_settings::dictation_hotkey(),
     );
     hotkey.set_double_tap_only(crate::app_settings::double_tap_only());
-    let mut edit_hotkey = DictationHotkey::new_without_paste(
-        CaptureInstant::now(),
-        input_monitor.paste_key_code,
-        crate::app_settings::edit_hotkey(),
-    );
+    let mut edit_hotkey = crate::app_settings::edit_hotkey().map(|binding| {
+        DictationHotkey::new_without_paste(
+            CaptureInstant::now(),
+            input_monitor.paste_key_code,
+            binding,
+        )
+    });
     let mut edit_context = None;
     let mut edit_pending_since = None;
     let mut mode = Mode::Listening;
@@ -276,7 +278,10 @@ pub fn listen(
             indicator.send(DictationIndicatorEvent::Started);
         }
     }
-    if edit_hotkey.is_recording() {
+    if edit_hotkey
+        .as_ref()
+        .is_some_and(DictationHotkey::is_recording)
+    {
         input.start(if microphone_policy.release_while_idle {
             CaptureInstant::now()
         } else {
@@ -290,7 +295,10 @@ pub fn listen(
     }
     emit_state(
         &mut events,
-        hotkey.is_recording() || edit_hotkey.is_recording(),
+        hotkey.is_recording()
+            || edit_hotkey
+                .as_ref()
+                .is_some_and(DictationHotkey::is_recording),
         mode,
         &input.device_name(),
     )?;
@@ -337,7 +345,9 @@ pub fn listen(
                         if programmatic.is_some()
                             || input.is_recording()
                             || hotkey.is_recording()
-                            || edit_hotkey.is_recording()
+                            || edit_hotkey
+                                .as_ref()
+                                .is_some_and(DictationHotkey::is_recording)
                             || voice_protocol.is_some()
                         {
                             let _ = reply.send(Err("dictation-busy".into()));
@@ -668,7 +678,44 @@ pub fn listen(
         hotkey.set_double_tap_enabled(crate::app_settings::double_tap_lock());
         hotkey.set_double_tap_only(crate::app_settings::double_tap_only());
         hotkey.set_binding(crate::app_settings::dictation_hotkey());
-        edit_hotkey.set_binding(crate::app_settings::edit_hotkey());
+        match crate::app_settings::edit_hotkey() {
+            Some(binding) => match &mut edit_hotkey {
+                Some(edit) => edit.set_binding(binding),
+                None => {
+                    let mut edit = DictationHotkey::new_without_paste(
+                        CaptureInstant::now(),
+                        input_monitor.paste_key_code,
+                        binding,
+                    );
+                    edit.wait_for_release();
+                    edit_hotkey = Some(edit);
+                }
+            },
+            None => {
+                if let Some(mut edit) = edit_hotkey.take() {
+                    let was_recording = edit.suspend().is_some();
+                    let was_pending = edit_pending_since.take().is_some();
+                    if (was_recording || was_pending || edit_context.is_some())
+                        && voice_protocol.is_none()
+                    {
+                        hotkey.suppress_until_release();
+                        handle_edit_hotkey_action(
+                            HotkeyAction::Cancel,
+                            CaptureInstant::now(),
+                            &mut edit_context,
+                            &mut recognizer,
+                            &input,
+                            &dictation_worker,
+                            mode,
+                            &context,
+                            &input.device_name(),
+                            &mut events,
+                            indicator.as_ref(),
+                        )?;
+                    }
+                }
+            }
+        }
         let (next_microphone_revision, microphone) = crate::app_settings::microphone_selection();
         if next_microphone_revision != microphone_revision {
             input.request_selection(next_microphone_revision, microphone.as_deref());
@@ -683,7 +730,7 @@ pub fn listen(
         if hotkey_capture_suspended && voice_protocol.is_none() {
             edit_pending_since = None;
             let normal_action = hotkey.suspend();
-            let edit_action = edit_hotkey.suspend();
+            let edit_action = edit_hotkey.as_mut().and_then(DictationHotkey::suspend);
             if normal_action.is_some() || edit_action.is_some() {
                 edit_context = None;
                 handle_hotkey_action(
@@ -740,7 +787,9 @@ pub fn listen(
                 continue;
             }
             if !hotkey.is_recording()
-                && !edit_hotkey.is_recording()
+                && !edit_hotkey
+                    .as_ref()
+                    .is_some_and(DictationHotkey::is_recording)
                 && input_event.is_escape_down()
                 && let Some(job_id) = dictation_worker.cancel_latest()
             {
@@ -753,7 +802,9 @@ pub fn listen(
                 }
                 continue;
             }
-            let edit_action = edit_hotkey.process(input_event, capture_at);
+            let edit_action = edit_hotkey
+                .as_mut()
+                .and_then(|edit| edit.process(input_event, capture_at));
             if matches!(edit_action, Some(HotkeyAction::Start)) && voice_protocol.is_none() {
                 start_pending_voice_action(
                     &mut edit_pending_since,
@@ -770,7 +821,9 @@ pub fn listen(
                 let voice_action_takeover = voice_action_owns_action(
                     action,
                     edit_pending_since.is_some(),
-                    edit_hotkey.is_recording(),
+                    edit_hotkey
+                        .as_ref()
+                        .is_some_and(DictationHotkey::is_recording),
                     edit_action,
                 );
                 if voice_action_takeover {
@@ -811,7 +864,7 @@ pub fn listen(
                             indicator.as_ref(),
                         )?;
                         if !accepted {
-                            edit_hotkey.suspend();
+                            edit_hotkey.as_mut().and_then(DictationHotkey::suspend);
                         }
                     }
                     Some(started_at)
@@ -879,7 +932,9 @@ pub fn listen(
             })
             .duration_since(started)
                 >= MINIMUM_HOLD_DURATION
-        }) && edit_hotkey.is_recording()
+        }) && edit_hotkey
+            .as_ref()
+            .is_some_and(DictationHotkey::is_recording)
         {
             let capture_at = edit_pending_since.expect("pending voice action has a boundary");
             edit_pending_since = None;
@@ -897,7 +952,7 @@ pub fn listen(
                 None,
             )?;
             if !accepted {
-                edit_hotkey.suspend();
+                edit_hotkey.as_mut().and_then(DictationHotkey::suspend);
                 if let Some(indicator) = &indicator {
                     indicator.send(DictationIndicatorEvent::Failed);
                 }
@@ -960,7 +1015,9 @@ pub fn listen(
         }
         input_monitor.set_escape_cancels(
             hotkey.is_recording()
-                || edit_hotkey.is_recording()
+                || edit_hotkey
+                    .as_ref()
+                    .is_some_and(DictationHotkey::is_recording)
                 || voice_protocol.is_some()
                 || programmatic.is_some()
                 || dictation_worker.pending_count() > 0,
@@ -968,7 +1025,11 @@ pub fn listen(
         if received_worker_event {
             emit_engine_state(
                 &mut events,
-                hotkey.is_recording() || edit_hotkey.is_recording() || voice_protocol.is_some(),
+                hotkey.is_recording()
+                    || edit_hotkey
+                        .as_ref()
+                        .is_some_and(DictationHotkey::is_recording)
+                    || voice_protocol.is_some(),
                 &dictation_worker,
                 mode,
                 &input.device_name(),
@@ -991,7 +1052,7 @@ pub fn listen(
                     }
                     programmatic = None;
                     hotkey.suspend();
-                    edit_hotkey.suspend();
+                    edit_hotkey.as_mut().and_then(DictationHotkey::suspend);
                     edit_context = None;
                     edit_pending_since = None;
                     feedback::play(Tone::Error);
@@ -1043,7 +1104,7 @@ pub fn listen(
                     if was_recording {
                         programmatic = None;
                         hotkey.suspend();
-                        edit_hotkey.suspend();
+                        edit_hotkey.as_mut().and_then(DictationHotkey::suspend);
                         voice_protocol = None;
                         edit_context = None;
                         edit_pending_since = None;
@@ -1089,7 +1150,7 @@ pub fn listen(
                     edit_context = None;
                     edit_pending_since = None;
                     hotkey.suspend();
-                    edit_hotkey.suspend();
+                    edit_hotkey.as_mut().and_then(DictationHotkey::suspend);
                     input.discard_recognition_backlog();
                     reset_recognizer(&mut recognizer)?;
                     recognition_origin = None;
@@ -1136,7 +1197,9 @@ pub fn listen(
             && recognizer.is_some()
             && programmatic.is_none()
             && !hotkey.suppresses_recognition()
-            && !edit_hotkey.suppresses_recognition()
+            && !edit_hotkey
+                .as_ref()
+                .is_some_and(DictationHotkey::suppresses_recognition)
         {
             let generation = input.recognition_generation();
             if recognition_origin.is_none_or(|(current, _)| current != generation) {
@@ -1159,7 +1222,9 @@ pub fn listen(
             Some(audio)
                 if programmatic.is_some()
                     || hotkey.suppresses_recognition()
-                    || edit_hotkey.suppresses_recognition() =>
+                    || edit_hotkey
+                        .as_ref()
+                        .is_some_and(DictationHotkey::suppresses_recognition) =>
             {
                 if let Some(indicator) = &indicator {
                     indicator.meter(&audio.samples);
@@ -1183,7 +1248,9 @@ pub fn listen(
         if !input.is_recovering()
             && programmatic.is_none()
             && !hotkey.suppresses_recognition()
-            && !edit_hotkey.suppresses_recognition()
+            && !edit_hotkey
+                .as_ref()
+                .is_some_and(DictationHotkey::suppresses_recognition)
             && last_update.elapsed() >= UPDATE_INTERVAL
             && let Some(recognizer) = &mut recognizer
             && let Some(action_executor) = &action_executor

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::c_void;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
@@ -498,20 +498,21 @@ fn send_input(context: &EventTapContext, event: InputEvent, capture_at: CaptureI
 
 #[derive(Default)]
 struct ShortcutSuppression {
-    shortcut_keys_pressed: HashSet<u16>,
+    // Repeats and releases keep the original press's suppression decision.
+    key_presses: HashMap<u16, bool>,
     escape_pressed: bool,
 }
 
 impl ShortcutSuppression {
     fn reset(&mut self) {
-        self.shortcut_keys_pressed.clear();
+        self.key_presses.clear();
         self.escape_pressed = false;
     }
 
     fn process_all(&mut self, input: InputEvent, hotkeys: RuntimeHotkeys, delivered: bool) -> bool {
         let bindings = [
             Some(hotkeys.dictation),
-            Some(hotkeys.edit),
+            hotkeys.edit,
             hotkeys.paste_last,
             hotkeys.paste_meeting,
         ];
@@ -520,18 +521,16 @@ impl ShortcutSuppression {
                 code,
                 down: true,
                 flags,
-            } if delivered
-                && bindings
-                    .iter()
-                    .flatten()
-                    .any(|hotkey| hotkey.matches_key_press(code, flags)) =>
-            {
-                self.shortcut_keys_pressed.insert(code);
-                true
-            }
+            } => *self.key_presses.entry(code).or_insert_with(|| {
+                delivered
+                    && bindings
+                        .iter()
+                        .flatten()
+                        .any(|hotkey| hotkey.matches_key_press(code, flags))
+            }),
             InputEvent::Key {
                 code, down: false, ..
-            } => self.shortcut_keys_pressed.remove(&code),
+            } => self.key_presses.remove(&code).unwrap_or(false),
             _ => false,
         }
     }
@@ -552,7 +551,7 @@ impl ShortcutSuppression {
             input,
             RuntimeHotkeys {
                 dictation: hotkey,
-                edit: RuntimeHotkey::default(),
+                edit: None,
                 paste_last: Some(paste_last),
                 paste_meeting: Some(paste_meeting),
             },
@@ -655,6 +654,7 @@ pub struct DictationHotkey {
     last_release_at: Option<CaptureInstant>,
     binding: RuntimeHotkey,
     paste_actions_enabled: bool,
+    ignore_before: Option<CaptureInstant>,
 }
 
 impl DictationHotkey {
@@ -711,6 +711,7 @@ impl DictationHotkey {
             last_release_at: None,
             binding,
             paste_actions_enabled: true,
+            ignore_before: None,
         }
     }
 
@@ -760,7 +761,48 @@ impl DictationHotkey {
         was_recording.then_some(HotkeyAction::Cancel)
     }
 
+    pub fn wait_for_release(&mut self) {
+        // A settings transition is not a new press; preserve held-key suppression.
+        let now = CaptureInstant::now();
+        // SAFETY: These are read-only queries of the documented HID system state.
+        let flags = unsafe { CGEventSourceFlagsState(HID_SYSTEM_STATE) };
+        let key_down = self
+            .binding
+            .key_code
+            .is_some_and(|code| unsafe { CGEventSourceKeyState(HID_SYSTEM_STATE, code) });
+        self.wait_for_release_with_state(now, flags, key_down);
+    }
+
+    pub fn suppress_until_release(&mut self) {
+        self.state = State::Dirty;
+        self.last_release_at = None;
+    }
+
+    fn wait_for_release_with_state(&mut self, now: CaptureInstant, flags: u64, key_down: bool) {
+        self.suspend();
+        self.ignore_before = Some(now);
+        if key_down && let Some(code) = self.binding.key_code {
+            self.pressed_keys.insert(code);
+        }
+        if flags & HOTKEY_MODIFIERS_MASK != 0 || !self.pressed_keys.is_empty() {
+            self.state = State::Dirty;
+        }
+    }
+
     pub fn process(&mut self, event: InputEvent, now: CaptureInstant) -> Option<HotkeyAction> {
+        if matches!(event, InputEvent::TapDisabled) {
+            let was_recording = self.is_recording();
+            self.state = State::Dirty;
+            self.last_release_at = None;
+            return was_recording.then_some(HotkeyAction::Cancel);
+        }
+        // Queued edges from before an opt-in transition cannot start a new capture.
+        if self
+            .ignore_before
+            .is_some_and(|changed_at| now < changed_at)
+        {
+            return None;
+        }
         let fresh_key_down = match event {
             InputEvent::Key { code, down, .. } => {
                 if down {
@@ -773,12 +815,6 @@ impl DictationHotkey {
             InputEvent::Flags(_) | InputEvent::MouseDown | InputEvent::TapDisabled => false,
         };
 
-        if matches!(event, InputEvent::TapDisabled) {
-            let was_recording = self.is_recording();
-            self.state = State::Dirty;
-            self.last_release_at = None;
-            return was_recording.then_some(HotkeyAction::Cancel);
-        }
         if self.paste_actions_enabled
             && fresh_key_down
             && let Some(action) = paste_action(event, crate::app_settings::runtime_hotkeys())
@@ -1313,6 +1349,207 @@ mod tests {
                 now + Duration::from_secs(1),
             ),
             Some(HotkeyAction::Finish)
+        );
+    }
+
+    #[test]
+    fn voice_action_uses_separate_binding_after_dictation_is_rebound() {
+        use crate::app_settings::{
+            AppSettings, COMMAND_KEY_MASK, CONTROL_KEY_MASK, LEFT_COMMAND_MASK, LEFT_CONTROL_MASK,
+            LEFT_OPTION_MASK, RIGHT_CONTROL_MASK,
+        };
+
+        let mut settings: AppSettings = serde_json::from_str(
+            r#"{"dictation_hotkey":{"modifiers":{"control":"right"},"key":null}}"#,
+        )
+        .unwrap();
+        settings.voice_action.enabled = true;
+        let now = capture_time();
+        let mut dictation = DictationHotkey::with_binding(
+            false,
+            now,
+            42,
+            false,
+            settings.dictation_hotkey.runtime(),
+        );
+        let mut edit = DictationHotkey::with_binding(
+            false,
+            now,
+            42,
+            false,
+            settings.runtime_hotkeys().edit.unwrap(),
+        );
+        assert_eq!(
+            dictation.process(InputEvent::Flags(CONTROL_KEY_MASK | LEFT_CONTROL_MASK), now),
+            None
+        );
+        assert_eq!(dictation.process(InputEvent::Flags(0), now), None);
+        assert_eq!(
+            dictation.process(
+                InputEvent::Flags(CONTROL_KEY_MASK | RIGHT_CONTROL_MASK),
+                now
+            ),
+            Some(HotkeyAction::Start)
+        );
+        assert_eq!(
+            dictation.process(InputEvent::Flags(0), now + Duration::from_secs(1)),
+            Some(HotkeyAction::Finish)
+        );
+
+        let chord = InputEvent::Flags(
+            OPTION_KEY_MASK | COMMAND_KEY_MASK | LEFT_OPTION_MASK | LEFT_COMMAND_MASK,
+        );
+        assert_eq!(dictation.process(chord, now + Duration::from_secs(2)), None);
+        assert_eq!(
+            edit.process(chord, now + Duration::from_secs(2)),
+            Some(HotkeyAction::Start)
+        );
+    }
+
+    #[test]
+    fn voice_action_toggle_preserves_ownership_of_in_progress_key_gestures() {
+        use crate::app_settings::{AppSettings, HotkeyKey};
+
+        let mut settings = AppSettings::default();
+        settings.edit_hotkey.key = Some(HotkeyKey {
+            code: 40,
+            label: "K".into(),
+        });
+        let event = |down| InputEvent::Key {
+            code: 40,
+            down,
+            flags: OPTION_KEY_MASK | crate::app_settings::COMMAND_KEY_MASK,
+        };
+        for enabled in [false, true] {
+            let mut suppression = ShortcutSuppression::default();
+            settings.voice_action.enabled = enabled;
+            assert_eq!(
+                suppression.process_all(event(true), settings.runtime_hotkeys(), true),
+                enabled
+            );
+            settings.voice_action.enabled = !enabled;
+            for delivered in [true, false] {
+                assert_eq!(
+                    suppression.process_all(event(true), settings.runtime_hotkeys(), delivered),
+                    enabled
+                );
+            }
+            assert_eq!(
+                suppression.process_all(event(false), settings.runtime_hotkeys(), true),
+                enabled
+            );
+            assert_eq!(
+                suppression.process_all(event(true), settings.runtime_hotkeys(), true),
+                !enabled
+            );
+            assert_eq!(
+                suppression.process_all(event(false), settings.runtime_hotkeys(), true),
+                !enabled
+            );
+        }
+    }
+
+    #[test]
+    fn tap_failure_cancels_recording_after_live_opt_in() {
+        let now = capture_time();
+        let mut hotkey = test_hotkey(false, now);
+        hotkey.wait_for_release_with_state(now, 0, false);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), now),
+            Some(HotkeyAction::Start)
+        );
+        assert_eq!(
+            hotkey.process(InputEvent::TapDisabled, CaptureInstant::ZERO),
+            Some(HotkeyAction::Cancel)
+        );
+        assert!(!hotkey.is_recording());
+    }
+
+    #[test]
+    fn enabling_a_held_key_binding_waits_for_a_fresh_press() {
+        let now = capture_time();
+        let binding = RuntimeHotkey {
+            modifiers: Default::default(),
+            key_code: Some(40),
+        };
+        let mut hotkey = DictationHotkey::with_binding(false, now, 42, false, binding);
+        let event = |down| InputEvent::Key {
+            code: 40,
+            down,
+            flags: 0,
+        };
+        hotkey.wait_for_release_with_state(now, 0, true);
+        assert_eq!(hotkey.process(event(true), now), None);
+        assert_eq!(hotkey.process(InputEvent::Flags(0), now), None);
+        assert_eq!(hotkey.process(event(false), now), None);
+        assert_eq!(hotkey.process(event(true), now), Some(HotkeyAction::Start));
+    }
+
+    #[test]
+    fn changing_voice_action_does_not_activate_a_remaining_option_modifier() {
+        let now = capture_time();
+        let chord = OPTION_KEY_MASK | crate::app_settings::COMMAND_KEY_MASK;
+        let mut hotkey = test_hotkey(false, now);
+        hotkey.suppress_until_release();
+        assert_eq!(hotkey.process(InputEvent::Flags(chord), now), None);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), now),
+            None
+        );
+        assert_eq!(hotkey.process(InputEvent::Flags(0), now), None);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), now),
+            Some(HotkeyAction::Start)
+        );
+    }
+
+    #[test]
+    fn waiting_for_release_does_not_block_explicit_paste() {
+        let now = capture_time();
+        let mut hotkey = test_hotkey(false, now);
+        hotkey.suppress_until_release();
+        let binding = HotkeyBinding::paste_last_default();
+        assert_eq!(
+            hotkey.process(
+                InputEvent::Key {
+                    code: binding.key.unwrap().code,
+                    down: true,
+                    flags: OPTION_KEY_MASK | SHIFT_KEY_MASK,
+                },
+                now
+            ),
+            Some(HotkeyAction::PasteLast)
+        );
+    }
+
+    #[test]
+    fn enabling_with_no_keys_held_accepts_the_next_gesture() {
+        let now = capture_time();
+        let mut hotkey = test_hotkey(false, now);
+        hotkey.wait_for_release_with_state(now, 0, false);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), now),
+            Some(HotkeyAction::Start)
+        );
+    }
+
+    #[test]
+    fn opt_in_transitions_ignore_queued_old_shortcut_edges() {
+        let now = capture_time();
+        let mut hotkey = test_hotkey(false, now);
+        let changed_at = now + Duration::from_secs(1);
+        hotkey.wait_for_release_with_state(changed_at, 0, false);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), now),
+            None
+        );
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(0), now + Duration::from_millis(500)),
+            None
+        );
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), changed_at),
+            Some(HotkeyAction::Start)
         );
     }
 


### PR DESCRIPTION
## Why

Changing Dictation to Right Control left the separate Command-Option Voice Action shortcut active. Someone who had never configured Voice Action could therefore see a recording HUD followed by an OpenCode error. Addresses #37.

## What Changes

| Case | New behavior |
| --- | --- |
| New installation or existing settings without an explicit opt-in | Voice Action starts off, including when a model was previously selected |
| Voice Action is off | Its saved shortcut neither captures nor reserves keys |
| User enables Voice Action | The existing shortcut and model are reused; conflicting active shortcuts are rejected without rebinding |
| OpenCode is unavailable | The enable/disable toggle and shortcut editor remain accessible |
| Feature changes while keys are held | Existing key gestures remain balanced; activation waits for a fresh gesture |
| Feature is disabled during capture | Active Voice Action capture is cancelled without cancelling accepted jobs or falling through to Option dictation |

Saved shortcuts, model choices, variants, and deadlines are retained. Runtime shortcut projection omits Voice Action until enabled. Event-tap failure still cancels recording even when its notification has no timestamp.

## Demo

The release previews opened for off, enabled, and OpenCode-unavailable states. Screenshot capture is blocked by macOS Screen Recording permission, so no visual comparison is attached. Native physical-key/UI behavior has not been manually exercised; the transition tests use the production state machines with deterministic events.

## Scope

Prepares macOS 2.1.3/build 20103. App identity, signing key, updater packaging, and Rust data location remain unchanged. This does not publish a Linux binary or alter the legacy Swift feed.

## Verification

```sh
cargo fmt --all --check
cargo test --locked --bin voice-control
cargo clippy --locked --all-targets --all-features -- -D warnings
cargo build --locked --release --bin voice-control
./scripts/test-app-identity.sh
git diff --check
```

370 tests passed, 9 ignored; Clippy, formatting, and identity checks passed. Regression tests demonstrated failure before the opt-in fix and before the held-key ownership and zero-timestamp cancellation fixes. Coverage includes persisted opt-in defaults, preserved configuration, inactive shortcuts, conflict rejection, key repeat/release ownership in both toggle directions, queued old edges, and explicit paste while waiting for release.

Native Linux and full Nix CI also passed: https://github.com/anomalyco/hex/actions/runs/33192773527.

Apple accepted app and DMG notarization; both are stapled, and Gatekeeper accepts them. Native Sparkle validation and temporary installation passed from public 2.0.24, 2.1.0, 2.1.1, and 2.1.2 to build 20103. Signed packaged previews opened in all three Voice Action states.

Publication completed artifact-first/feed-last. Public versioned DMG, latest DMG, updater ZIP, and feed matched the prepared artifacts byte-for-byte. The installed app updated through Sparkle from 2.1.2 to 2.1.3 and relaunched; installed contents, metadata, signatures, and Gatekeeper validation match the release.

## Release Artifacts

[Download Hex 2.1.3](https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/releases/HEX-2.1.3-arm64.dmg)

- DMG: 34,347,117 bytes; SHA-256 `4b24516471e022fc649e51b8afdebf96500bb2bb0b31b3375a6775cf3e5245c5`.
- Updater ZIP: 32,796,964 bytes; SHA-256 `50a806af77c45f64d0416a562f026c50152141459cc289cc3e4c8c932361bd57`.
