### PR TITLE
fix(macos): handle assistive input and preserve modifier sides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8677,7 +8677,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voice-control"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice-control"
-version = "2.1.6"
+version = "2.1.7"
 edition = "2024"
 default-run = "voice-control"
 license = "MIT"

--- a/docs/releases/2.1.7.md
+++ b/docs/releases/2.1.7.md
@@ -1,0 +1,16 @@
+## Hex 2.1.7
+
+- Shortcuts now listen at the annotated macOS session boundary so assistive
+  keyboard events injected after the hardware input tap can reach Hex.
+  Modifier keys remain passively observed, preserving normal application behavior.
+- Left-only and right-only modifier shortcuts now require the matching side's
+  event flag. A side-less Control event, such as a remapped Caps Lock, no longer
+  activates a right-Control shortcut. Choose Either to accept side-less input.
+- Releasing the configured side finishes its capture even if a side-less
+  modifier remains held. Holding both physical sides still satisfies either
+  side-specific binding.
+
+This macOS release uses build 20107. App identity, permissions, settings,
+signing key, and the Rust update feed are unchanged. The public transcription
+SDK remains at 0.2.2. No Linux binary is published, and the legacy Swift app
+and feed are unchanged.

--- a/src/app_settings.rs
+++ b/src/app_settings.rs
@@ -333,10 +333,25 @@ impl RuntimeHotkey {
 
     pub fn exact_modifiers(self, flags: u64) -> bool {
         modifiers_from_flags(flags).matches_exactly(self.modifiers)
+            && self.required_modifiers_down(flags)
     }
 
     pub fn required_modifiers_down(self, flags: u64) -> bool {
         modifiers_from_flags(flags).contains(self.modifiers)
+            // `Either` also represents side-less input and both sides held. Only the
+            // original device flags distinguish those cases for a sided binding.
+            && [
+                (self.modifiers.control, LEFT_CONTROL_MASK, RIGHT_CONTROL_MASK),
+                (self.modifiers.option, LEFT_OPTION_MASK, RIGHT_OPTION_MASK),
+                (self.modifiers.shift, LEFT_SHIFT_MASK, RIGHT_SHIFT_MASK),
+                (self.modifiers.command, LEFT_COMMAND_MASK, RIGHT_COMMAND_MASK),
+            ]
+            .into_iter()
+            .all(|(side, left, right)| match side {
+                Some(ModifierSide::Left) => flags & left != 0,
+                Some(ModifierSide::Right) => flags & right != 0,
+                Some(ModifierSide::Either) | None => true,
+            })
     }
 
     pub fn matches_key_press(self, code: u16, flags: u64) -> bool {
@@ -1367,6 +1382,63 @@ mod tests {
                 .runtime()
                 .matches_key_press(0, OPTION_KEY_MASK | RIGHT_OPTION_MASK,)
         );
+    }
+
+    #[test]
+    fn runtime_side_constraints_require_the_requested_device_flag() {
+        for (modifier, general, left, right) in [
+            (
+                "control",
+                CONTROL_KEY_MASK,
+                LEFT_CONTROL_MASK,
+                RIGHT_CONTROL_MASK,
+            ),
+            (
+                "option",
+                OPTION_KEY_MASK,
+                LEFT_OPTION_MASK,
+                RIGHT_OPTION_MASK,
+            ),
+            ("shift", SHIFT_KEY_MASK, LEFT_SHIFT_MASK, RIGHT_SHIFT_MASK),
+            (
+                "command",
+                COMMAND_KEY_MASK,
+                LEFT_COMMAND_MASK,
+                RIGHT_COMMAND_MASK,
+            ),
+        ] {
+            for side in ["left", "right", "either"] {
+                let binding: HotkeyBinding = serde_json::from_value(serde_json::json!({
+                    "modifiers": { (modifier): side },
+                    "key": { "code": 0, "label": "A" },
+                }))
+                .unwrap();
+                let binding = binding.runtime();
+                for (device_flags, matches) in [
+                    (0, side == "either"),
+                    (left, side != "right"),
+                    (right, side != "left"),
+                    (left | right, true),
+                ] {
+                    let flags = general | device_flags;
+                    assert_eq!(
+                        binding.required_modifiers_down(flags),
+                        matches,
+                        "{side:?}, flags={flags:#x}"
+                    );
+                    assert_eq!(
+                        binding.matches_key_press(0, flags),
+                        matches,
+                        "{side:?}, flags={flags:#x}"
+                    );
+                    assert!(!binding.exact_modifiers(flags | FUNCTION_KEY_MASK));
+                    assert_eq!(
+                        binding.required_modifiers_down(flags | FUNCTION_KEY_MASK),
+                        matches
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -29,7 +29,8 @@ const EVENT_TAP_DISABLED_BY_USER_INPUT: u32 = u32::MAX;
 const KEYBOARD_EVENT_KEYCODE: u32 = 9;
 const EVENT_SOURCE_USER_DATA: u32 = 42;
 
-const HID_EVENT_TAP: u32 = 0;
+// Assistive keyboards inject downstream of HID; observe them alongside hardware input.
+const ANNOTATED_SESSION_EVENT_TAP: u32 = 2;
 const HEAD_INSERT_EVENT_TAP: u32 = 0;
 const DEFAULT_EVENT_TAP: u32 = 0;
 const LISTEN_ONLY_EVENT_TAP: u32 = 1;
@@ -311,7 +312,7 @@ fn run_event_tap(
     // SAFETY: The callback context remains allocated until this run loop stops.
     let key_tap = unsafe {
         CGEventTapCreate(
-            HID_EVENT_TAP,
+            ANNOTATED_SESSION_EVENT_TAP,
             HEAD_INSERT_EVENT_TAP,
             DEFAULT_EVENT_TAP,
             key_mask,
@@ -331,7 +332,7 @@ fn run_event_tap(
     // flagsChanged events unchanged. Observe modifiers and mouse clicks with a passive tap.
     let observation_tap = unsafe {
         CGEventTapCreate(
-            HID_EVENT_TAP,
+            ANNOTATED_SESSION_EVENT_TAP,
             HEAD_INSERT_EVENT_TAP,
             LISTEN_ONLY_EVENT_TAP,
             observation_mask,
@@ -1356,6 +1357,64 @@ mod tests {
                 InputEvent::Flags(SHIFT_KEY_MASK),
                 now + Duration::from_secs(1),
             ),
+            Some(HotkeyAction::Finish)
+        );
+    }
+
+    #[test]
+    fn remapped_control_does_not_start_or_hold_right_control_dictation() {
+        use crate::app_settings::{HotkeyModifiers, ModifierSide, RIGHT_CONTROL_MASK};
+
+        let now = capture_time();
+        let binding = RuntimeHotkey {
+            modifiers: HotkeyModifiers {
+                control: Some(ModifierSide::Right),
+                ..Default::default()
+            },
+            key_code: None,
+        };
+        let mut hotkey = DictationHotkey::with_binding(false, now, 9, false, binding);
+        // Remapped Caps Lock may carry the general Control flag without a side.
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(CONTROL_KEY_MASK), now),
+            None
+        );
+        assert!(!hotkey.is_recording());
+        assert_eq!(hotkey.process(InputEvent::Flags(0), now), None);
+        assert_eq!(
+            hotkey.process(
+                InputEvent::Flags(CONTROL_KEY_MASK | RIGHT_CONTROL_MASK),
+                now
+            ),
+            Some(HotkeyAction::Start)
+        );
+        assert_eq!(
+            hotkey.process(
+                InputEvent::Flags(CONTROL_KEY_MASK),
+                now + Duration::from_secs(1)
+            ),
+            Some(HotkeyAction::Finish)
+        );
+
+        let mut either = DictationHotkey::with_binding(
+            false,
+            now,
+            9,
+            false,
+            RuntimeHotkey {
+                modifiers: HotkeyModifiers {
+                    control: Some(ModifierSide::Either),
+                    ..Default::default()
+                },
+                key_code: None,
+            },
+        );
+        assert_eq!(
+            either.process(InputEvent::Flags(CONTROL_KEY_MASK), now),
+            Some(HotkeyAction::Start)
+        );
+        assert_eq!(
+            either.process(InputEvent::Flags(0), now + Duration::from_secs(1)),
             Some(HotkeyAction::Finish)
         );
     }


### PR DESCRIPTION
## Why

Assistive keyboard events injected after the HID tap never reach Hex's shortcut listener. Separately, a side-less Control event can activate a right-Control binding because runtime matching treats an unknown event side like a configured wildcard.

Addresses the input-routing report in #44 and the remapped Caps Lock follow-up in #37.

## What Changes

- Both macOS event taps listen at the annotated-session boundary. Modifier and mouse observation remains passive, and Hex's own synthetic events remain filtered.
- Runtime matching requires the requested device-side flag without changing saved bindings or configuration conflict detection.

| Input | Right-Control binding | Either-Control binding |
| --- | --- | --- |
| Side-less Control | Ignore | Activate |
| Left Control | Ignore | Activate |
| Right Control | Activate | Activate |
| Both physical Control keys | Activate | Activate |
| Release Right Control while side-less Control remains | Finish capture | Continue capture |

Prepares macOS version 2.1.7, build 20107, with release notes.

## Scope

Input routing and modifier matching only. The Activity logging expansion from #44 is not included. App identity, signing, settings, and the update feed are unchanged; no Linux or TypeScript SDK release is included.

## Verification

```sh
cargo fmt --check
cargo test --locked --all-features -- --quiet
cargo clippy --locked --all-targets --all-features -- -D warnings
git diff --check
```

392 tests pass, with 9 existing environment-dependent tests ignored. The new modifier regressions failed before the fix. Cargo used a working local CMake executable and the existing target cache.

A native CoreGraphics probe on macOS 26.5.1 verified that annotated-session synthetic key and flags events reach the annotated tap but not HID, with HID positive controls. Actual Accessibility Keyboard gestures and physical-key/Finder smoke checks remain unverified; this is not an end-to-end Accessibility Keyboard claim.
