### PR TITLE
refactor: simplify recovery and workspace updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8677,7 +8677,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voice-control"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice-control"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 default-run = "voice-control"
 license = "MIT"
@@ -33,6 +33,7 @@ ratatui = "0.30.2"
 regex = "1.12.3"
 rodio = { version = "0.22.2", default-features = false, features = ["playback", "mp3"] }
 rubato = "0.16.2"
+semver = "1.0.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"
@@ -67,7 +68,6 @@ evdev = "0.13.2"
 gpui = { version = "0.2.2", default-features = false, features = ["font-kit", "wayland", "x11"] }
 gtk = "0.18.2"
 gtk-layer-shell = { version = "0.8.2", features = ["v0_6"] }
-semver = "1.0.28"
 tray-icon = { version = "0.24.1", default-features = false, features = ["gtk"] }
 transcribe-cpp = { version = "=0.1.3", features = ["vulkan"] }
 x11-clipboard = "0.9.3"

--- a/docs/releases/2.1.5.md
+++ b/docs/releases/2.1.5.md
@@ -1,0 +1,14 @@
+## Hex 2.1.5
+
+- Simplified microphone recovery so failed opens share one transition and an
+  active recovery does not repeatedly reapply the same state. Existing retry,
+  cancellation, and idle-release behavior is preserved.
+- Command workspace updates now clean up temporary files after failed writes
+  without overwriting or removing a pre-existing temporary file.
+- The command SDK's exact Effect version is validated with the shared SemVer
+  parser instead of a custom regular expression.
+
+This macOS release uses build 20105. App identity, permissions, settings,
+signing key, and the Rust update feed are unchanged. The public TypeScript SDK
+remains at 0.2.2 with Effect 4.0.0-rc.112 support. No Linux binary is published,
+and the legacy Swift app and feed are unchanged.

