### PR TITLE
fix(macos): discover OpenCode beta install

### DIFF
--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -4407,16 +4407,24 @@ impl AppWindow {
         };
         let processing_enabled = self.selected_mode_settings().post_processing.enabled;
         let processing_can_toggle = processing_enabled || self.opencode_available();
-        let processing_unavailable = opencode_unavailable_copy(&self.model_catalog).map(|copy| {
-            (
-                copy.title,
-                copy.description,
-                copy.error.map(str::to_owned),
-                copy.can_retry,
-                copy.retry_label,
-                copy.can_open_setup,
-            )
-        });
+        let processing_unavailable =
+            opencode_unavailable_copy(&self.model_catalog).map(|mut copy| {
+                if matches!(self.model_catalog, ModelCatalogState::Loading) {
+                    copy.description =
+                        "OpenCode transformation will be available after HEX connects to OpenCode.";
+                } else if matches!(self.model_catalog, ModelCatalogState::Missing) {
+                    copy.title = "Transformation requires OpenCode";
+                    copy.description = "Install and configure OpenCode to transform dictated text.";
+                }
+                (
+                    copy.title,
+                    copy.description,
+                    copy.error.map(str::to_owned),
+                    copy.can_retry,
+                    copy.retry_label,
+                    copy.can_open_setup,
+                )
+            });
         let corrections = self.render_mode_replacements(selection, cx);
         let transformations = self.render_mode_transformations(selection, cx);
         let application_picker =

--- a/src/dictation_processor.rs
+++ b/src/dictation_processor.rs
@@ -935,6 +935,7 @@ fn find_opencode_executable(
         .map(|directory| absolute_path(directory.join("opencode2"), current_directory));
     let home_candidates = home.into_iter().flat_map(|home| {
         [
+            home.join(".opencode/bin/opencode2"),
             home.join(".bun/bin/opencode2"),
             home.join("Library/pnpm/opencode2"),
             home.join("Library/pnpm/bin/opencode2"),


### PR DESCRIPTION
## Summary

- Discover `opencode2` at `~/.opencode/bin/opencode2`. On macOS, `curl -fsSL https://opencode.ai/v2/install | bash` installs the beta CLI there, outside the GUI app PATH.
- Show transformation-specific setup copy in Modes instead of reusing the Voice Action wording.

## Testing

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
- Manually launched HEX and confirmed Voice Action and OpenCode transformation become available.
- `cargo test`: 391 passed, 9 ignored; the unrelated `application_catalog::tests::finder_has_native_picker_metadata_and_an_icon` test failed because this Mac reports `Finder.app` where the fixture expects `Finder`.