### PR TITLE
fix: recover startup audio and update Effect SDKs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,9 @@ CoreAudio formats, AppleScript details, or event serialization.
   `--device` remains authoritative for that listener process. A runtime stream
   failure cancels an incomplete capture, discards stale chunks, and retries the
   same selection with bounded backoff; it must not require a settings change or
-  process restart.
+  process restart. An initial open failure uses the same bounded recovery without
+  stopping the listener. Cancellation does not stop warm-microphone retries;
+  enabling release-while-idle stops them once capture is idle.
 - Feedback volume is persisted from zero through one; zero disables tones.
   Volume changes apply immediately and preview one recording-start tone.
 - Launch at Login uses `SMAppService` for the signed main app. Treat both

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8677,7 +8677,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voice-control"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice-control"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 default-run = "voice-control"
 license = "MIT"

--- a/docs/plans/personal-commands.md
+++ b/docs/plans/personal-commands.md
@@ -111,8 +111,9 @@ Provisioning installs:
 
 `.hex-sdk` is bundled and managed by HEX; it is not an npm package and must not
 be edited. On startup, HEX atomically refreshes it from the running app bundle
-and runs `bun install` when its contents or required workspace dependencies
-change. User config, unrelated package metadata, scripts, and third-party
+and runs the targeted `bun update @hex/commands` when its contents or required
+workspace dependencies change. A plain install can retain stale Effect peer
+metadata for the local SDK in `bun.lock`. User config, unrelated package metadata, scripts, and third-party
 dependencies are preserved. There is one narrow metadata exception: on init
 and startup, HEX adds a missing Effect dependency or upgrades the exact legacy
 pins `4.0.0-beta.97` and `4.0.0-beta.107` to the bundled SDK's exact

--- a/docs/plans/personal-commands.md
+++ b/docs/plans/personal-commands.md
@@ -111,11 +111,34 @@ Provisioning installs:
 
 `.hex-sdk` is bundled and managed by HEX; it is not an npm package and must not
 be edited. On startup, HEX atomically refreshes it from the running app bundle
-and reinstalls only the managed `@hex/commands` dependency when its contents
-change. User config, package metadata, and third-party dependencies are
-preserved. Run `bun run check` after changing the config. HEX watches the
-workspace, activates valid changes, and reports the last reload error in the
-Commands pane.
+and runs `bun install` when its contents or required workspace dependencies
+change. User config, unrelated package metadata, scripts, and third-party
+dependencies are preserved. There is one narrow metadata exception: on init
+and startup, HEX adds a missing Effect dependency or upgrades the exact legacy
+pins `4.0.0-beta.97` and `4.0.0-beta.107` to the bundled SDK's exact
+`peerDependencies.effect` version. The current exact pin is left untouched.
+Effect entries in dependency, dev/optional/peer dependency, override, and
+resolution maps are checked together so duplicate pins cannot conflict.
+Custom Effect specifications are never silently replaced. Effect-targeting
+indirect selectors (such as `**/effect` or `@hex/commands>effect`) and nested
+Effect overrides/resolutions must be removed rather than automatically rewritten;
+use the SDK-required exact version in `dependencies.effect`. Unrelated scoped
+packages such as `@effect/platform` and `@other/effect` are preserved. Bun 1.3.14
+honors `resolutions["**/effect"]`; some other selector forms are currently ignored
+or warned about, but HEX rejects them rather than relying on that behavior.
+
+Manifest validation failures leave existing files unchanged and report how to
+repair the manifest. A symlinked `package.json` is retained when already current;
+links needing migration and dangling links are never replaced automatically.
+Update the linked manifest manually or use a regular manifest before retrying. Rewrites
+preserve regular-file permissions. SDK refresh and manifest replacement are
+separate operations, not a multi-file transaction: if writing the manifest
+fails, the SDK may already be refreshed while the old manifest remains. Fix
+the reported filesystem problem and rerun `hex commands init`; the unchanged
+legacy pin still triggers migration and installation on retry.
+
+Run `bun run check` after changing the config. HEX watches the workspace,
+activates valid changes, and reports the last reload error in the Commands pane.
 
 ## Runtime Boundary
 

--- a/docs/releases/2.1.4.md
+++ b/docs/releases/2.1.4.md
@@ -1,0 +1,20 @@
+## Hex 2.1.4
+
+- If the microphone cannot open at startup, Hex now keeps running and retries
+  automatically instead of requiring an app restart. Retries back off from
+  250 milliseconds to a maximum interval of five seconds.
+- Cancelling a capture does not stop warm-microphone recovery. Microphone
+  selection changes and the Release microphone while idle setting preserve
+  the intended recording policy, including while a device is still opening.
+- A capture rejected while the microphone is unavailable no longer reports a
+  successful recording or leaves a recording indicator behind.
+- The bundled TypeScript command SDK now uses Effect 4.0.0-rc.112 and its
+  current tagged-error API. Existing workspaces with known older Effect pins
+  upgrade without replacing user configuration or unrelated dependencies;
+  conflicting custom pins receive an actionable error instead of being overwritten.
+  The public TypeScript SDK is updated separately through its npm release workflow.
+
+This macOS release uses build 20104 and retains the existing app identity,
+permissions, settings location, signing key, and Rust update feed. The legacy
+Swift app and its separate feed are unchanged. No Linux binary is published
+with this release.

--- a/scripts/smoke-commands-workspace.sh
+++ b/scripts/smoke-commands-workspace.sh
@@ -6,13 +6,63 @@ temporary=$(mktemp -d "${TMPDIR:-/tmp}/hex-commands.XXXXXX")
 trap 'rm -rf "$temporary"' EXIT
 
 (cd "$root/sdk/commands" && bun run build)
-cp -R "$root/sdk/commands/workspace-template/." "$temporary/"
-mkdir "$temporary/.hex-sdk"
-cp "$root/sdk/commands/package.json" "$temporary/.hex-sdk/"
-cp -R "$root/sdk/commands/dist" "$temporary/.hex-sdk/dist"
-(cd "$temporary" && bun install && bun run check)
 
