### PR TITLE
fix(commands): support application deep links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8677,7 +8677,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voice-control"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice-control"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 default-run = "voice-control"
 license = "MIT"

--- a/docs/plans/personal-commands.md
+++ b/docs/plans/personal-commands.md
@@ -34,6 +34,13 @@ Available capabilities are `openUrl`, `openApplication`, `openPath`, `press`,
 and `typeText`. Handlers may compose several capabilities and may use ordinary
 TypeScript, local modules, Effect, and installed npm packages.
 
+`openUrl` accepts absolute web URLs and app deep links, for example
+`hex.openUrl("slack://channel?team=T_EXAMPLE&id=C_EXAMPLE")`. The URL is passed
+unchanged to macOS, which requires an installed handler for its scheme. Use
+`openApplication("Slack")` to launch an app by name or path, not to navigate a
+deep link. The API spelling is `openUrl`, not `openURL`. File URLs and inline
+script/data URLs remain unsupported; use `openPath` for filesystem paths.
+
 ## Dictation Transformations
 
 The config may register named string transformations. They appear as optional

--- a/docs/releases/2.1.6.md
+++ b/docs/releases/2.1.6.md
@@ -1,0 +1,14 @@
+## Hex 2.1.6
+
+- Custom commands can now open app deep links, such as Slack channel URLs,
+  using `hex.openUrl("slack://channel?team=...&id=...")`. Both fixed actions and
+  handlers accept app URL schemes and preserve the original URL.
+- Command documentation clarifies that `openApplication` launches an app by
+  name or path; `openUrl` navigates a deep link using its installed macOS handler.
+  File URLs and inline script/data URLs remain unsupported; use `openPath`
+  for filesystem paths.
+
+This macOS release uses build 20106. App identity, permissions, settings,
+signing key, and the Rust update feed are unchanged. The bundled command SDK
+updates with the app; the public transcription SDK remains at 0.2.2. No Linux
+binary is published, and the legacy Swift app and feed are unchanged.

--- a/sdk/commands/src/host.ts
+++ b/sdk/commands/src/host.ts
@@ -267,14 +267,17 @@ const validateNativeAction = (value: unknown, label: string): NativeAction | und
     case "openUrl": {
       if (typeof action.url !== "string") return undefined
       const url = boundedString(action.url, `${label}.url`, MAX_VALUE_BYTES)
+      if (/[\u0000-\u001f\u007f]/.test(url)) {
+        throw new Error(`${label}.url must not contain control characters`)
+      }
       let parsed: URL
       try {
         parsed = new URL(url)
       } catch {
         throw new Error(`${label}.url must be an absolute URL`)
       }
-      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-        throw new Error(`${label}.url must use http or https`)
+      if (["file:", "javascript:", "data:", "vbscript:"].includes(parsed.protocol)) {
+        throw new Error(`${label}.url scheme is not supported; use openPath for files`)
       }
       return openUrl(url)
     }

--- a/sdk/commands/src/model.ts
+++ b/sdk/commands/src/model.ts
@@ -20,8 +20,10 @@ export interface PressOptions {
   readonly repeat?: number
 }
 
+/** Open an absolute web URL or app deep link with its macOS handler. */
 export const openUrl = (url: string): NativeAction => Object.freeze({ type: "openUrl", url })
 
+/** Launch an application by name or path. Use openUrl for app deep links. */
 export const openApplication = (application: string): NativeAction =>
   Object.freeze({ type: "openApplication", application })
 
@@ -41,7 +43,9 @@ export function press(input: string | PressOptions): NativeAction {
 export const typeText = (text: string): NativeAction => Object.freeze({ type: "typeText", text })
 
 export interface HexCapabilities<Result> {
+  /** Open an absolute web URL or app deep link, such as slack://channel?team=...&id=... . */
   readonly openUrl: (url: string) => Result
+  /** Launch an application by name or path. Use openUrl for app deep links. */
   readonly openApplication: (application: string) => Result
   readonly openPath: (path: string) => Result
   readonly press: (input: string | PressOptions) => Result

--- a/sdk/commands/test/host.test.ts
+++ b/sdk/commands/test/host.test.ts
@@ -92,7 +92,10 @@ describe("command host", () => {
     })
   })
 
