### PR TITLE
fix(macOS): handle Accessibility Keyboard shortcuts

### DIFF
--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -47,7 +47,8 @@ use crate::desktop_ui::{
 use crate::dictation_indicator::{DictationIndicatorEvent, DictationIndicatorSender, HudTuning};
 use crate::dictation_processor::{ModelCatalog, ModelChoice};
 use crate::events::{
-    CommandOutcome, DictationPhase, EventReader, TranscriptPhase, VoiceEvent, VoiceState, now_ms,
+    CommandOutcome, DictationPhase, EventReader, ShortcutAction, ShortcutKind, TranscriptPhase,
+    VoiceEvent, VoiceState, now_ms,
 };
 use crate::history::{History, HistoryEntry, HistoryKind, HistoryRetention};
 use crate::login_item::LoginItemStatus;
@@ -8527,6 +8528,9 @@ fn event_summary(event: &VoiceEvent) -> String {
                     )
                 })
         }
+        VoiceEvent::Shortcut {
+            shortcut, action, ..
+        } => shortcut_summary(*shortcut, *action),
         VoiceEvent::Context {
             application,
             browser_url,
@@ -8546,6 +8550,10 @@ fn event_summary(event: &VoiceEvent) -> String {
     }
 }
 
+fn shortcut_summary(shortcut: ShortcutKind, action: ShortcutAction) -> String {
+    format!("{} hotkey {}", shortcut.name(), action.description())
+}
+
 fn text_or(prefix: &str, text: &str) -> String {
     if text.is_empty() {
         prefix.into()
@@ -8560,6 +8568,22 @@ mod tests {
 
     use super::*;
     use crate::personal_commands::StatusExecution;
+
+    #[test]
+    fn activity_summarizes_configured_shortcut_actions() {
+        assert_eq!(
+            shortcut_summary(ShortcutKind::Dictation, ShortcutAction::Started),
+            "Dictation hotkey activated"
+        );
+        assert_eq!(
+            shortcut_summary(ShortcutKind::VoiceAction, ShortcutAction::Finished),
+            "Voice Action hotkey finished capture"
+        );
+        assert_eq!(
+            shortcut_summary(ShortcutKind::PasteLast, ShortcutAction::Pressed),
+            "Paste Last hotkey pressed"
+        );
+    }
 
     #[test]
     fn command_model_failure_has_recovery_without_blocking_dictation() {

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -110,6 +110,7 @@ fn draw(
         | VoiceEvent::Transcript { .. }
         | VoiceEvent::Command { .. }
         | VoiceEvent::Dictation { .. }
+        | VoiceEvent::Shortcut { .. }
         | VoiceEvent::Context { .. }
         | VoiceEvent::ApiServerStarted { .. }
         | VoiceEvent::ApiServerStopped { .. }
@@ -134,6 +135,7 @@ fn draw(
         | VoiceEvent::State { .. }
         | VoiceEvent::Command { .. }
         | VoiceEvent::Dictation { .. }
+        | VoiceEvent::Shortcut { .. }
         | VoiceEvent::Context { .. }
         | VoiceEvent::ApiServerStarted { .. }
         | VoiceEvent::ApiServerStopped { .. }
@@ -428,6 +430,16 @@ fn draw_activity(
                     Span::styled(processing, Style::default().fg(Color::DarkGray)),
                 ]))
             }
+            VoiceEvent::Shortcut {
+                shortcut, action, ..
+            } => Some(Line::from(vec![
+                Span::styled("◇ hotkey      ", Style::default().fg(Color::Yellow)),
+                Span::raw(shortcut.name()),
+                Span::styled(
+                    format!("  {}", action.description()),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ])),
             VoiceEvent::SessionStarted { .. }
             | VoiceEvent::State { .. }
             | VoiceEvent::Transcript { .. }

--- a/src/events.rs
+++ b/src/events.rs
@@ -45,6 +45,11 @@ pub enum VoiceEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         processing: Option<DictationProcessing>,
     },
+    Shortcut {
+        timestamp_ms: u64,
+        shortcut: ShortcutKind,
+        action: ShortcutAction,
+    },
     Context {
         timestamp_ms: u64,
         application: Option<String>,
@@ -72,6 +77,7 @@ impl VoiceEvent {
             | Self::Transcript { timestamp_ms, .. }
             | Self::Command { timestamp_ms, .. }
             | Self::Dictation { timestamp_ms, .. }
+            | Self::Shortcut { timestamp_ms, .. }
             | Self::Context { timestamp_ms, .. }
             | Self::ApiServerStarted { timestamp_ms, .. }
             | Self::ApiServerStopped { timestamp_ms }
@@ -86,6 +92,7 @@ impl VoiceEvent {
             Self::Transcript { .. } => "transcript",
             Self::Command { .. } => "command",
             Self::Dictation { .. } => "dictation",
+            Self::Shortcut { .. } => "shortcut",
             Self::Context { .. } => "context",
             Self::ApiServerStarted { .. } => "api_server_started",
             Self::ApiServerStopped { .. } => "api_server_stopped",
@@ -127,6 +134,48 @@ pub struct DictationProcessing {
     pub latency_ms: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fallback: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShortcutKind {
+    Dictation,
+    VoiceAction,
+    PasteLast,
+    PasteMeeting,
+}
+
+impl ShortcutKind {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Dictation => "Dictation",
+            Self::VoiceAction => "Voice Action",
+            Self::PasteLast => "Paste Last",
+            Self::PasteMeeting => "Paste Meeting",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShortcutAction {
+    Started,
+    Finished,
+    Discarded,
+    Cancelled,
+    Pressed,
+}
+
+impl ShortcutAction {
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::Started => "activated",
+            Self::Finished => "finished capture",
+            Self::Discarded => "interrupted",
+            Self::Cancelled => "cancelled",
+            Self::Pressed => "pressed",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -207,7 +256,9 @@ impl EventLog {
             .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "event writer stopped"))?;
         match sender.try_send(WriterMessage::Event(event.clone())) {
             Ok(()) => Ok(()),
-            Err(TrySendError::Full(WriterMessage::Event(event))) if event.is_replaceable() => {
+            Err(TrySendError::Full(WriterMessage::Event(event)))
+                if event.may_drop_under_pressure() =>
+            {
                 Ok(())
             }
             Err(TrySendError::Full(message)) => sender
@@ -273,16 +324,25 @@ impl EventLog {
             processing,
         })
     }
+
+    pub fn shortcut(&self, shortcut: ShortcutKind, action: ShortcutAction) {
+        let _ = self.emit(&VoiceEvent::Shortcut {
+            timestamp_ms: now_ms(),
+            shortcut,
+            action,
+        });
+    }
 }
 
 impl VoiceEvent {
-    fn is_replaceable(&self) -> bool {
+    fn may_drop_under_pressure(&self) -> bool {
         matches!(
             self,
             Self::Transcript {
                 phase: TranscriptPhase::Started | TranscriptPhase::Updated,
                 ..
-            } | Self::Context { .. }
+            } | Self::Shortcut { .. }
+                | Self::Context { .. }
         )
     }
 }
@@ -504,6 +564,56 @@ mod tests {
                 ..
             } if profile == "slack" && fallback == "deadline exceeded"
         ));
+    }
+
+    #[test]
+    fn shortcut_observation_round_trips() {
+        let event = VoiceEvent::Shortcut {
+            timestamp_ms: 42,
+            shortcut: ShortcutKind::VoiceAction,
+            action: ShortcutAction::Finished,
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        assert_eq!(
+            json,
+            r#"{"kind":"shortcut","timestamp_ms":42,"shortcut":"voice_action","action":"finished"}"#
+        );
+        assert!(matches!(
+            serde_json::from_str(&json).unwrap(),
+            VoiceEvent::Shortcut {
+                timestamp_ms: 42,
+                shortcut: ShortcutKind::VoiceAction,
+                action: ShortcutAction::Finished,
+            }
+        ));
+    }
+
+    #[test]
+    fn shortcut_observations_drop_when_the_writer_queue_is_full() {
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let log = EventLog {
+            inner: Arc::new(EventLogInner {
+                sender: Some(sender),
+                error: Arc::new(Mutex::new(None)),
+                worker: None,
+            }),
+        };
+        log.emit(&VoiceEvent::SessionStarted { timestamp_ms: 1 })
+            .unwrap();
+        let (done, completed) = mpsc::channel();
+        let observer = thread::spawn(move || {
+            log.shortcut(ShortcutKind::Dictation, ShortcutAction::Started);
+            done.send(()).unwrap();
+        });
+
+        let result = completed.recv_timeout(std::time::Duration::from_secs(1));
+        drop(receiver);
+        observer.join().unwrap();
+        assert!(
+            result.is_ok(),
+            "shortcut observation blocked on a full queue"
+        );
     }
 
     #[test]

--- a/src/recognition.rs
+++ b/src/recognition.rs
@@ -16,8 +16,8 @@ use crate::dictation::{
 use crate::dictation_audio::{DictationAudio, DictationAudioEvent};
 use crate::dictation_indicator::{DictationIndicatorEvent, DictationIndicatorSender};
 use crate::events::{
-    CommandOutcome, DictationPhase, DictationProcessing, EventLog, TranscriptPhase, VoiceEvent,
-    VoiceState, now_ms,
+    CommandOutcome, DictationPhase, DictationProcessing, EventLog, ShortcutAction, ShortcutKind,
+    TranscriptPhase, VoiceEvent, VoiceState, now_ms,
 };
 use crate::feedback::{self, Tone};
 use crate::meeting::MeetingRequest;
@@ -817,6 +817,11 @@ pub fn listen(
             let edit_action = edit_hotkey
                 .as_mut()
                 .and_then(|edit| edit.process(input_event, capture_at));
+            if let Some(action) = edit_action
+                && voice_protocol.is_none()
+            {
+                emit_shortcut_action(&events, ShortcutKind::VoiceAction, action);
+            }
             if matches!(edit_action, Some(HotkeyAction::Start)) && voice_protocol.is_none() {
                 start_pending_voice_action(
                     &mut edit_pending_since,
@@ -841,6 +846,7 @@ pub fn listen(
                 if voice_action_takeover {
                     let _ = hotkey.suspend();
                 } else if voice_protocol.is_none() {
+                    emit_shortcut_action(&events, ShortcutKind::Dictation, action);
                     let accepted = handle_hotkey_action(
                         action,
                         capture_at,
@@ -1517,6 +1523,18 @@ fn start_voice_capture(
     }
     emit_state(events, true, mode, device)?;
     Ok(true)
+}
+
+fn emit_shortcut_action(events: &EventLog, shortcut: ShortcutKind, action: HotkeyAction) {
+    let (shortcut, action) = match action {
+        HotkeyAction::Start => (shortcut, ShortcutAction::Started),
+        HotkeyAction::Finish => (shortcut, ShortcutAction::Finished),
+        HotkeyAction::Discard => (shortcut, ShortcutAction::Discarded),
+        HotkeyAction::Cancel => (shortcut, ShortcutAction::Cancelled),
+        HotkeyAction::PasteLast => (ShortcutKind::PasteLast, ShortcutAction::Pressed),
+        HotkeyAction::PasteMeeting => (ShortcutKind::PasteMeeting, ShortcutAction::Pressed),
+    };
+    events.shortcut(shortcut, action);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -29,7 +29,9 @@ const EVENT_TAP_DISABLED_BY_USER_INPUT: u32 = u32::MAX;
 const KEYBOARD_EVENT_KEYCODE: u32 = 9;
 const EVENT_SOURCE_USER_DATA: u32 = 42;
 
-const HID_EVENT_TAP: u32 = 0;
+// Accessibility Keyboard injects events downstream of the HID tap. The
+// annotated-session boundary receives both physical and assistive keyboard input.
+const ANNOTATED_SESSION_EVENT_TAP: u32 = 2;
 const HEAD_INSERT_EVENT_TAP: u32 = 0;
 const DEFAULT_EVENT_TAP: u32 = 0;
 const LISTEN_ONLY_EVENT_TAP: u32 = 1;
@@ -311,7 +313,7 @@ fn run_event_tap(
     // SAFETY: The callback context remains allocated until this run loop stops.
     let key_tap = unsafe {
         CGEventTapCreate(
-            HID_EVENT_TAP,
+            ANNOTATED_SESSION_EVENT_TAP,
             HEAD_INSERT_EVENT_TAP,
             DEFAULT_EVENT_TAP,
             key_mask,
@@ -331,7 +333,7 @@ fn run_event_tap(
     // flagsChanged events unchanged. Observe modifiers and mouse clicks with a passive tap.
     let observation_tap = unsafe {
         CGEventTapCreate(
-            HID_EVENT_TAP,
+            ANNOTATED_SESSION_EVENT_TAP,
             HEAD_INSERT_EVENT_TAP,
             LISTEN_ONLY_EVENT_TAP,
             observation_mask,


### PR DESCRIPTION
## What changed

- Listen at the annotated session event tap so macOS Accessibility Keyboard shortcuts reach HEX.
- Record dictation, Voice Action, and paste hotkey activity in the Activity views.
- Drop shortcut observations if the event queue is full so diagnostics never delay recording.
- Add tests for event serialization, queue pressure, and Activity summaries.

## Why

Accessibility Keyboard injects key events after the HID event tap HEX previously used. Physical keyboards worked, but the same shortcut sent by Accessibility Keyboard never reached the listener.

Moving the tap fixes that. The new Activity entries make future shortcut problems easier to diagnose.

## Testing

- `cargo test --bin voice-control suppression::tests -- --nocapture` (30 passed)
- `cargo test --bin voice-control events::tests -- --nocapture` (6 passed)
- `cargo test --bin voice-control app_window::tests::activity_summarizes_configured_shortcut_actions -- --exact --nocapture` (1 passed)
- `cargo fmt --check`
- `git diff --check`