--- a/src/dictation_audio.rs
+++ b/src/dictation_audio.rs
@@ -648,10 +648,7 @@ impl Owner {
             RecoveringAudioInputEvent::OpenFailed(error) => {
                 let was_recording = self.pending_capture.take().is_some();
                 self.state.recording.store(false, Ordering::Release);
-                if !self.release_while_idle {
-                    self.input.request_recovery();
-                    self.state.recovering.store(true, Ordering::Release);
-                }
+                self.reconcile_input();
                 if was_recording {
                     let _ = self.events.send(DictationAudioEvent::OpenFailed {
                         capture_generation: self.state.capture_generation.load(Ordering::Acquire),
@@ -731,7 +728,7 @@ impl Owner {
             {
                 self.close_input();
             }
-        } else if !self.input.is_open() && !self.input.is_opening() {
+        } else if !self.input.is_open() && !self.input.is_opening() && !self.input.is_recovering() {
             // A key release is acknowledged after its synchronous controls return;
             // waiting for that acknowledgment here can leave the owner asleep.
             self.input.request_recovery();

--- a/src/personal_commands.rs
+++ b/src/personal_commands.rs
@@ -305,9 +305,7 @@ fn workspace_effect_update(workspace: &Path, sdk: &Path) -> Result<Option<Vec<u8
     let required = sdk_manifest["peerDependencies"]["effect"]
         .as_str()
         .filter(|version| {
-            regex::Regex::new(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$")
-                .expect("valid exact-version pattern")
-                .is_match(version)
+            semver::Version::parse(version).is_ok_and(|version| version.build.is_empty())
         })
         .ok_or_else(|| {
             eyre!("personal command SDK peerDependencies.effect must be an exact version")
@@ -458,24 +456,37 @@ fn refresh_managed_sdk_at(workspace: &Path, sdk: &Path) -> Result<bool> {
         }
     }
     if let Some(encoded) = &manifest_update {
-        let path = workspace.join("package.json");
-        let temporary = path.with_extension(format!("json.{}.tmp", std::process::id()));
-        (|| -> Result<()> {
-            fs::write(&temporary, encoded)?;
-            match fs::metadata(&path) {
-                Ok(metadata) => fs::set_permissions(&temporary, metadata.permissions())?,
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => return Err(error.into()),
-            }
-            fs::rename(&temporary, &path)?;
-            Ok(())
-        })()
-        .wrap_err_with(|| format!(
-            "could not update {}; the SDK may already be refreshed; fix filesystem access or space (including {}), then rerun `hex commands init`",
-            path.display(), temporary.display()
-        ))?;
+        write_workspace_manifest(&workspace.join("package.json"), encoded)?;
     }
     Ok(sdk_changed || manifest_update.is_some())
+}
+
+fn write_workspace_manifest(path: &Path, encoded: &[u8]) -> Result<()> {
+    let temporary = path.with_extension(format!("json.{}.tmp", std::process::id()));
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)
+        .and_then(|mut file| {
+            let result = (|| {
+                file.write_all(encoded)?;
+                match fs::metadata(path) {
+                    Ok(metadata) => file.set_permissions(metadata.permissions())?,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(error),
+                }
+                fs::rename(&temporary, path)
+            })();
+            drop(file);
+            if result.is_err() {
+                let _ = fs::remove_file(&temporary);
+            }
+            result
+        })
+    .wrap_err_with(|| format!(
+        "could not update {}; the SDK may already be refreshed; fix filesystem access or space (including {}), then rerun `hex commands init`",
+        path.display(), temporary.display()
+    ))
 }
 
 fn directory_manifest(root: &Path) -> Result<Vec<(PathBuf, Option<Vec<u8>>)>> {
@@ -3979,6 +3990,33 @@ mod tests {
     }
 
     #[test]
+    fn workspace_manifest_write_cleans_up_after_rename_failure() {
+        let (workspace, _) = workspace_upgrade_fixture();
+        let path = workspace.join("package.json");
+        let temporary = path.with_extension(format!("json.{}.tmp", std::process::id()));
+        fs::create_dir(&path).unwrap();
+
+        assert!(write_workspace_manifest(&path, b"{}").is_err());
+        assert!(path.is_dir());
+        assert!(!temporary.exists());
+        fs::remove_dir_all(workspace.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn workspace_manifest_write_preserves_preexisting_temporary_file() {
+        let (workspace, _) = workspace_upgrade_fixture();
+        let path = workspace.join("package.json");
+        let temporary = path.with_extension(format!("json.{}.tmp", std::process::id()));
+        fs::write(&path, b"original manifest").unwrap();
+        fs::write(&temporary, b"existing temporary file").unwrap();
+
+        assert!(write_workspace_manifest(&path, b"{}").is_err());
+        assert_eq!(fs::read(&path).unwrap(), b"original manifest");
+        assert_eq!(fs::read(&temporary).unwrap(), b"existing temporary file");
+        fs::remove_dir_all(workspace.parent().unwrap()).unwrap();
+    }
+
+    #[test]
     fn invalid_sdk_effect_requirement_does_not_mutate_workspace() {
         let (workspace, sdk) = workspace_upgrade_fixture();
         assert!(initialize_workspace_at(&workspace, &sdk).unwrap());
@@ -3988,6 +4026,9 @@ mod tests {
             "[]",
             "{}",
             r#"{"peerDependencies":{"effect":"^4.0.0-rc.999"}}"#,
+            r#"{"peerDependencies":{"effect":"4.0.0-rc.999+build"}}"#,
+            r#"{"peerDependencies":{"effect":"04.0.0"}}"#,
+            r#"{"peerDependencies":{"effect":"4.0.0-01"}}"#,
         ] {
             fs::write(sdk.join("package.json"), invalid).unwrap();
             assert!(refresh_managed_sdk_at(&workspace, &sdk).is_err());


### PR DESCRIPTION
## Why

The recent recovery and command-workspace changes had a duplicated recovery transition, repeated no-op state updates, and a custom exact-version parser despite an existing SemVer dependency. Failed manifest writes could also leave temporary files behind or overwrite a pre-existing temporary file.

## What Changes

| Area | Change |
| --- | --- |
| Microphone recovery | Reuse `reconcile_input` for failed opens and skip transitions while recovery is already active |
| SDK version validation | Use the existing `semver::Version` parser; retain rejection of build metadata and add coverage for invalid leading zeros |
| Manifest persistence | Isolate the write operation, create its temporary file exclusively, and clean up only a temporary file owned by the failed attempt |
| Existing behavior | Preserve backoff, event publication ordering, cancellation, pending keyboard acknowledgment handling, file permissions, and custom-manifest safeguards |

The simplify pass used three independent reviews for reuse, code quality, and efficiency. No broader restructuring was justified. Existing atomic writers have different permission and persistence contracts, so this does not introduce a generic filesystem abstraction.

## Scope

Prepares macOS 2.1.5/build 20105. The public TypeScript SDK remains at 0.2.2 with Effect rc.112 support; no npm release is needed. App identity, signing key, settings, updater packaging, Linux publication, and the legacy Swift feed are unchanged.

## Verification

```sh
cargo fmt --all --check
cargo test --locked --bin voice-control
cargo clippy --locked --all-targets --all-features -- -D warnings
./scripts/smoke-commands-workspace.sh
./scripts/test-app-identity.sh
git diff --check
```

388 Rust tests passed, 9 ignored; strict Clippy, formatting, diff and identity checks passed. Both new temporary-file regressions failed before the fix. Fresh, beta.97, and beta.107 command workspace smoke fixtures pass. The post-edit safety review found no blockers.

The release build is signed, notarized, stapled, and Gatekeeper-accepted. Packaged CLI tests pass against workspaces copied from the actual 2.1.3 and 2.1.4 apps, retaining custom fields and configuration through repeated initialization. Native Sparkle validation and temporary installation pass from public 2.0.24 and every 2.1.0 through 2.1.4 release to build 20105.

Native Linux and full Nix CI passed: https://github.com/anomalyco/hex/actions/runs/33210054256.

Hex 2.1.5 was published artifact-first/feed-last. Public versioned/latest DMGs, updater ZIP, and appcast match the validated artifacts byte-for-byte. The installed app updated through Sparkle to 2.1.5/build 20105, and its contents, identity, signatures, and Gatekeeper assessment match the release. Physical microphone unplug/replug is not part of this automated verification.

## Release Artifacts

[Download Hex 2.1.5](https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/releases/HEX-2.1.5-arm64.dmg)

- DMG: 34,402,679 bytes; SHA-256 `7d1d5c1955f429f4638b4674f62c738c699596ca4540ee85f7e756a8f81712c8`.
- Updater ZIP: 32,818,633 bytes; SHA-256 `ab276409be264b8923816f3156cdb08bde42548691a6e55914ef7d1ea5d27713`.