-  it("adapts vanilla handlers and round-trips tool calls", async () => {
+  it.each([
+    "https://example.com",
+    "slack://channel?team=T_EXAMPLE&id=C_EXAMPLE",
+  ])("adapts vanilla handlers and round-trips %s", async (url) => {
     const output: HostOutput[] = []
     let observedApplication: string | undefined
     await runHost({
@@ -102,7 +105,7 @@ describe("command host", () => {
             phrases: ["open example"],
             run: async ({ hex, context }: HandlerArguments) => {
               observedApplication = context.application
-              await hex.openUrl("https://example.com")
+              await hex.openUrl(url)
             },
           },
         },
@@ -133,7 +136,7 @@ describe("command host", () => {
       type: "toolCall",
       invocationId: "inv-1",
       toolCallId: "1",
-      action: { type: "openUrl", url: "https://example.com" },
+      action: { type: "openUrl", url },
     })
     expect(observedApplication).toBe("Brave Browser")
   })
@@ -583,7 +586,7 @@ describe("command host", () => {
     })).toThrow("repeat must be")
     expect(() => prepareConfig({
       commands: { bad: { phrases: ["bad"], run: { type: "openUrl", url: "file:///tmp/example" } } },
-    })).toThrow("must use http or https")
+    })).toThrow("scheme is not supported")
     expect(() => prepareConfig({
       commands: {
         bad: {
@@ -596,6 +599,33 @@ describe("command host", () => {
     expect(() => prepareConfig({
       commands: { bad: { phrases: ["bad"], action: { type: "press", key: "x", modifiers: ["meta"] } } },
     })).toThrow("unsupported modifier")
+  })
+
+  it.each([
+    "slack://channel?team=T_EXAMPLE&id=C_EXAMPLE",
+    "obsidian://open?vault=Work%20Notes&file=Plans%2FToday#section",
+    "mailto:hello@example.com?subject=Hello%20there",
+    "x-example+test://route?value=one%26two",
+    "SLACK://channel?team=T_EXAMPLE&id=C_EXAMPLE",
+  ])("registers deep links unchanged: %s", (url) => {
+    for (const field of ["action", "run"]) {
+      const prepared = prepareConfig({
+        commands: { link: { phrases: ["open link"], [field]: openUrl(url) } },
+      })
+      expect(prepared.registration.commands[0]?.execution).toEqual({
+        type: "native", action: { type: "openUrl", url },
+      })
+    }
+  })
+
+  it.each([
+    "relative/path", "//example.com", "", "slack://channel\u0000",
+    "javascript:alert(1)", "JaVaScRiPt:alert(1)", "data:text/plain,hello",
+    "vbscript:msgbox(1)", "file:///tmp/example",
+  ])("rejects invalid or non-launchable URLs: %s", (url) => {
+    expect(() => prepareConfig({
+      commands: { link: { phrases: ["open link"], action: openUrl(url) } },
+    })).toThrow()
   })
 
   it("bounds every dictation protocol phrase list", () => {

--- a/sdk/commands/workspace-template/.agents/skills/personal-commands/SKILL.md
+++ b/sdk/commands/workspace-template/.agents/skills/personal-commands/SKILL.md
@@ -61,6 +61,17 @@ export default defineHexConfig({
 })
 ```
 
+To navigate inside an app, use `openUrl` (lowercase `rl`) with its deep link.
+`openApplication` takes an app name or path, not a URL. macOS must have an
+installed handler for the URL scheme:
+
+```ts
+run: ({ hex }) => hex.openUrl("slack://channel?team=T_EXAMPLE&id=C_EXAMPLE")
+```
+
+URLs are passed unchanged, including their query and fragment. File URLs and
+inline script/data URLs are unsupported; use `openPath` for filesystem paths.
+
 Handlers may issue several calls. HEX waits for all calls started by the handler,
 including calls that were not explicitly awaited:
 

--- a/sdk/commands/workspace-template/AGENTS.md
+++ b/sdk/commands/workspace-template/AGENTS.md
@@ -49,6 +49,10 @@ files and third-party dependencies.
   `run`.
 - Capabilities are `openUrl`, `openApplication`, `openPath`, `press`, and
   `typeText`.
+- `openUrl` opens absolute web URLs and app deep links such as
+  `slack://channel?team=T_EXAMPLE&id=C_EXAMPLE` using an installed macOS handler.
+  `openApplication` takes an app name or path, not a deep link. Use `openPath`
+  for files; file, inline-script, and data URLs are unsupported.
 - Structured native action descriptors are available for fixed single actions,
   but handlers are the clearest default and compose multiple capabilities.
 - Effect `run` accepts an Effect value or a function that returns an Effect.

--- a/src/personal_commands.rs
+++ b/src/personal_commands.rs
@@ -2217,9 +2217,16 @@ impl NativeAction {
         Ok(match self {
             Self::OpenUrl { url } => {
                 validate_text(&url, "URL", 4096)?;
+                if url.bytes().any(|byte| byte.is_ascii_control()) {
+                    return Err(eyre!(
+                        "personal command URL must not contain control characters"
+                    ));
+                }
                 let parsed = url::Url::parse(&url).wrap_err("personal command URL is invalid")?;
-                if !matches!(parsed.scheme(), "http" | "https") {
-                    return Err(eyre!("personal command URL must use http or https"));
+                if matches!(parsed.scheme(), "file" | "javascript" | "data" | "vbscript") {
+                    return Err(eyre!(
+                        "personal command URL scheme is not supported; use openPath for files"
+                    ));
                 }
                 Action::OpenUrl(url)
             }
@@ -2654,9 +2661,48 @@ mod tests {
     use std::time::UNIX_EPOCH;
 
     #[test]
+    fn native_url_actions_preserve_deep_links() {
+        for url in [
+            "https://example.com",
+            "slack://channel?team=T_EXAMPLE&id=C_EXAMPLE",
+            "obsidian://open?vault=Work%20Notes&file=Plans%2FToday#section",
+            "mailto:hello@example.com?subject=Hello%20there",
+            "x-example+test://route?value=one%26two",
+            "SLACK://channel?team=T_EXAMPLE&id=C_EXAMPLE",
+        ] {
+            let action = NativeAction::OpenUrl { url: url.into() }
+                .into_action()
+                .unwrap();
+            assert!(matches!(action, Action::OpenUrl(value) if value == url));
+        }
+    }
+
+    #[test]
+    fn native_url_actions_reject_invalid_and_non_launchable_urls() {
+        for url in [
+            "relative/path",
+            "//example.com",
+            "",
+            "slack://channel\0",
+            "javascript:alert(1)",
+            "JaVaScRiPt:alert(1)",
+            "data:text/plain,hello",
+            "vbscript:msgbox(1)",
+            "file:///tmp/example",
+        ] {
+            assert!(
+                NativeAction::OpenUrl { url: url.into() }
+                    .into_action()
+                    .is_err(),
+                "{url:?}"
+            );
+        }
+    }
+
+    #[test]
     fn registration_compiles_native_and_handler_commands() {
         let registration: HostOutput = serde_json::from_str(
-            r#"{"type":"registration","protocolVersion":2,"commands":[{"id":"native","phrases":["open example"],"execution":{"type":"native","action":{"type":"openUrl","url":"https://example.com"}}},{"id":"handled","phrases":["do work"],"group":"Work","when":{"application":"Slack"},"execution":{"type":"handler"}}]}"#,
+            r#"{"type":"registration","protocolVersion":2,"commands":[{"id":"native","phrases":["open example"],"execution":{"type":"native","action":{"type":"openUrl","url":"slack://channel?team=T_EXAMPLE&id=C_EXAMPLE"}}},{"id":"handled","phrases":["do work"],"group":"Work","when":{"application":"Slack"},"execution":{"type":"handler"}}]}"#,
         )
         .unwrap();
         let HostOutput::Registration {
@@ -2679,7 +2725,7 @@ mod tests {
 
         assert!(matches!(
             compiled.commands.resolve(Mode::Listening, "open example", &ContextSnapshot::default()),
-            Decision::Execute { action: Action::OpenUrl(url), .. } if url == "https://example.com"
+            Decision::Execute { action: Action::OpenUrl(url), .. } if url == "slack://channel?team=T_EXAMPLE&id=C_EXAMPLE"
         ));
         let slack = ContextSnapshot {
             application: Some("Slack".into()),


### PR DESCRIPTION
## Why

Commands using Slack channel deep links fail before macOS receives the URL. Both the TypeScript fixed-action validator and Rust's shared registration/tool-call validator restrict `openUrl` to HTTP(S). This addresses #41.

## What Changes

| Input | Result |
| --- | --- |
| `hex.openUrl("slack://channel?team=T_EXAMPLE&id=C_EXAMPLE")` | Open through the installed macOS scheme handler |
| Fixed `action: openUrl("obsidian://open?vault=Work%20Notes")` | Register and preserve the original URL |
| `hex.openApplication("Slack")` | Continue launching an app by name or path |
| Relative URLs, ASCII controls, file/script/data URLs | Reject; use `openPath` for filesystem paths |

Both validators accept custom app schemes without rewriting query strings, escaping, or fragments. The existing native executor passes the URL as a single `/usr/bin/open` argument, not through a shell. Documentation and API comments distinguish deep links from application names; no `openURL` alias or overloaded application-launch behavior is introduced.

## Scope

Prepares macOS 2.1.6/build 20106, including its bundled private command SDK. The public transcription SDK remains at 0.2.2. No Linux binary or legacy Swift feed publication.

## Verification

```sh
cargo fmt --all --check
cargo test --locked --bin voice-control
cargo clippy --locked --all-targets --all-features -- -D warnings
cd sdk/commands
bun run check
bun run test
bun run build
```

The deep-link regression failed against both old validators. All 390 Rust tests pass (9 ignored), along with strict Clippy, app identity guards, and fresh/legacy command-workspace smoke checks. Command SDK typecheck/build and 46 tests pass, including fixed `action`/`run` descriptors, handler tool calls, original URL preservation, custom/mixed-case schemes, and invalid URL rejection. The unchanged public SDK also passes typecheck/build and all 28 tests. Independent review found no blockers.

The signed package is notarized, stapled, and Gatekeeper-accepted. The actual 2.1.5 bundled SDK reproduced the failure in an isolated workspace; upgrading that same workspace with the signed 2.1.6 CLI preserves user config and passes the deep-link descriptor/handler checks. A separate macOS smoke test delivers a custom URL through `/usr/bin/open` to an isolated registered app and verifies the complete received URL. This does not claim navigation within a private Slack channel.

Seven native Sparkle validation/temporary-install paths pass: public 2.0.24 and every 2.1.0 through 2.1.5 release to build 20106. Native Linux and full Nix CI passed: https://github.com/anomalyco/hex/actions/runs/33213987184.

Published after merge, artifacts first and feed last. Public versioned/latest DMGs, updater ZIP, and appcast match the prepared files byte-for-byte. [Hex 2.1.6 is available](https://pub-089d681d41754031a4aefa7017d8c2fb.r2.dev/releases/HEX-2.1.6-arm64.dmg), and the reporter has been asked to retry their channel URL.
