### PR TITLE
fix(linux): keep Wayland dictation running after Settings close

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,8 +288,10 @@ CoreAudio formats, AppleScript details, or event serialization.
   shortcut/double-tap settings stops and restores only a previously running
   listener; cancellation restores the old binding unless its save already
   committed. Settings must expose listener state, recovery, and errors. Without
-  a usable tray, closing Settings quits after draining workers, never detaches
-  an unmanageable microphone. HUD teardown only hides that listener's HUD.
+  a usable X11 tray, closing Settings quits after draining workers, never
+  detaches an unmanageable microphone. On Wayland, closing Settings keeps the
+  in-process listener; Quit HEX and SIGTERM remain the stop paths. HUD teardown
+  only hides that listener's HUD.
 - Linux paste keeps transcripts off helper argv, bounds helper I/O, and waits
   for physical modifiers without discarding accepted output. Shutdown cancels
   that wait. New installs use Ctrl-V; the terminal-paste preference selects

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8694,6 +8694,7 @@ dependencies = [
  "ed25519-dalek",
  "evdev",
  "fs2",
+ "gdk-pixbuf",
  "getrandom 0.4.3",
  "gpui",
  "gpui-symbols",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ ctrlc = { version = "3.5.2", features = ["termination"] }
 ed25519-dalek = "2.2.0"
 evdev = "0.13.2"
 gpui = { version = "0.2.2", default-features = false, features = ["font-kit", "wayland", "x11"] }
+gdk-pixbuf = "0.18"
 gtk = "0.18.2"
 gtk-layer-shell = { version = "0.8.2", features = ["v0_6"] }
 tray-icon = { version = "0.24.1", default-features = false, features = ["gtk"] }

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -75,10 +75,12 @@ and restores the previous running state after the edit. Cancelling shortcut
 capture restores the old binding and running state.
 
 With a working X11 tray, closing Settings hides the window. Without a working
-tray, closing Settings quits after stopping its workers; it never leaves an
-unmanageable microphone running. `--hidden` is honored only with a usable tray.
-On Wayland, leave Settings open while dictating; the recording/processing pill
-uses layer-shell without taking focus or intercepting clicks.
+X11 tray, closing Settings quits after stopping its workers; it never leaves an
+unmanageable microphone running. `--hidden` is honored only with a usable X11
+tray. On Wayland, a StatusNotifier tray icon is shown when a host is present,
+and closing Settings leaves dictation running until Quit HEX or SIGTERM. The
+recording/processing pill uses layer-shell without taking focus or intercepting
+clicks.
 
 Insertion uses the clipboard and **Ctrl-V** for new installations. Enable
 **Terminal paste shortcut** in Settings for targets that require **Ctrl-Shift-V**.
@@ -131,7 +133,8 @@ compositor, and target-application smoke tests remain necessary before a release
 `scripts/test-wayland-paste.sh /path/to/compiled-test-executable /path/to/voice-control` runs the real
 paste helpers against a GTK target under an isolated headless Sway compositor.
 It also launches Settings with `--hidden`, repeats paste while Settings remains
-open, and verifies that the tray-less native window closes cleanly. It requires the GTK development
+open, and verifies that the tray-less native window closes without exiting the
+process until SIGTERM. It requires the GTK development
 libraries, Sway, `wl-clipboard`, `wtype`, `dbus-run-session`, and a Vulkan driver
 (Mesa's software driver is sufficient), and must run as a non-root user. It uses
 isolated app data and no microphone; CI runs it with the display-free suite and

--- a/scripts/test-wayland-paste.sh
+++ b/scripts/test-wayland-paste.sh
@@ -79,6 +79,19 @@ if [[ "${1:-}" == --inside ]]; then
   target=
 
   swaymsg '[app_id="hex"] kill' >/dev/null
+  for ((attempt = 0; attempt < 100; attempt++)); do
+    kill -0 "$app"
+    if ! swaymsg -t get_tree -r | grep '"name": "HEX"' >/dev/null; then
+      break
+    fi
+    sleep 0.05
+  done
+  kill -0 "$app"
+  if swaymsg -t get_tree -r | grep '"name": "HEX"' >/dev/null; then
+    echo "HEX Settings window did not close" >&2
+    exit 1
+  fi
+  kill -TERM "$app"
   wait "$app"
   app=
   exit 0

--- a/src/linux_app.rs
+++ b/src/linux_app.rs
@@ -91,6 +91,7 @@ struct LinuxDesktopHost {
     transcription_preparation: Option<TranscriptionPreparation>,
     transcription_error: Option<String>,
     update: UpdateState,
+    keep_listening: Arc<AtomicBool>,
 }
 
 struct LinuxApp {
@@ -126,17 +127,19 @@ enum UpdateState {
 pub fn open(event_path: PathBuf, start_hidden: bool, shutdown: &'static AtomicBool) -> Result<()> {
     let listener_stop = Arc::new(Mutex::new(None));
     let quit_stop = listener_stop.clone();
+    let listener_stop_after_shell = listener_stop.clone();
+    let keep_listening = Arc::new(AtomicBool::new(true));
+    let keep_listening_after_shell = keep_listening.clone();
     let (tray_sender, tray_commands) = mpsc::channel();
     let session = LinuxSession::detect();
-    // GPUI cannot hide/reopen a native Wayland toplevel. Keep it manageable without a tray.
-    let close_to_tray = !session.is_wayland()
-        && match crate::linux_desktop::start_tray(tray_sender) {
-            Ok(()) => true,
-            Err(error) => {
-                tracing::warn!(%error, "system tray is unavailable; closing HEX will quit");
-                false
-            }
-        };
+    let tray_started = match crate::linux_desktop::start_tray(tray_sender) {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::warn!(%error, "system tray is unavailable");
+            false
+        }
+    };
+    let close_to_tray = !session.is_wayland() && tray_started;
     let (settings, settings_error) = match crate::linux_settings::LinuxSettings::load() {
         Ok(settings) => (settings, None),
         Err(error) => (
@@ -161,17 +164,21 @@ pub fn open(event_path: PathBuf, start_hidden: bool, shutdown: &'static AtomicBo
                     ..Default::default()
                 },
                 |_, cx| {
-                    cx.new(|_| LinuxApp {
-                        host: LinuxDesktopHost::new(
+                    cx.new(|_| {
+                        let mut host = LinuxDesktopHost::new(
                             event_path.clone(),
                             listener_stop.clone(),
                             settings.clone(),
                             settings_error.clone(),
                             update,
-                        ),
-                        quitting: false,
-                        restart_requested: false,
-                        transcription_picker: TranscriptionPickerState::Closed,
+                        );
+                        host.keep_listening = keep_listening.clone();
+                        LinuxApp {
+                            host,
+                            quitting: false,
+                            restart_requested: false,
+                            transcription_picker: TranscriptionPickerState::Closed,
+                        }
                     })
                 },
             )
@@ -288,6 +295,9 @@ pub fn open(event_path: PathBuf, start_hidden: bool, shutdown: &'static AtomicBo
                     {
                         return false;
                     }
+                    if session.is_wayland() {
+                        return true;
+                    }
                     // A missing X11 handle must not swallow close and strand a microphone.
                     if close_app
                         .update(cx, |app, cx| {
@@ -308,19 +318,41 @@ pub fn open(event_path: PathBuf, start_hidden: bool, shutdown: &'static AtomicBo
             let _ = set_x11_window_mapped(&x11_window, false);
         }
         cx.on_app_quit(move |cx| {
-            let _ = quit_app.update(cx, |app, _| app.request_quit());
-            if let Some(stop) = quit_stop
-                .lock()
-                .unwrap_or_else(|error| error.into_inner())
-                .take()
-            {
-                stop.store(true, Ordering::Relaxed);
+            if !keep_listening.load(Ordering::Relaxed) {
+                let _ = quit_app.update(cx, |app, _| app.request_quit());
+                if let Some(stop) = quit_stop
+                    .lock()
+                    .unwrap_or_else(|error| error.into_inner())
+                    .take()
+                {
+                    stop.store(true, Ordering::Relaxed);
+                }
+                crate::linux_desktop::shutdown();
             }
-            crate::linux_desktop::shutdown();
             async {}
         })
         .detach();
     });
+    if keep_listening_after_shell.load(Ordering::Relaxed) {
+        while !shutdown.load(Ordering::Relaxed) {
+            let stopped = listener_stop_after_shell
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .as_ref()
+                .is_none_or(|stop| stop.load(Ordering::Relaxed));
+            if stopped {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(250));
+        }
+        if let Some(stop) = listener_stop_after_shell
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .take()
+        {
+            stop.store(true, Ordering::Relaxed);
+        }
+    }
     crate::linux_desktop::shutdown();
     Ok(())
 }
@@ -430,6 +462,7 @@ impl LinuxDesktopHost {
             transcription_preparation: None,
             transcription_error: None,
             update,
+            keep_listening: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -837,6 +870,7 @@ impl LinuxDesktopHost {
 
 impl LinuxApp {
     fn request_quit(&mut self) {
+        self.host.keep_listening.store(false, Ordering::Relaxed);
         self.quitting = true;
         self.host.stop();
         self.host.cancel_transcription_preparation();
@@ -879,6 +913,10 @@ fn start_update_check() -> Receiver<Result<Option<InstalledUpdate>, String>> {
 
 impl Drop for LinuxDesktopHost {
     fn drop(&mut self) {
+        if self.keep_listening.load(Ordering::Relaxed) {
+            let _ = self.listener_worker.take();
+            return;
+        }
         self.stop();
         self.cancel_transcription_preparation();
         self.listener_stop
@@ -1632,6 +1670,40 @@ mod tests {
         app.host.refresh_settings_edit();
         assert!(!app.host.listen_when_ready);
         assert!(!app.host.has_pending_work());
+    }
+
+    #[test]
+    fn dropping_settings_can_leave_the_wayland_listener_running() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let listener_stop = Arc::new(Mutex::new(Some(stop.clone())));
+        let worker_stop = stop.clone();
+        let worker = std::thread::spawn(move || {
+            while !worker_stop.load(Ordering::Relaxed) {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Ok(())
+        });
+        {
+            let mut host = LinuxDesktopHost::new(
+                PathBuf::new(),
+                listener_stop.clone(),
+                crate::linux_settings::LinuxSettings::default(),
+                None,
+                UpdateState::Unmanaged,
+            );
+            host.keep_listening = Arc::new(AtomicBool::new(true));
+            host.listener_worker = Some(worker);
+            host.listen_when_ready = true;
+        }
+        assert!(!stop.load(Ordering::Relaxed));
+        assert!(
+            listener_stop
+                .lock()
+                .unwrap()
+                .as_ref()
+                .is_some_and(|flag| !flag.load(Ordering::Relaxed))
+        );
+        stop.store(true, Ordering::Relaxed);
     }
 
     #[test]

--- a/src/linux_desktop.rs
+++ b/src/linux_desktop.rs
@@ -5,6 +5,7 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use color_eyre::eyre::{Result, eyre};
+use gdk_pixbuf::Pixbuf;
 use gtk::prelude::*;
 use gtk_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use tray_icon::menu::{Menu, MenuEvent, MenuItem};
@@ -402,21 +403,46 @@ fn create_tray(commands: Sender<TrayCommand>) -> Result<TrayIcon> {
             let _ = commands.send(TrayCommand::Show);
         }
     }));
-    const SIZE: u32 = 22;
-    let mut data = vec![0_u8; (SIZE * SIZE * 4) as usize];
-    for y in 3..19 {
-        for x in 4..18 {
-            if matches!(x, 4..=7 | 14..=17) || (9..=12).contains(&y) {
-                let index = ((y * SIZE + x) * 4) as usize;
-                data[index..index + 4].copy_from_slice(&[0xd9, 0xff, 0x68, 0xff]);
-            }
-        }
-    }
+    let (data, width, height) = hex_tray_rgba()?;
     Ok(TrayIconBuilder::new()
         .with_tooltip("HEX Dictation")
-        .with_icon(Icon::from_rgba(data, SIZE, SIZE)?)
+        .with_icon(Icon::from_rgba(data, width, height)?)
         .with_menu(Box::new(menu))
         .build()?)
+}
+
+fn hex_tray_rgba() -> Result<(Vec<u8>, u32, u32)> {
+    const SIZE: i32 = 22;
+    let source = Pixbuf::from_read(std::io::Cursor::new(include_bytes!(
+        "../app/AppIcon.icon/Assets/Image.png"
+    )))
+    .map_err(|error| eyre!("could not decode HEX icon: {error}"))?;
+    let scaled = source
+        .scale_simple(SIZE, SIZE, gdk_pixbuf::InterpType::Bilinear)
+        .ok_or_else(|| eyre!("could not scale HEX icon"))?;
+    let width = scaled.width() as u32;
+    let height = scaled.height() as u32;
+    let rowstride = scaled.rowstride() as usize;
+    let channels = scaled.n_channels() as usize;
+    let pixels = scaled.read_pixel_bytes();
+    let mut rgba = Vec::with_capacity((width * height * 4) as usize);
+    for y in 0..height as usize {
+        let row = y * rowstride;
+        for x in 0..width as usize {
+            let index = row + x * channels;
+            rgba.extend_from_slice(&[
+                pixels[index],
+                pixels[index + 1],
+                pixels[index + 2],
+                if channels == 4 {
+                    pixels[index + 3]
+                } else {
+                    255
+                },
+            ]);
+        }
+    }
+    Ok((rgba, width, height))
 }
 
 fn tray_host_available() -> bool {
@@ -497,5 +523,14 @@ mod tests {
         assert_eq!(slot.state, IndicatorState::Recording);
         slot.set(current, IndicatorState::Hidden);
         assert_eq!(slot.state, IndicatorState::Hidden);
+    }
+
+    #[test]
+    fn tray_icon_uses_the_hex_logo() {
+        let (rgba, width, height) = hex_tray_rgba().unwrap();
+        assert_eq!((width, height), (22, 22));
+        assert_eq!(rgba.len(), 22 * 22 * 4);
+        assert!(rgba.iter().any(|byte| *byte > 200));
+        assert!(rgba.iter().any(|byte| *byte < 50));
     }
 }


### PR DESCRIPTION
Fix: Closing the app (Settings) on Wayland no longer stops the listener or the systemd user service.

Also start a `StatusNotifier` tray on Wayland when a host is present, using the HEX app icon.

### Not done, requires follow-up (let me know!):

- "Show HEX" cannot reopen Settings after close. GPUI stops when the last Wayland toplevel is destroyed.