-resolved=$(cd "$temporary" && bun -e \
-  'import sdk from "@hex/commands/package.json" with { type: "json" }; import effect from "effect/package.json" with { type: "json" }; console.log(`${sdk.version}:${effect.version}`)')
-test "$resolved" = "0.0.0:4.0.0-beta.97"
-echo "$temporary workspace passed"
+for fixture in fresh 4.0.0-beta.97 4.0.0-beta.107; do
+  workspace="$temporary/$fixture"
+  mkdir "$workspace"
+  cp -R "$root/sdk/commands/workspace-template/." "$workspace/"
+  mkdir "$workspace/.hex-sdk"
+  cp "$root/sdk/commands/package.json" "$workspace/.hex-sdk/"
+  cp -R "$root/sdk/commands/dist" "$workspace/.hex-sdk/dist"
+
+  if [ "$fixture" != fresh ]; then
+    # Rust tests cover reconciliation. Exercise Bun upgrading an existing lockfile
+    # and node_modules here, rather than only installing into an empty workspace.
+    (cd "$workspace" && bun -e '
+      const manifest = await Bun.file("package.json").json()
+      const sdk = await Bun.file(".hex-sdk/package.json").json()
+      manifest.dependencies.effect = sdk.peerDependencies.effect = process.argv[1]
+      manifest.scripts.custom = "echo preserved"
+      manifest.userMetadata = { keep: true }
+      await Bun.write("package.json", JSON.stringify(manifest, null, 2))
+      await Bun.write(".hex-sdk/package.json", JSON.stringify(sdk, null, 2))
+    ' "$fixture" && bun install)
+    cp "$workspace/hex.config.ts" "$workspace/config-before.ts"
+    cp "$root/sdk/commands/package.json" "$workspace/.hex-sdk/package.json"
+    rm -rf "$workspace/node_modules/@hex/commands"
+    (cd "$workspace" && bun -e '
+      const manifest = await Bun.file("package.json").json()
+      const sdk = await Bun.file(".hex-sdk/package.json").json()
+      manifest.dependencies.effect = sdk.peerDependencies.effect
+      await Bun.write("package.json", JSON.stringify(manifest, null, 2))
+    ')
+  fi
+
+  (cd "$workspace" && bun install && bun run check && bun -e '
+    import assert from "node:assert/strict"
+    import { Effect } from "effect"
+    import { ToolCallError } from "@hex/commands/effect"
+    import { evaluateConfig, runHost } from "./node_modules/@hex/commands/dist/host.js"
+    import sdk from "@hex/commands/package.json" with { type: "json" }
+    import effect from "effect/package.json" with { type: "json" }
+
+    const manifest = await Bun.file("package.json").json()
+    assert.equal(effect.version, sdk.peerDependencies.effect)
+    assert.equal(manifest.dependencies.effect, sdk.peerDependencies.effect)
+    assert.equal(new ToolCallError({ message: "smoke" })._tag, "Hex.ToolCallError")
+    assert.equal(await Effect.runPromise(Effect.succeed("ready")), "ready")
+    const frames = []
+    await runHost({
+      config: await evaluateConfig(`${process.cwd()}/hex.config.ts`),
+      input: (async function* () { yield "{\"type\":\"shutdown\"}\n" })(),
+      write: (frame) => { frames.push(frame) },
+    })
+    assert.equal(frames[0]?.type, "registration")
+    if (await Bun.file("config-before.ts").exists()) {
+      assert.equal(await Bun.file("hex.config.ts").text(), await Bun.file("config-before.ts").text())
+      assert.equal(manifest.scripts.custom, "echo preserved")
+      assert.deepEqual(manifest.userMetadata, { keep: true })
+    }
+  ')
+  echo "$fixture workspace passed"
+done

--- a/scripts/smoke-commands-workspace.sh
+++ b/scripts/smoke-commands-workspace.sh
@@ -22,6 +22,7 @@ for fixture in fresh 4.0.0-beta.97 4.0.0-beta.107; do
       const manifest = await Bun.file("package.json").json()
       const sdk = await Bun.file(".hex-sdk/package.json").json()
       manifest.dependencies.effect = sdk.peerDependencies.effect = process.argv[1]
+      sdk.devDependencies.effect = process.argv[1]
       manifest.scripts.custom = "echo preserved"
       manifest.userMetadata = { keep: true }
       await Bun.write("package.json", JSON.stringify(manifest, null, 2))
@@ -38,7 +39,7 @@ for fixture in fresh 4.0.0-beta.97 4.0.0-beta.107; do
     ')
   fi
 
-  (cd "$workspace" && bun install && bun run check && bun -e '
+  (cd "$workspace" && bun update @hex/commands && bun run check && bun -e '
     import assert from "node:assert/strict"
     import { Effect } from "effect"
     import { ToolCallError } from "@hex/commands/effect"

--- a/sdk/.changeset/modern-effect-sdk.md
+++ b/sdk/.changeset/modern-effect-sdk.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/hex": patch
+---
+
+Support Effect 4.0.0-rc.112 and newer in the Effect client, using the current tagged-error API.

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -16,12 +16,12 @@
       },
       "devDependencies": {
         "@types/bun": "^1.3.0",
-        "effect": "4.0.0-beta.97",
+        "effect": "4.0.0-rc.112",
         "typescript": "^7.0.0",
         "vitest": "^3.2.4",
       },
       "peerDependencies": {
-        "effect": "4.0.0-beta.97",
+        "effect": "4.0.0-rc.112",
       },
     },
     "service-darwin-arm64": {
@@ -30,15 +30,15 @@
     },
     "typescript": {
       "name": "@kitlangton/hex",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "devDependencies": {
         "@types/node": "^24.0.0",
-        "effect": "4.0.0-beta.97",
+        "effect": "4.0.0-rc.112",
         "typescript": "^7.0.0",
         "vitest": "^3.2.4",
       },
       "peerDependencies": {
-        "effect": ">=4.0.0-beta.97 <5.0.0",
+        "effect": ">=4.0.0-rc.112 <5.0.0",
       },
       "optionalPeers": [
         "effect",
@@ -216,8 +216,6 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
@@ -318,7 +316,7 @@
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
-    "effect": ["effect@4.0.0-beta.97", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg=="],
+    "effect": ["effect@4.0.0-rc.112", "", { "dependencies": { "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A=="],
 
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
@@ -344,8 +342,6 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
-    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
-
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
@@ -363,8 +359,6 @@
     "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -384,8 +378,6 @@
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
-    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
-
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
@@ -402,11 +394,9 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
+    "msgpackr": ["msgpackr@2.1.0", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
-
-    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
 
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
@@ -508,15 +498,11 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "toml": ["toml@4.3.0", "", {}, "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A=="],
-
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
-    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 

--- a/sdk/commands/package.json
+++ b/sdk/commands/package.json
@@ -28,11 +28,11 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "effect": "4.0.0-beta.97"
+    "effect": "4.0.0-rc.112"
   },
   "devDependencies": {
     "@types/bun": "^1.3.0",
-    "effect": "4.0.0-beta.97",
+    "effect": "4.0.0-rc.112",
     "typescript": "^7.0.0",
     "vitest": "^3.2.4"
   }

--- a/sdk/commands/src/effect.ts
+++ b/sdk/commands/src/effect.ts
@@ -23,7 +23,7 @@ import type {
   NativeAction,
 } from "./model.js"
 
-export class ToolCallError extends Schema.TaggedErrorClass<ToolCallError>()(
+export class ToolCallError extends Schema.TaggedError<ToolCallError>()(
   "Hex.ToolCallError",
   { message: Schema.String, code: Schema.optionalKey(Schema.String) },
 ) {}

--- a/sdk/commands/workspace-template/package.json
+++ b/sdk/commands/workspace-template/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@hex/commands": "file:.hex-sdk",
-    "effect": "4.0.0-beta.97"
+    "effect": "4.0.0-rc.112"
   },
   "devDependencies": {
     "typescript": "7.0.2"

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -78,6 +78,9 @@ deadline.
 
 ## Effect API
 
+Install Effect 4.0.0-rc.112 or newer within v4 to use `@kitlangton/hex/effect`.
+Effect remains optional for the Promise API.
+
 The Effect entrypoint exposes scoped acquisition, typed schema-backed errors,
 Effect operations, and a progress `Stream`:
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -38,7 +38,7 @@
     "prepublishOnly": "bun run check && bun run test && bun run build"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0-beta.97 <5.0.0"
+    "effect": ">=4.0.0-rc.112 <5.0.0"
   },
   "peerDependenciesMeta": {
     "effect": {
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
-    "effect": "4.0.0-beta.97",
+    "effect": "4.0.0-rc.112",
     "typescript": "^7.0.0",
     "vitest": "^3.2.4"
   }

--- a/sdk/typescript/src/effect.ts
+++ b/sdk/typescript/src/effect.ts
@@ -18,17 +18,17 @@ const ErrorFields = {
   cause: Schema.optionalKey(Schema.Defect()),
 }
 
-export class StartupError extends Schema.TaggedErrorClass<StartupError>()(
+export class StartupError extends Schema.TaggedError<StartupError>()(
   "Hex.StartupError",
   ErrorFields,
 ) {}
 
-export class ProtocolError extends Schema.TaggedErrorClass<ProtocolError>()(
+export class ProtocolError extends Schema.TaggedError<ProtocolError>()(
   "Hex.ProtocolError",
   ErrorFields,
 ) {}
 
-export class RequestError extends Schema.TaggedErrorClass<RequestError>()(
+export class RequestError extends Schema.TaggedError<RequestError>()(
   "Hex.RequestError",
   {
     ...ErrorFields,
@@ -37,7 +37,7 @@ export class RequestError extends Schema.TaggedErrorClass<RequestError>()(
   },
 ) {}
 
-export class ModelPreparationError extends Schema.TaggedErrorClass<ModelPreparationError>()(
+export class ModelPreparationError extends Schema.TaggedError<ModelPreparationError>()(
   "Hex.ModelPreparationError",
   {
     ...ErrorFields,
@@ -45,7 +45,7 @@ export class ModelPreparationError extends Schema.TaggedErrorClass<ModelPreparat
   },
 ) {}
 
-export class CancellationError extends Schema.TaggedErrorClass<CancellationError>()(
+export class CancellationError extends Schema.TaggedError<CancellationError>()(
   "Hex.CancellationError",
   ErrorFields,
 ) {}

--- a/sdk/typescript/test/effect.test.ts
+++ b/sdk/typescript/test/effect.test.ts
@@ -4,6 +4,25 @@ import * as Hex from "../src/effect.js"
 import { options, processIsAlive } from "./support.js"
 
 describe("Effect client", () => {
+  it.each([
+    Hex.StartupError,
+    Hex.ProtocolError,
+    Hex.RequestError,
+    Hex.ModelPreparationError,
+    Hex.CancellationError,
+  ])("preserves tagged error fields and yieldable failures for %s", async (ErrorClass) => {
+    const cause = new Error("underlying failure")
+    const error = new ErrorClass({ code: "test-failure", message: "operation failed", cause })
+    expect(error).toBeInstanceOf(Error)
+    expect(error._tag).toBe(`Hex.${ErrorClass.name}`)
+    expect(error.message).toBe("operation failed")
+    expect(error.cause).toBe(cause)
+    const failure = await Effect.runPromise(Effect.gen(function* () {
+      return yield* error
+    }).pipe(Effect.flip))
+    expect(failure).toBe(error)
+  })
+
   it("scopes the helper and exposes Effect and Stream operations", async () => {
     let pid = 0
     const result = await Effect.runPromise(Effect.scoped(Effect.gen(function* () {

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -106,7 +106,8 @@ impl Add<Duration> for CaptureInstant {
 }
 
 pub struct AudioInput {
-    _stream: Stream,
+    // Tests can deliver PCM through channels without opening a native microphone.
+    _stream: Option<Stream>,
     chunks: Receiver<(Vec<f32>, CaptureInstant)>,
     pub sample_rate: u32,
     pub device_name: String,
@@ -122,13 +123,15 @@ pub enum AudioInputEvent {
     StreamFailed(String),
 }
 
+type InputOpenResult = (u64, Result<AudioInput, String>);
+
 pub struct RecoveringAudioInput {
     input: Option<AudioInput>,
     device_override: Option<String>,
     selected_device: Option<String>,
     active_revision: u64,
     recovery: MicrophoneRecovery,
-    replacement: Option<Receiver<(u64, Result<AudioInput, String>)>>,
+    replacement: Option<Receiver<InputOpenResult>>,
 }
 
 pub enum RecoveringAudioInputEvent {
@@ -211,6 +214,22 @@ impl MicrophoneRecovery {
 }
 
 impl AudioInput {
+    #[cfg(test)]
+    pub fn channel_for_test() -> (Self, Sender<(Vec<f32>, CaptureInstant)>) {
+        let (sender, chunks) = mpsc::channel();
+        let (_, stream_errors) = mpsc::channel();
+        (
+            Self {
+                _stream: None,
+                chunks,
+                stream_errors,
+                sample_rate: 48_000,
+                device_name: "Test microphone".into(),
+            },
+            sender,
+        )
+    }
+
     pub fn open(device_queries: &[&str]) -> Result<Self> {
         let host = cpal::default_host();
         let device = find_device(&host, device_queries)?;
@@ -272,7 +291,7 @@ impl AudioInput {
             .wrap_err("could not start microphone capture")?;
 
         Ok(Self {
-            _stream: stream,
+            _stream: Some(stream),
             chunks,
             sample_rate,
             device_name,
@@ -310,16 +329,22 @@ impl RecoveringAudioInput {
         device_override: Option<&str>,
         selection_revision: u64,
         selected_device: Option<&str>,
-    ) -> Result<Self> {
-        let input = open_configured_input(device_override, selected_device, true)?;
-        Ok(Self {
-            input: Some(input),
-            device_override: device_override.map(str::to_owned),
-            selected_device: selected_device.map(str::to_owned),
-            active_revision: selection_revision,
-            recovery: MicrophoneRecovery::default(),
-            replacement: None,
-        })
+    ) -> Self {
+        let mut input = Self::closed(device_override, selection_revision, selected_device);
+        let opened = open_configured_input(device_override, selected_device, true);
+        input.finish_initial_open(opened, Instant::now());
+        input
+    }
+
+    fn finish_initial_open(&mut self, opened: Result<AudioInput>, now: Instant) {
+        match opened {
+            Ok(opened) => self.input = Some(opened),
+            Err(error) => {
+                tracing::warn!(%error, "could not open dictation microphone at startup; retrying");
+                self.recovery.request_stream_recovery(now);
+                self.recovery.failed(now);
+            }
+        }
     }
 
     pub fn closed(
@@ -337,10 +362,30 @@ impl RecoveringAudioInput {
         }
     }
 
+    #[cfg(test)]
+    pub fn pending_for_test() -> (Self, Sender<InputOpenResult>) {
+        let mut input = Self::closed(
+            Some("HEX nonexistent microphone for pending open test"),
+            0,
+            None,
+        );
+        let (sender, receiver) = mpsc::channel();
+        input.replacement = Some(receiver);
+        (input, sender)
+    }
+
     pub fn request_open(&mut self) {
-        if self.input.is_none() && self.replacement.is_none() {
+        if self.input.is_none() && self.replacement.is_none() && !self.is_recovering() {
             self.start_replacement();
         }
+    }
+
+    pub fn request_recovery(&mut self) {
+        self.recovery.request_stream_recovery(Instant::now());
+    }
+
+    pub fn is_recovering(&self) -> bool {
+        self.recovery.blocks_audio()
     }
 
     pub fn close(&mut self) {
@@ -358,6 +403,10 @@ impl RecoveringAudioInput {
     }
 
     pub fn cancel_open(&mut self) {
+        // Cancelling a capture must not cancel the warm microphone's recovery.
+        if self.is_recovering() {
+            return;
+        }
         self.replacement = None;
         if self.input.is_none() {
             self.recovery.recovered();
@@ -369,7 +418,7 @@ impl RecoveringAudioInput {
             return;
         }
         self.selected_device = selected_device.map(str::to_owned);
-        if self.input.is_none() {
+        if self.input.is_none() && !self.is_recovering() {
             let was_opening = self.replacement.take().is_some();
             self.active_revision = revision;
             self.recovery.recovered();
@@ -409,20 +458,22 @@ impl RecoveringAudioInput {
                     self.recovery.failed(now);
                 }
                 Err(error) => {
-                    if self.input.is_none() {
+                    if self.input.is_none() && !self.is_recovering() {
                         self.recovery.recovered();
                         return RecoveringAudioInputEvent::OpenFailed(error);
                     }
                     self.recovery.failed(now);
                     tracing::warn!(
                         %error,
-                        device = %self.device_name(),
                         "could not reopen dictation microphone; retrying"
                     );
                 }
             }
         }
-        if capture_idle && self.recovery.should_attempt(now) && self.replacement.is_none() {
+        if (capture_idle || self.input.is_none())
+            && self.recovery.should_attempt(now)
+            && self.replacement.is_none()
+        {
             self.start_replacement();
         }
         if self.recovery.blocks_audio() {
@@ -486,7 +537,7 @@ impl RecoveringAudioInput {
         self.replacement = Some(receiver);
     }
 
-    fn poll_replacement(&mut self) -> Option<(u64, Result<AudioInput, String>)> {
+    fn poll_replacement(&mut self) -> Option<InputOpenResult> {
         let result = match self.replacement.as_ref()?.try_recv() {
             Ok(result) => result,
             Err(TryRecvError::Empty) => return None,
@@ -695,6 +746,121 @@ mod tests {
         assert_eq!(input.active_revision, 4);
         assert_eq!(input.selected_device.as_deref(), Some("Next microphone"));
         assert!(input.replacement.is_none());
+    }
+
+    #[test]
+    fn failed_startup_retry_keeps_backoff_without_an_open_stream() {
+        let mut input = RecoveringAudioInput::closed(None, 3, Some("Missing microphone"));
+        let started = Instant::now();
+        input.finish_initial_open(Err(eyre!("device unavailable")), started);
+        assert!(input.is_recovering());
+        assert!(
+            !input
+                .recovery
+                .should_attempt(started + Duration::from_millis(249))
+        );
+        assert!(
+            input
+                .recovery
+                .should_attempt(started + Duration::from_millis(250))
+        );
+        let (sender, receiver) = mpsc::channel();
+        input.replacement = Some(receiver);
+        sender.send((3, Err("device unavailable".into()))).unwrap();
+
+        let before = Instant::now();
+        assert!(matches!(
+            input.recv_timeout(Duration::ZERO, true),
+            RecoveringAudioInputEvent::Timeout
+        ));
+        let after = Instant::now();
+        assert!(!input.is_open());
+        assert!(!input.is_opening());
+        assert!(input.is_recovering());
+        let next_attempt = input.recovery.next_attempt.unwrap();
+        assert!(next_attempt >= before + Duration::from_millis(500));
+        assert!(next_attempt <= after + Duration::from_millis(500));
+
+        input.cancel_open();
+        input.request_open();
+        assert!(input.is_recovering());
+        assert!(!input.is_opening());
+        assert_eq!(input.recovery.next_attempt, Some(next_attempt));
+
+        input.request_selection(4, Some("Next microphone"));
+        assert!(input.is_recovering());
+        assert_eq!(input.recovery.target_revision, Some(4));
+        assert_eq!(input.active_revision, 3);
+        assert_eq!(input.selected_device.as_deref(), Some("Next microphone"));
+        assert!(input.recovery.should_attempt(Instant::now()));
+    }
+
+    #[test]
+    fn startup_retry_recovers_metadata_and_audio_without_restarting() {
+        let mut input = RecoveringAudioInput::closed(None, 3, Some("Test microphone"));
+        input.finish_initial_open(Err(eyre!("device unavailable")), Instant::now());
+        let (sender, receiver) = mpsc::channel();
+        input.replacement = Some(receiver);
+        let (opened, samples) = AudioInput::channel_for_test();
+        sender.send((3, Ok(opened))).unwrap();
+
+        assert!(matches!(
+            input.recv_timeout(Duration::ZERO, true),
+            RecoveringAudioInputEvent::Reopened
+        ));
+        assert!(!input.is_recovering());
+        assert!(!input.is_opening());
+        assert!(input.recovery.next_attempt.is_none());
+        assert_eq!(input.sample_rate(), 48_000);
+        assert_eq!(input.device_name(), "Test microphone");
+        let at = CaptureInstant::from_nanos(60_000_000_000);
+        samples.send((vec![0.25; 480], at)).unwrap();
+        assert!(matches!(
+            input.recv_timeout(Duration::ZERO, true),
+            RecoveringAudioInputEvent::Chunk { samples, captured_through }
+                if samples == vec![0.25; 480] && captured_through == at
+        ));
+    }
+
+    #[test]
+    fn startup_recovery_opens_even_when_a_capture_is_pending() {
+        let mut input = RecoveringAudioInput::closed(
+            Some("HEX nonexistent microphone for pending recovery test"),
+            3,
+            None,
+        );
+        input.request_recovery();
+        input.request_selection(4, Some("Ignored selection under CLI override"));
+        assert_eq!(input.active_revision, 3);
+        assert!(input.selected_device.is_none());
+
+        assert!(matches!(
+            input.recv_timeout(Duration::ZERO, false),
+            RecoveringAudioInputEvent::Timeout
+        ));
+        assert!(input.is_opening());
+        input.cancel_open();
+        assert!(input.is_opening());
+        input.close();
+        assert!(!input.is_opening());
+        assert!(!input.is_recovering());
+        assert!(input.recovery.next_attempt.is_none());
+    }
+
+    #[test]
+    fn failed_on_demand_open_does_not_retry_while_idle() {
+        let mut input = RecoveringAudioInput::closed(None, 3, None);
+        let (sender, receiver) = mpsc::channel();
+        input.replacement = Some(receiver);
+        sender.send((3, Err("device unavailable".into()))).unwrap();
+
+        assert!(matches!(
+            input.recv_timeout(Duration::ZERO, true),
+            RecoveringAudioInputEvent::OpenFailed(error) if error == "device unavailable"
+        ));
+        assert!(!input.is_recovering());
+        assert!(!input.is_opening());
+        assert!(input.recovery.next_attempt.is_none());
     }
 
     #[test]

--- a/src/dictation_audio.rs
+++ b/src/dictation_audio.rs
@@ -167,8 +167,30 @@ impl DictationAudio {
         let input = if release_while_idle {
             RecoveringAudioInput::closed(device_override, selection_revision, selected_device)
         } else {
-            RecoveringAudioInput::open(device_override, selection_revision, selected_device)?
+            RecoveringAudioInput::open(device_override, selection_revision, selected_device)
         };
+        let device_name = input
+            .is_open()
+            .then(|| input.device_name().to_owned())
+            .or_else(|| device_override.map(str::to_owned))
+            .or_else(|| selected_device.map(str::to_owned))
+            .unwrap_or_else(|| "Default microphone".into());
+        Self::with_input(
+            input,
+            device_name,
+            recording_environment,
+            pending_input,
+            release_while_idle,
+        )
+    }
+
+    fn with_input(
+        input: RecoveringAudioInput,
+        device_name: String,
+        recording_environment: RecordingEnvironmentController,
+        pending_input: PendingInputEvents,
+        release_while_idle: bool,
+    ) -> Result<Self> {
         let state = Arc::new(State {
             sample_rate: AtomicU64::new(if input.is_open() {
                 u64::from(input.sample_rate())
@@ -176,16 +198,9 @@ impl DictationAudio {
                 0
             }),
             captured_through: AtomicU64::new(0),
-            device_name: Mutex::new(
-                input
-                    .is_open()
-                    .then(|| input.device_name().to_owned())
-                    .or_else(|| device_override.map(str::to_owned))
-                    .or_else(|| selected_device.map(str::to_owned))
-                    .unwrap_or_else(|| "Default microphone".into()),
-            ),
+            device_name: Mutex::new(device_name),
             recording: AtomicBool::new(false),
-            recovering: AtomicBool::new(false),
+            recovering: AtomicBool::new(input.is_recovering()),
             recognition_generation: AtomicU64::new(0),
             outstanding_recognition_frames: Arc::new(AtomicU64::new(0)),
             capture_generation: AtomicU64::new(0),
@@ -296,14 +311,16 @@ impl DictationAudio {
         while self.recognition.try_recv().is_ok() {}
     }
 
-    pub fn start(&self, at: CaptureInstant) -> Result<()> {
-        let _ = self.start_capture(at, false, false, None)?;
-        Ok(())
+    pub fn start(&self, at: CaptureInstant) -> Result<bool> {
+        self.start_capture(at, false, false, None)
     }
 
     pub fn start_programmatic(&self, at: CaptureInstant) -> Result<()> {
-        let _ = self.start_capture(at, false, true, None)?;
-        Ok(())
+        if self.start_capture(at, false, true, None)? {
+            Ok(())
+        } else {
+            Err(eyre!("microphone-unavailable"))
+        }
     }
 
     pub fn start_voice(&self, at: CaptureInstant, recognition_generation: u64) -> Result<bool> {
@@ -378,19 +395,19 @@ impl Owner {
                     if !self.handle(command) {
                         break;
                     }
-                    self.close_if_idle();
+                    self.reconcile_input();
                     continue;
                 }
                 Err(TryRecvError::Disconnected) => break,
                 Err(TryRecvError::Empty) => {}
             }
-            if !self.input.is_open() && !self.input.is_opening() {
+            if !self.input.is_open() && !self.input.is_opening() && !self.input.is_recovering() {
                 match self.commands.recv() {
                     Ok(command) => {
                         if !self.handle(command) {
                             break;
                         }
-                        self.close_if_idle();
+                        self.reconcile_input();
                         continue;
                     }
                     Err(_) => break,
@@ -401,7 +418,7 @@ impl Owner {
                 .input
                 .recv_timeout(Duration::from_millis(10), capture_idle);
             self.handle_input(event);
-            self.close_if_idle();
+            self.reconcile_input();
         }
     }
 
@@ -414,10 +431,12 @@ impl Owner {
                 expected_recognition_generation,
                 reply,
             } => {
-                if expected_recognition_generation.is_some_and(|generation| {
-                    generation != self.recognition_generation
-                        || self.pending_input.oldest().is_some()
-                }) {
+                if self.input.is_recovering()
+                    || expected_recognition_generation.is_some_and(|generation| {
+                        generation != self.recognition_generation
+                            || self.pending_input.oldest().is_some()
+                    })
+                {
                     let _ = reply.send(false);
                     return true;
                 }
@@ -482,13 +501,6 @@ impl Owner {
             }
             Command::SetReleaseWhileIdle(release) => {
                 self.release_while_idle = release;
-                if self.capture_idle() {
-                    if release {
-                        self.close_input();
-                    } else if !self.input.is_open() {
-                        self.input.request_open();
-                    }
-                }
             }
             Command::InvalidateRecognition { reply } => {
                 let generation = self.next_recognition_generation();
@@ -634,12 +646,18 @@ impl Owner {
                 let _ = self.events.send(DictationAudioEvent::Reopened);
             }
             RecoveringAudioInputEvent::OpenFailed(error) => {
-                self.pending_capture = None;
+                let was_recording = self.pending_capture.take().is_some();
                 self.state.recording.store(false, Ordering::Release);
-                let _ = self.events.send(DictationAudioEvent::OpenFailed {
-                    capture_generation: self.state.capture_generation.load(Ordering::Acquire),
-                    error,
-                });
+                if !self.release_while_idle {
+                    self.input.request_recovery();
+                    self.state.recovering.store(true, Ordering::Release);
+                }
+                if was_recording {
+                    let _ = self.events.send(DictationAudioEvent::OpenFailed {
+                        capture_generation: self.state.capture_generation.load(Ordering::Acquire),
+                        error,
+                    });
+                }
             }
         }
     }
@@ -706,9 +724,18 @@ impl Owner {
         }
     }
 
-    fn close_if_idle(&mut self) {
-        if self.release_while_idle && self.input.is_open() && self.capture_idle() {
-            self.close_input();
+    fn reconcile_input(&mut self) {
+        if self.release_while_idle {
+            if self.capture_idle()
+                && (self.input.is_open() || self.input.is_opening() || self.input.is_recovering())
+            {
+                self.close_input();
+            }
+        } else if !self.input.is_open() && !self.input.is_opening() {
+            // A key release is acknowledged after its synchronous controls return;
+            // waiting for that acknowledgment here can leave the owner asleep.
+            self.input.request_recovery();
+            self.state.recovering.store(true, Ordering::Release);
         }
     }
 
@@ -737,6 +764,125 @@ mod tests {
 
     fn capture_time() -> CaptureInstant {
         CaptureInstant::from_nanos(60_000_000_000)
+    }
+
+    #[test]
+    fn startup_microphone_failure_keeps_audio_owner_alive() {
+        let input = DictationAudio::open(
+            Some("HEX nonexistent microphone for startup recovery test"),
+            0,
+            None,
+            RecordingEnvironmentController::start(),
+            PendingInputEvents::default(),
+            false,
+        )
+        .expect("a missing microphone should enter recovery, not stop the listener");
+
+        assert!(input.is_recovering());
+        assert_eq!(input.sample_rate(), 0);
+        assert!(
+            input
+                .recv_timeout(Duration::from_millis(20))
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            input
+                .start_programmatic(capture_time())
+                .unwrap_err()
+                .to_string(),
+            "microphone-unavailable"
+        );
+        assert!(!input.is_recording());
+        assert_eq!(input.capture_generation(), 0);
+        assert!(!input.start(capture_time()).unwrap());
+        assert!(!input.is_recording());
+        assert!(matches!(
+            input.finish(capture_time()).unwrap(),
+            Finish::Discard
+        ));
+        input.cancel().unwrap();
+        assert!(input.is_recovering());
+
+        input.set_release_while_idle(true);
+        input.cancel().unwrap();
+        assert!(!input.is_recovering());
+        input.set_release_while_idle(false);
+        input.cancel().unwrap();
+        assert!(input.is_recovering());
+    }
+
+    #[test]
+    fn enabling_warm_microphone_preserves_pending_capture_and_recovers_after_cancellation() {
+        for finish in [false, true] {
+            let (input, _opened) = RecoveringAudioInput::pending_for_test();
+            let (pending_input, acknowledge) =
+                PendingInputEvents::with_pending_for_test(capture_time());
+            let input = DictationAudio::with_input(
+                input,
+                "Test microphone".into(),
+                RecordingEnvironmentController::start(),
+                pending_input,
+                false,
+            )
+            .unwrap();
+            assert!(input.start(capture_time()).unwrap());
+            assert!(input.is_recording());
+            input.set_release_while_idle(true);
+            input.invalidate_recognition().unwrap();
+
+            input.set_release_while_idle(false);
+            input.invalidate_recognition().unwrap();
+            assert!(!input.is_recovering());
+            assert!(input.is_recording());
+
+            if finish {
+                assert!(matches!(
+                    input.finish(capture_time()).unwrap(),
+                    Finish::Discard
+                ));
+            } else {
+                input.cancel().unwrap();
+            }
+            input.invalidate_recognition().unwrap();
+            assert!(!input.is_recording());
+            assert!(input.is_recovering());
+            acknowledge();
+        }
+    }
+
+    #[test]
+    fn recovered_owner_delivers_audio_and_accepts_a_new_capture() {
+        let (mut input, opened) = RecoveringAudioInput::pending_for_test();
+        input.request_recovery();
+        let input = DictationAudio::with_input(
+            input,
+            "Missing microphone".into(),
+            RecordingEnvironmentController::start(),
+            PendingInputEvents::default(),
+            false,
+        )
+        .unwrap();
+        assert!(!input.start(capture_time()).unwrap());
+        let (replacement, samples) = crate::audio::AudioInput::channel_for_test();
+        opened.send((0, Ok(replacement))).unwrap();
+        assert!(matches!(
+            input.events.recv_timeout(Duration::from_secs(2)).unwrap(),
+            DictationAudioEvent::Reopened
+        ));
+        assert!(!input.is_recovering());
+        assert_eq!(input.sample_rate(), 48_000);
+        assert_eq!(input.device_name(), "Test microphone");
+        samples.send((vec![0.25; 480], capture_time())).unwrap();
+        let audio = input.recv_timeout(Duration::from_secs(2)).unwrap().unwrap();
+        assert_eq!(audio.samples, vec![0.25; 480]);
+        assert!(audio.is_current(input.recognition_generation()));
+        assert_eq!(input.captured_through(), capture_time());
+        assert!(input.start(capture_time()).unwrap());
+        assert!(input.is_recording());
+        input.cancel().unwrap();
+        assert!(!input.is_recording());
+        assert!(!input.is_recovering());
     }
 
     #[test]

--- a/src/personal_commands.rs
+++ b/src/personal_commands.rs
@@ -276,9 +276,9 @@ fn validate_status(status: &StatusSnapshot) -> Result<()> {
 pub fn initialize_workspace() -> Result<PathBuf> {
     let workspace = crate::app_paths::personal_commands_workspace()?;
     let sdk = crate::app_paths::personal_commands_sdk()?;
-    let sdk_changed = initialize_workspace_at(&workspace, &sdk)?;
+    let workspace_changed = initialize_workspace_at(&workspace, &sdk)?;
     let bun = find_bun().ok_or_else(|| eyre!("Bun is required to install personal commands"))?;
-    if sdk_changed {
+    if workspace_changed {
         remove_installed_managed_sdk(&workspace)?;
     }
     install_workspace_dependencies(&workspace, &bun)?;
@@ -293,16 +293,140 @@ pub fn initialize_workspace_at(workspace: &Path, sdk: &Path) -> Result<bool> {
     {
         return Err(eyre!("personal command SDK resources are incomplete"));
     }
-    fs::create_dir_all(workspace)?;
-    let sdk_changed = refresh_managed_sdk_at(workspace, sdk)?;
+    let workspace_changed = refresh_managed_sdk_at(workspace, sdk)?;
     copy_directory(&template, workspace, false)?;
-    Ok(sdk_changed)
+    Ok(workspace_changed)
+}
+
+fn workspace_effect_update(workspace: &Path, sdk: &Path) -> Result<Option<Vec<u8>>> {
+    let sdk_manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(sdk.join("package.json"))?)
+            .wrap_err("personal command SDK package.json is invalid")?;
+    let required = sdk_manifest["peerDependencies"]["effect"]
+        .as_str()
+        .filter(|version| {
+            regex::Regex::new(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$")
+                .expect("valid exact-version pattern")
+                .is_match(version)
+        })
+        .ok_or_else(|| {
+            eyre!("personal command SDK peerDependencies.effect must be an exact version")
+        })?;
+    let path = workspace.join("package.json");
+    let linked = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata.file_type().is_symlink(),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => return Err(error.into()),
+    };
+    let linked_error = || {
+        eyre!(
+            "{} is a symlink; update the linked manifest to Effect \"{required}\" or replace the link with a regular package.json, then retry",
+            path.display()
+        )
+    };
+    let (bytes, mut changed) = match fs::read(&path) {
+        Ok(bytes) => (bytes, false),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            if linked {
+                return Err(linked_error());
+            }
+            (fs::read(sdk.join("workspace-template/package.json"))?, true)
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let mut manifest: serde_json::Value = serde_json::from_slice(&bytes)
+        .wrap_err_with(|| format!("{} is invalid JSON; repair it and retry", path.display()))?;
+    let manifest = manifest
+        .as_object_mut()
+        .ok_or_else(|| eyre!("{} must be a JSON object", path.display()))?;
+    let mut has_dependency = false;
+    for section in [
+        "dependencies",
+        "devDependencies",
+        "optionalDependencies",
+        "peerDependencies",
+        "overrides",
+        "resolutions",
+    ] {
+        let Some(entries) = manifest.get_mut(section) else {
+            continue;
+        };
+        let entries = entries
+            .as_object_mut()
+            .ok_or_else(|| eyre!("{} {section} must be a JSON object", path.display()))?;
+        if matches!(section, "overrides" | "resolutions") {
+            let mut pending = vec![(section.to_string(), &*entries)];
+            while let Some((location, entries)) = pending.pop() {
+                for (selector, value) in entries {
+                    let mut parts = selector.rsplit('>').next().unwrap_or(selector).split('/');
+                    let mut targets_effect = false;
+                    while let Some(part) = parts.next() {
+                        targets_effect = part == "effect" || part.starts_with("effect@");
+                        // The slash in @scope/package is not a dependency selector.
+                        if part.starts_with('@') {
+                            let _ = parts.next();
+                            targets_effect = false;
+                        }
+                    }
+                    if targets_effect && (location != section || selector != "effect") {
+                        return Err(eyre!(
+                            "{} has unsupported Effect selector {location}[{selector:?}]; remove this selector and set dependencies.effect to \"{required}\", the version required by the HEX SDK, then retry",
+                            path.display()
+                        ));
+                    }
+                    if let Some(nested) = value.as_object() {
+                        pending.push((format!("{location}[{selector:?}]"), nested));
+                    }
+                }
+            }
+        }
+        let Some(effect) = entries.get_mut("effect") else {
+            continue;
+        };
+        has_dependency |= matches!(
+            section,
+            "dependencies" | "devDependencies" | "optionalDependencies"
+        );
+        match effect.as_str() {
+            Some(version) if version == required => {}
+            Some("4.0.0-beta.97" | "4.0.0-beta.107") => {
+                *effect = required.into();
+                changed = true;
+            }
+            _ => {
+                return Err(eyre!(
+                    "{} has incompatible {section}.effect ({effect}); set it to \"{required}\", the version required by the HEX SDK, then retry",
+                    path.display()
+                ));
+            }
+        }
+    }
+    if !has_dependency {
+        manifest
+            .entry("dependencies")
+            .or_insert_with(|| serde_json::json!({}))
+            .as_object_mut()
+            .expect("dependencies was validated")
+            .insert("effect".into(), required.into());
+        changed = true;
+    }
+    if !changed {
+        return Ok(None);
+    }
+    if linked {
+        return Err(linked_error());
+    }
+    let mut encoded = serde_json::to_vec_pretty(manifest)?;
+    encoded.push(b'\n');
+    Ok(Some(encoded))
 }
 
 fn refresh_managed_sdk_at(workspace: &Path, sdk: &Path) -> Result<bool> {
     if !sdk.join("package.json").is_file() || !sdk.join("dist/bin.js").is_file() {
         return Err(eyre!("personal command SDK resources are incomplete"));
     }
+    // Validate both manifests before touching the installed SDK or user files.
+    let manifest_update = workspace_effect_update(workspace, sdk)?;
     fs::create_dir_all(workspace)?;
     let staged_sdk = workspace.join(".hex-sdk.tmp");
     let installed_sdk = workspace.join(".hex-sdk");
@@ -312,27 +436,46 @@ fn refresh_managed_sdk_at(workspace: &Path, sdk: &Path) -> Result<bool> {
     fs::create_dir(&staged_sdk)?;
     fs::copy(sdk.join("package.json"), staged_sdk.join("package.json"))?;
     copy_directory(&sdk.join("dist"), &staged_sdk.join("dist"), true)?;
-    if directory_manifest(&staged_sdk)? == directory_manifest(&installed_sdk)? {
+    let sdk_changed = directory_manifest(&staged_sdk)? != directory_manifest(&installed_sdk)?;
+    if !sdk_changed {
         fs::remove_dir_all(staged_sdk)?;
-        return Ok(false);
-    }
-    let previous_sdk = workspace.join(".hex-sdk.previous");
-    if previous_sdk.exists() {
-        fs::remove_dir_all(&previous_sdk)?;
-    }
-    if installed_sdk.exists() {
-        fs::rename(&installed_sdk, &previous_sdk)?;
-    }
-    if let Err(error) = fs::rename(&staged_sdk, &installed_sdk) {
+    } else {
+        let previous_sdk = workspace.join(".hex-sdk.previous");
         if previous_sdk.exists() {
-            let _ = fs::rename(&previous_sdk, &installed_sdk);
+            fs::remove_dir_all(&previous_sdk)?;
         }
-        return Err(error.into());
+        if installed_sdk.exists() {
+            fs::rename(&installed_sdk, &previous_sdk)?;
+        }
+        if let Err(error) = fs::rename(&staged_sdk, &installed_sdk) {
+            if previous_sdk.exists() {
+                let _ = fs::rename(&previous_sdk, &installed_sdk);
+            }
+            return Err(error.into());
+        }
+        if previous_sdk.exists() {
+            fs::remove_dir_all(previous_sdk)?;
+        }
     }
-    if previous_sdk.exists() {
-        fs::remove_dir_all(previous_sdk)?;
+    if let Some(encoded) = &manifest_update {
+        let path = workspace.join("package.json");
+        let temporary = path.with_extension(format!("json.{}.tmp", std::process::id()));
+        (|| -> Result<()> {
+            fs::write(&temporary, encoded)?;
+            match fs::metadata(&path) {
+                Ok(metadata) => fs::set_permissions(&temporary, metadata.permissions())?,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+            fs::rename(&temporary, &path)?;
+            Ok(())
+        })()
+        .wrap_err_with(|| format!(
+            "could not update {}; the SDK may already be refreshed; fix filesystem access or space (including {}), then rerun `hex commands init`",
+            path.display(), temporary.display()
+        ))?;
     }
-    Ok(true)
+    Ok(sdk_changed || manifest_update.is_some())
 }
 
 fn directory_manifest(root: &Path) -> Result<Vec<(PathBuf, Option<Vec<u8>>)>> {
@@ -1057,7 +1200,7 @@ fn run_worker(
             return;
         }
     };
-    let sdk_changed = match refresh_managed_sdk_at(&workspace, &sdk) {
+    let workspace_changed = match refresh_managed_sdk_at(&workspace, &sdk) {
         Ok(changed) => changed,
         Err(error) => {
             status.host_state = HostState::Unavailable;
@@ -1068,9 +1211,9 @@ fn run_worker(
         }
     };
     let managed_host = workspace.join("node_modules/@hex/commands/dist/bin.js");
-    if sdk_changed || !managed_host.is_file() {
+    if workspace_changed || !managed_host.is_file() {
         let refreshed = (|| {
-            if sdk_changed {
+            if workspace_changed {
                 remove_installed_managed_sdk(&workspace)?;
             }
             install_workspace_dependencies(&workspace, &bun)
@@ -1082,7 +1225,10 @@ fn run_worker(
             tracing::warn!(%error, "could not activate the current personal command SDK");
             return;
         }
-        tracing::info!(sdk_changed, "refreshed the managed personal command SDK");
+        tracing::info!(
+            workspace_changed,
+            "refreshed the managed personal command SDK"
+        );
     }
     let host_entrypoint = match crate::app_paths::personal_commands_host() {
         Ok(path) => path,
@@ -3512,6 +3658,372 @@ mod tests {
             .unwrap();
         kill_and_wait(&mut child);
         assert!(child.try_wait().unwrap().is_some());
+    }
+
+    #[test]
+    fn workspace_effect_migration_preserves_user_fields_and_is_idempotent() {
+        let (workspace, sdk) = workspace_upgrade_fixture();
+        let required = "4.0.0-rc.999";
+        for old in [None, Some("4.0.0-beta.97"), Some("4.0.0-beta.107")] {
+            let mut manifest = serde_json::json!({
+                "name": "my-commands", "private": true, "custom": { "keep": [1, 2] },
+                "scripts": { "check": "custom-check", "start": "custom-start" },
+                "dependencies": { "user-library": "^1.2.3" },
+                "devDependencies": { "typescript": "7.0.2" }
+            });
+            if let Some(old) = old {
+                manifest["dependencies"]["effect"] = old.into();
+            }
+            fs::write(workspace.join("package.json"), manifest.to_string()).unwrap();
+            fs::write(workspace.join("hex.config.ts"), "// user config\n").unwrap();
+            assert!(initialize_workspace_at(&workspace, &sdk).unwrap());
+            manifest["dependencies"]["effect"] = required.into();
+            let bytes = fs::read(workspace.join("package.json")).unwrap();
+            assert_eq!(
+                serde_json::from_slice::<serde_json::Value>(&bytes).unwrap(),
+                manifest
+            );
+            assert_eq!(
+                fs::read_to_string(workspace.join("hex.config.ts")).unwrap(),
+                "// user config\n"
+            );
+            assert!(!initialize_workspace_at(&workspace, &sdk).unwrap());
+            assert_eq!(fs::read(workspace.join("package.json")).unwrap(), bytes);
+        }
+        fs::remove_dir_all(workspace.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn unchanged_sdk_with_stale_effect_requires_install_on_startup() {
+        let (workspace, sdk) = workspace_upgrade_fixture();
+        assert!(initialize_workspace_at(&workspace, &sdk).unwrap());
+        let sdk_before = directory_manifest(&workspace.join(".hex-sdk")).unwrap();
+        fs::write(
+            workspace.join("package.json"),
+            r#"{"dependencies":{"effect":"4.0.0-beta.97"}}"#,
+        )
+        .unwrap();
+        assert!(refresh_managed_sdk_at(&workspace, &sdk).unwrap());
+        assert_eq!(
+            directory_manifest(&workspace.join(".hex-sdk")).unwrap(),
+            sdk_before
+        );
+        assert!(!refresh_managed_sdk_at(&workspace, &sdk).unwrap());
+        // A compatible manifest is not even reformatted.
+        let current = r#"{ "dependencies": { "effect": "4.0.0-rc.999" } }"#;
+        fs::write(workspace.join("package.json"), current).unwrap();
+        assert!(!refresh_managed_sdk_at(&workspace, &sdk).unwrap());
+        assert_eq!(
+            fs::read_to_string(workspace.join("package.json")).unwrap(),
+            current
+        );
+        fs::remove_dir_all(workspace.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn workspace_effect_migration_reconciles_duplicate_pins() {
+        let (workspace, sdk) = workspace_upgrade_fixture();
+        let mut manifest = serde_json::json!({});
+        for section in [
+            "dependencies",
+            "devDependencies",
+            "optionalDependencies",
+            "peerDependencies",
+            "overrides",
+            "resolutions",
+        ] {
+            manifest[section] = serde_json::json!({"effect": "4.0.0-beta.107", "other": "1.0.0"});
+        }
+        fs::write(workspace.join("package.json"), manifest.to_string()).unwrap();
+        assert!(refresh_managed_sdk_at(&workspace, &sdk).unwrap());
+        for entries in manifest.as_object_mut().unwrap().values_mut() {
+            entries["effect"] = "4.0.0-rc.999".into();
+        }
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(
+                &fs::read(workspace.join("package.json")).unwrap()
+            )
+            .unwrap(),
+            manifest
+        );
+        fs::remove_dir_all(workspace.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn workspace_effect_conflicts_leave_manifest_config_and_sdk_untouched() {
+        let (workspace, sdk) = workspace_upgrade_fixture();
+        assert!(initialize_workspace_at(&workspace, &sdk).unwrap());
+        fs::write(sdk.join("dist/bin.js"), "// new SDK\n").unwrap();
+        let before = directory_manifest(&workspace.join(".hex-sdk")).unwrap();
+        for invalid in [
+            "{",
+            "[]",
+            r#"{"dependencies":null}"#,
+            r#"{"devDependencies":[]}"#,
+        ] {
+            fs::write(workspace.join("package.json"), invalid).unwrap();
+            assert!(initialize_workspace_at(&workspace, &sdk).is_err());
+            assert_eq!(
+                fs::read_to_string(workspace.join("package.json")).unwrap(),
+                invalid
+            );
+            assert_eq!(
+                directory_manifest(&workspace.join(".hex-sdk")).unwrap(),
+                before
+            );
+        }
+        for section in [
+            "dependencies",
+            "devDependencies",
+            "optionalDependencies",
+            "peerDependencies",
+            "overrides",
+            "resolutions",
+        ] {
+            for custom in [
+                serde_json::json!("^4.0.0-beta.97"),
+                serde_json::json!("4.0.0-beta.108"),
+                serde_json::json!("file:../effect"),
+                serde_json::json!({".": "4.0.0-beta.97"}),
+                serde_json::Value::Null,
+            ] {
+                let mut manifest = serde_json::json!({"dependencies": {"effect": "4.0.0-beta.97"}});
+                manifest[section] = serde_json::json!({"effect": custom});
+                let original = manifest.to_string();
+                fs::write(workspace.join("package.json"), &original).unwrap();
+                let error = refresh_managed_sdk_at(&workspace, &sdk)
+                    .unwrap_err()
+                    .to_string();
+                assert!(error.contains(&format!("{section}.effect")), "{error}");
+                assert!(error.contains("set it to \"4.0.0-rc.999\""), "{error}");
+                assert_eq!(
+                    fs::read_to_string(workspace.join("package.json")).unwrap(),
+                    original
+                );
+                assert_eq!(
+                    directory_manifest(&workspace.join(".hex-sdk")).unwrap(),
+                    before
+                );
+            }
+        }
+        assert_eq!(
+            fs::read_to_string(workspace.join("hex.config.ts")).unwrap(),
+            "// template config\n"
+        );
+        fs::remove_dir_all(workspace.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn workspace_rejects_indirect_effect_selectors_but_preserves_scoped_packages() {
+        let (workspace, sdk) = workspace_upgrade_fixture();
+        assert!(initialize_workspace_at(&workspace, &sdk).unwrap());
+        fs::write(sdk.join("dist/bin.js"), "// new SDK\n").unwrap();
+        let before = directory_manifest(&workspace.join(".hex-sdk")).unwrap();
+        for section in ["overrides", "resolutions"] {
+            for selectors in [
+                serde_json::json!({"**/effect": "4.0.0-beta.97"}),
+                serde_json::json!({"@hex/commands>effect": "4.0.0-beta.97"}),
+                serde_json::json!({"effect@4.0.0-beta.97": "4.0.0-beta.97"}),
+                serde_json::json!({"@hex/commands/effect": "4.0.0-beta.97"}),
+                serde_json::json!({"@hex/commands": {"effect": "4.0.0-beta.97"}}),
+                serde_json::json!({"other": {"@hex/commands": {"**/effect": "4.0.0-rc.999"}}}),
+            ] {
+                let mut manifest = serde_json::json!({"dependencies": {"effect": "4.0.0-beta.97"}});
+                manifest[section] = selectors;
+                let original = manifest.to_string();
+                fs::write(workspace.join("package.json"), &original).unwrap();
+                let error = initialize_workspace_at(&workspace, &sdk)
+                    .unwrap_err()
+                    .to_string();
+                assert!(
+                    error.contains(&format!("unsupported Effect selector {section}[")),
+                    "{error}"
+                );
+                assert!(error.contains("remove this selector"), "{error}");
+                assert!(error.contains("4.0.0-rc.999"), "{error}");
+                assert_eq!(
+                    fs::read_to_string(workspace.join("package.json")).unwrap(),
+                    original
+                );
+                assert_eq!(
+                    directory_manifest(&workspace.join(".hex-sdk")).unwrap(),
+                    before
+                );
+            }
+        }
+        let unrelated = serde_json::json!({
+            "@effect/platform": "1.0.0", "@other/effect": "2.0.0",
+            "**/@other/effect": "2.0.0", "@hex/commands>@other/effect": "2.0.0",
+            "@scope/package": {"@effect/platform": "1.0.0", "unrelated": "1.0.0"}
+        });
+        let mut manifest = serde_json::json!({
+            "dependencies": {"effect": "4.0.0-beta.97"},
+            "overrides": unrelated, "resolutions": unrelated
+        });
+        fs::write(workspace.join("package.json"), manifest.to_string()).unwrap();
+        assert!(initialize_workspace_at(&workspace, &sdk).unwrap());
+        manifest["dependencies"]["effect"] = "4.0.0-rc.999".into();
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(
+                &fs::read(workspace.join("package.json")).unwrap()
+            )
+            .unwrap(),
+            manifest
+        );
+        assert_eq!(
+            fs::read_to_string(workspace.join("hex.config.ts")).unwrap(),
+            "// template config\n"
+        );
+        fs::remove_dir_all(workspace.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn workspace_only_rejects_manifest_symlinks_that_need_migration() {
+        let (workspace, sdk) = workspace_upgrade_fixture();
+        assert!(initialize_workspace_at(&workspace, &sdk).unwrap());
+        fs::write(sdk.join("dist/bin.js"), "// new SDK\n").unwrap();
+        let before = directory_manifest(&workspace.join(".hex-sdk")).unwrap();
+        let path = workspace.join("package.json");
+        let target = workspace.parent().unwrap().join("user-package.json");
+        let original = r#"{"dependencies":{"effect":"4.0.0-beta.97"}}"#;
+        fs::remove_file(&path).unwrap();
+        for present in [true, false] {
+            if present {
+                fs::write(&target, original).unwrap();
+            } else {
+                fs::remove_file(&target).unwrap();
+            }
+            std::os::unix::fs::symlink(&target, &path).unwrap();
+            let error = initialize_workspace_at(&workspace, &sdk)
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("is a symlink"), "{error}");
+            assert!(
+                error.contains("update the linked manifest to Effect"),
+                "{error}"
+            );
+            assert_eq!(fs::read_link(&path).unwrap(), target);
+            if present {
+                assert_eq!(fs::read_to_string(&target).unwrap(), original);
+            } else {
+                assert!(!target.exists());
+            }
+            assert_eq!(
+                directory_manifest(&workspace.join(".hex-sdk")).unwrap(),
+                before
+            );
+            fs::remove_file(&path).unwrap();
+        }
+        let current = r#"{"dependencies":{"effect":"4.0.0-rc.999"}}"#;
+        fs::write(&target, current).unwrap();
+        std::os::unix::fs::symlink(&target, &path).unwrap();
+        assert!(initialize_workspace_at(&workspace, &sdk).unwrap());
+        assert!(!initialize_workspace_at(&workspace, &sdk).unwrap());
+        assert_eq!(fs::read_link(&path).unwrap(), target);
+        assert_eq!(fs::read_to_string(&target).unwrap(), current);
+        assert_eq!(
+            fs::read_to_string(workspace.join("hex.config.ts")).unwrap(),
+            "// template config\n"
+        );
+        fs::remove_dir_all(workspace.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn workspace_effect_migration_preserves_manifest_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (workspace, sdk) = workspace_upgrade_fixture();
+        let path = workspace.join("package.json");
+        for mode in [0o600, 0o640] {
+            fs::write(&path, r#"{"dependencies":{"effect":"4.0.0-beta.97"}}"#).unwrap();
+            fs::set_permissions(&path, fs::Permissions::from_mode(mode)).unwrap();
+            assert!(refresh_managed_sdk_at(&workspace, &sdk).unwrap());
+            assert_eq!(
+                fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                mode
+            );
+        }
+        fs::remove_dir_all(workspace.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn workspace_effect_write_failure_is_retryable_after_sdk_refresh() {
+        let (workspace, sdk) = workspace_upgrade_fixture();
+        assert!(initialize_workspace_at(&workspace, &sdk).unwrap());
+        fs::write(sdk.join("dist/bin.js"), "// new SDK\n").unwrap();
+        let path = workspace.join("package.json");
+        let original = r#"{"dependencies":{"effect":"4.0.0-beta.97"}}"#;
+        fs::write(&path, original).unwrap();
+        let obstruction = path.with_extension(format!("json.{}.tmp", std::process::id()));
+        fs::create_dir(&obstruction).unwrap();
+        let error = refresh_managed_sdk_at(&workspace, &sdk)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("SDK may already be refreshed"), "{error}");
+        assert!(error.contains("rerun `hex commands init`"), "{error}");
+        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+        assert_eq!(
+            fs::read_to_string(workspace.join(".hex-sdk/dist/bin.js")).unwrap(),
+            "// new SDK\n"
+        );
+        fs::remove_dir(&obstruction).unwrap();
+        // Reconciliation still requests installation, even though the SDK is current.
+        assert!(refresh_managed_sdk_at(&workspace, &sdk).unwrap());
+        assert!(!refresh_managed_sdk_at(&workspace, &sdk).unwrap());
+        assert_eq!(
+            fs::read_to_string(workspace.join("hex.config.ts")).unwrap(),
+            "// template config\n"
+        );
+        fs::remove_dir_all(workspace.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn invalid_sdk_effect_requirement_does_not_mutate_workspace() {
+        let (workspace, sdk) = workspace_upgrade_fixture();
+        assert!(initialize_workspace_at(&workspace, &sdk).unwrap());
+        let before = directory_manifest(&workspace).unwrap();
+        for invalid in [
+            "{",
+            "[]",
+            "{}",
+            r#"{"peerDependencies":{"effect":"^4.0.0-rc.999"}}"#,
+        ] {
+            fs::write(sdk.join("package.json"), invalid).unwrap();
+            assert!(refresh_managed_sdk_at(&workspace, &sdk).is_err());
+            assert_eq!(directory_manifest(&workspace).unwrap(), before);
+        }
+        fs::remove_dir_all(workspace.parent().unwrap()).unwrap();
+    }
+
+    fn workspace_upgrade_fixture() -> (PathBuf, PathBuf) {
+        static NEXT_FIXTURE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let sequence = NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed);
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "hex-workspace-upgrade-{}-{unique}-{sequence}",
+            std::process::id()
+        ));
+        let workspace = root.join("workspace");
+        let sdk = root.join("sdk");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::create_dir_all(sdk.join("dist")).unwrap();
+        fs::create_dir_all(sdk.join("workspace-template")).unwrap();
+        fs::write(sdk.join("dist/bin.js"), "// SDK\n").unwrap();
+        fs::write(
+            sdk.join("package.json"),
+            r#"{"peerDependencies":{"effect":"4.0.0-rc.999"}}"#,
+        )
+        .unwrap();
+        fs::write(sdk.join("workspace-template/package.json"), "{}").unwrap();
+        fs::write(
+            sdk.join("workspace-template/hex.config.ts"),
+            "// template config\n",
+        )
+        .unwrap();
+        (workspace, sdk)
     }
 
     #[test]

--- a/src/personal_commands.rs
+++ b/src/personal_commands.rs
@@ -510,7 +510,8 @@ fn directory_manifest(root: &Path) -> Result<Vec<(PathBuf, Option<Vec<u8>>)>> {
 
 fn install_workspace_dependencies(workspace: &Path, bun: &Path) -> Result<()> {
     let status = Command::new(bun)
-        .arg("install")
+        // A plain install reuses stale peer metadata for file:.hex-sdk in bun.lock.
+        .args(["update", "@hex/commands"])
         .current_dir(workspace)
         .status()
         .wrap_err("could not install the personal command workspace")?;

--- a/src/recognition.rs
+++ b/src/recognition.rs
@@ -267,30 +267,42 @@ pub fn listen(
     events.emit(&VoiceEvent::SessionStarted {
         timestamp_ms: now_ms(),
     })?;
+    if input.is_recovering() {
+        hotkey.suspend();
+        edit_hotkey.as_mut().and_then(DictationHotkey::suspend);
+    }
     if hotkey.is_recording() {
-        input.start(if microphone_policy.release_while_idle {
+        let accepted = input.start(if microphone_policy.release_while_idle {
             CaptureInstant::now()
         } else {
             input.captured_through()
         })?;
-        events.dictation(DictationPhase::Started, "")?;
-        if let Some(indicator) = &indicator {
-            indicator.send(DictationIndicatorEvent::Started);
+        if accepted {
+            events.dictation(DictationPhase::Started, "")?;
+            if let Some(indicator) = &indicator {
+                indicator.send(DictationIndicatorEvent::Started);
+            }
+        } else {
+            hotkey.suspend();
         }
     }
     if edit_hotkey
         .as_ref()
         .is_some_and(DictationHotkey::is_recording)
     {
-        input.start(if microphone_policy.release_while_idle {
+        let accepted = input.start(if microphone_policy.release_while_idle {
             CaptureInstant::now()
         } else {
             input.captured_through()
         })?;
-        edit_context = Some(voice_action_context_snapshot(&context));
-        events.dictation(DictationPhase::Started, "")?;
-        if let Some(indicator) = &indicator {
-            indicator.send(DictationIndicatorEvent::EditingStarted);
+        if accepted {
+            edit_context = Some(voice_action_context_snapshot(&context));
+            events.dictation(DictationPhase::Started, "")?;
+            if let Some(indicator) = &indicator {
+                indicator.send(DictationIndicatorEvent::EditingStarted);
+            }
+        } else {
+            edit_hotkey.as_mut().and_then(DictationHotkey::suspend);
         }
     }
     emit_state(
@@ -333,7 +345,7 @@ pub fn listen(
                             &input.device_name(),
                             &mut events,
                             indicator.as_ref(),
-                        )?
+                        )?;
                     }
                     RecognitionControl::PasteLast => {}
                     RecognitionControl::StartDictation {
@@ -829,7 +841,7 @@ pub fn listen(
                 if voice_action_takeover {
                     let _ = hotkey.suspend();
                 } else if voice_protocol.is_none() {
-                    handle_hotkey_action(
+                    let accepted = handle_hotkey_action(
                         action,
                         capture_at,
                         &mut recognizer,
@@ -841,6 +853,9 @@ pub fn listen(
                         &mut events,
                         indicator.as_ref(),
                     )?;
+                    if !accepted {
+                        hotkey.suspend();
+                    }
                 }
             }
             if let Some(action) = edit_action
@@ -1516,10 +1531,12 @@ fn handle_hotkey_action(
     device: &str,
     events: &mut EventLog,
     indicator: Option<&DictationIndicatorSender>,
-) -> Result<()> {
+) -> Result<bool> {
     match action {
         HotkeyAction::Start => {
-            dictation.start(action_at)?;
+            if !dictation.start(action_at)? {
+                return Ok(false);
+            }
             reset_command_recognizer(dictation, recognizer)?;
             worker.prepare_paste();
             events.dictation(DictationPhase::Started, "")?;
@@ -1583,7 +1600,8 @@ fn handle_hotkey_action(
             }
             emit_engine_state(events, false, worker, mode, device)
         }
-    }
+    }?;
+    Ok(true)
 }
 
 fn voice_action_context_snapshot(fallback: &ContextSnapshot) -> ContextSnapshot {
@@ -1627,7 +1645,10 @@ fn handle_edit_hotkey_action(
             }
             let promoted = dictation.is_recording();
             if !promoted {
-                dictation.start(action_at)?;
+                if !dictation.start(action_at)? {
+                    *edit_context = None;
+                    return Ok(false);
+                }
                 reset_command_recognizer(dictation, recognizer)?;
             }
             let became_intentional = dictation.become_intentional(CaptureInstant::now())?;

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -120,6 +120,14 @@ pub struct ObservedInputEvent {
 pub struct PendingInputEvents(Arc<Mutex<VecDeque<(u64, CaptureInstant)>>>);
 
 impl PendingInputEvents {
+    #[cfg(test)]
+    pub fn with_pending_for_test(at: CaptureInstant) -> (Self, impl FnOnce()) {
+        let pending = Self::default();
+        pending.push(0, at);
+        let acknowledge = pending.clone();
+        (pending, move || acknowledge.acknowledge(0))
+    }
+
     pub fn oldest(&self) -> Option<CaptureInstant> {
         self.0
             .lock()


### PR DESCRIPTION
## Why

If the microphone could not open at startup, Hex returned before starting the audio owner's recovery loop. Plugging the microphone back in could not recover dictation without restarting the app.

The TypeScript SDKs also still targeted Effect beta.97. Effect's current v4 prerelease is `4.0.0-rc.112`, which uses `Schema.TaggedError` instead of `Schema.TaggedErrorClass`.

## What Changes

| Situation | Behavior |
| --- | --- |
| Startup microphone open fails | Keep the listener alive and retry with backoff from 250 ms to a five-second maximum interval |
| Capture is cancelled while recovering | Preserve the warm-microphone retry policy |
| Idle-release policy changes during a pending open | Preserve accepted capture; reconcile the microphone after finish/cancellation without waiting for keyboard acknowledgment |
| Hotkey or API start arrives during recovery | Reject admission without reporting a successful recording |
| Replacement microphone opens | Refresh metadata and the audio generation, resume PCM delivery, and accept new capture |
| TypeScript SDK uses Effect | Use rc.112 and the current tagged-error API; the Promise client still works without Effect |
| Existing command workspace has a known old Effect pin | Update that pin to the bundled SDK requirement while preserving user config and unrelated package fields |
| Custom conflicting Effect override or linked manifest needing migration | Leave user files unchanged and explain the required repair; already-current linked manifests keep working |

## Scope

Prepares macOS 2.1.4/build 20104 and a patch Changeset for `@kitlangton/hex`. App identity, signing key, settings, and updater packaging stay unchanged. Linux binary publication and the legacy Swift feed are outside this release.

## Verification

```sh
cargo fmt --all --check
cargo test --locked --bin voice-control
cargo clippy --locked --all-targets --all-features -- -D warnings
MACOSX_DEPLOYMENT_TARGET=15.0 cargo build --locked --release --bin voice-control
./scripts/test-app-identity.sh
git diff --check
cd sdk
bun install --frozen-lockfile
bun run --cwd commands check
bun run --cwd commands test
bun run --cwd commands build
bun run --cwd typescript check
bun run --cwd typescript test
bun run --cwd typescript build
npm pack --dry-run --workspace @kitlangton/hex
```

The microphone startup and policy/acknowledgment regressions were demonstrated failing before their fixes. Owner integration tests inject a replacement and PCM through the production channels, verify metadata and audio delivery, and accept a fresh capture. Physical USB unplug/replug has not been manually exercised.

The SDK has 28 passing tests, including all five public tagged-error classes; the command SDK has 31 passing tests. Both packages pass type checking and builds on rc.112. Packed clean consumers exercise the Promise and Effect APIs, and a separate consumer verifies the Promise API without Effect installed.

386 Rust tests passed, 9 ignored. Strict Clippy, formatting, diff checks, and identity guards passed. Fresh, beta.97, and beta.107 workspace installation/typecheck/host smoke fixtures passed; production reconciliation is also covered by Rust tests, including manifest-only refresh, custom selectors, symlinks, permissions, retryable write failure, and idempotence.

The signed release build passed Apple notarization and Gatekeeper. Native Sparkle validation and temporary installation passed from public 2.0.24, 2.1.0, 2.1.1, 2.1.2, and 2.1.3 to build 20104.

A packaged `hex commands init` test upgraded a workspace copied from the actual 2.1.3 app, preserving user config and custom package fields. It caught stale Bun lockfile peer metadata that the initial synthetic fixture missed; a targeted `bun update @hex/commands` now refreshes the local package's dependency graph without deleting the user's lockfile. The corrected fixture reproduces the error before the fix and passes afterward. The packaged CLI test passes, including a second idempotent initialization.

Final native Linux and full Nix CI passed: https://github.com/anomalyco/hex/actions/runs/33205020539.

Hex 2.1.4 was published artifact-first/feed-last. Public versioned/latest DMGs, updater ZIP, and feed match the prepared artifacts byte-for-byte. The installed app updated through Sparkle to 2.1.4/build 20104 and matches the prepared contents, signatures, and Gatekeeper assessment.

The SDK version PR [#40](https://github.com/anomalyco/hex/pull/40) is merged and `@kitlangton/hex@0.2.2` is published through the existing Changesets/OIDC workflow. Fresh npm-registry consumers pass in Bun and Node with rc.112, and without Effect for the Promise API. Registry visibility lagged the successful publish; a workflow retry confirmed the version was already published and performed no duplicate publication.

## Release Artifacts

[Download Hex 2.1.4](https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/releases/HEX-2.1.4-arm64.dmg)

- DMG: 34,391,087 bytes; SHA-256 `7026ae91313998eb8ffed26a7ff0b205cbc0bc32657e1180568096c953e14be1`.
- Updater ZIP: 32,817,464 bytes; SHA-256 `c4599089866451d7411515e63db8b64f3a2ef4298c2e07dc15d87e6accd714c7`.
