### PR TITLE
fix(macos): lock dictation on natural-paced double-taps (#47)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,8 +159,9 @@ CoreAudio formats, AppleScript details, or event serialization.
   300 ms discard. A 450 ms hotkey pre-roll and one-second voice-trigger pre-roll
   protect speech onset. Capture has no automatic duration limit; release,
   explicit stop, or Escape ends it.
-- When enabled, a second shortcut tap within 300 ms locks dictation. Press the
-  shortcut again to finish or Escape to cancel.
+- When enabled, a second shortcut tap within 500 ms locks dictation. Press the
+  shortcut again to finish or Escape to cancel. Double-tap-only mode keeps the
+  tighter 300 ms window for its deliberate two-tap gesture.
 - When commands are enabled, every dictation or paste hotkey action resets
   Moonshine so shortcut audio cannot leak into a later command.
 - Recording audio behavior and idle-sleep prevention begin only after the

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -15,7 +15,15 @@ use crate::app_settings::{HOTKEY_MODIFIERS_MASK, RuntimeHotkey, RuntimeHotkeys};
 use crate::audio::CaptureInstant;
 use crate::dictation::MINIMUM_HOLD_DURATION;
 
+// The double-tap-only gesture is a deliberate, tight two-tap sequence, so it
+// stays gated on the hold threshold.
 const DOUBLE_TAP_WINDOW: Duration = MINIMUM_HOLD_DURATION;
+// A press-and-hold double-tap-to-lock spans a full press, release, press, and
+// release. Measuring that whole gesture against the 300 ms hold threshold was
+// too tight: a deliberate double-tap routinely landed outside the window and
+// fell back to two ordinary captures instead of locking (#47). Allow a window
+// closer to the macOS default double-click interval.
+const DOUBLE_TAP_LOCK_WINDOW: Duration = Duration::from_millis(500);
 const ESCAPE_KEY_CODE: u16 = 53;
 
 const EVENT_LEFT_MOUSE_DOWN: u32 = 1;
@@ -926,7 +934,8 @@ impl DictationHotkey {
             }
             State::Idle if trigger_pressed => {
                 let previous_release = self.last_release_at.take().filter(|released| {
-                    self.double_tap_enabled && now.duration_since(*released) < DOUBLE_TAP_WINDOW
+                    self.double_tap_enabled
+                        && now.duration_since(*released) < DOUBLE_TAP_LOCK_WINDOW
                 });
                 self.state = State::Recording {
                     started_at: now,
@@ -937,7 +946,7 @@ impl DictationHotkey {
             State::Recording {
                 previous_release: Some(released),
                 ..
-            } if trigger_released && now.duration_since(released) < DOUBLE_TAP_WINDOW => {
+            } if trigger_released && now.duration_since(released) < DOUBLE_TAP_LOCK_WINDOW => {
                 self.state = State::Locked;
                 None
             }
@@ -1713,6 +1722,38 @@ mod tests {
     }
 
     #[test]
+    fn a_natural_paced_double_tap_still_locks() {
+        // A deliberate double-tap spans four events and easily runs past the
+        // 300 ms hold threshold; it must still lock rather than fall back to two
+        // ordinary press-and-hold captures (#47).
+        let now = capture_time();
+        let mut hotkey = test_hotkey(false, now);
+
+        hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), now);
+        hotkey.process(InputEvent::Flags(NO_FLAGS), now + Duration::from_millis(90));
+        hotkey.process(
+            InputEvent::Flags(OPTION_KEY_MASK),
+            now + Duration::from_millis(250),
+        );
+        assert_eq!(
+            hotkey.process(
+                InputEvent::Flags(NO_FLAGS),
+                now + Duration::from_millis(450)
+            ),
+            None
+        );
+        assert!(hotkey.is_recording());
+        assert_eq!(
+            hotkey.process(
+                InputEvent::Flags(OPTION_KEY_MASK),
+                now + Duration::from_secs(2)
+            ),
+            Some(HotkeyAction::Finish)
+        );
+        assert!(!hotkey.is_recording());
+    }
+
+    #[test]
     fn a_slow_second_release_does_not_lock() {
         let now = capture_time();
         let mut hotkey = test_hotkey(false, now);
@@ -1726,7 +1767,7 @@ mod tests {
         assert_eq!(
             hotkey.process(
                 InputEvent::Flags(NO_FLAGS),
-                now + Duration::from_millis(450)
+                now + Duration::from_millis(800)
             ),
             Some(HotkeyAction::Finish)
         );


### PR DESCRIPTION
## Summary

Complementary follow-up to #49. **#49 is the primary fix** for double-tap-lock on side-specific modifier-only bindings (e.g. Right Option / Right Command): its `flagsChanged` HID-delivery fix is what makes the gesture register correctly at all. This PR addresses a **separate, timing-only** failure mode that remains once the edges are clean — the double-tap window is too tight for a natural-paced tap.

Verified on hardware (Right Option, `double_tap_lock: true`): #49 alone locks on a quick double-tap; #49 + this change also locks on a natural-paced double-tap; **this change alone does not fix the delivery bug and is not sufficient on its own.**

## Timing issue

`DictationHotkey` gated the whole double-tap gesture on `DOUBLE_TAP_WINDOW`, aliased to `MINIMUM_HOLD_DURATION` (300 ms). To lock, both the second press and the second release must fall within that window of the first release. A real double-tap of a modifier spans four events, and the second release routinely lands 300–500 ms after the first, so the gesture falls through to an ordinary `Finish` even when edges are delivered correctly. macOS's default double-click interval is 500 ms.

## Change

Decouple the press-and-hold lock window from the hold threshold:

```rust
const DOUBLE_TAP_LOCK_WINDOW: Duration = Duration::from_millis(500);
```

Used only by the two press-and-hold lock transitions (the `previous_release` filter and the `Recording → Locked` arm). The deliberate **double-tap-only** gesture keeps its tighter 300 ms `DOUBLE_TAP_WINDOW`, so its semantics and tests are unchanged.

## Tests

- Added `a_natural_paced_double_tap_still_locks` (second release 360 ms after the first): fails on the old 300 ms window (`Some(Finish)`), passes on 500 ms (`None` / locked).
- Updated `a_slow_second_release_does_not_lock` to a release beyond the new window.
- All `suppression` tests pass; merges cleanly with #49 (no textual conflict); `cargo fmt --check` and `cargo clippy -- -D warnings` clean.

## Sequencing

Land #49 first; this is a follow-up on top. Can also be folded into #49 if preferred.
