### PR TITLE
fix(macos): restore double-tap timing and preserve capture ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,11 +175,13 @@ CoreAudio formats, AppleScript details, or event serialization.
 - Dictation remains available while command recognition sleeps.
 - Model inference, optional post-processing, paste, and application actions must
   never block authoritative audio capture. Their queues remain bounded.
-- CoreAudio capture timestamps and CGEvent shortcut timestamps share the macOS
-  boot-time clock, but raw CGEvent Mach ticks must be converted through the
-  current timebase before comparison. Delayed press handling reconstructs the
-  original onset from the timeline; delayed release handling excludes audio
-  captured after the physical release.
+- CoreAudio capture timestamps and annotated-session CGEvent shortcut timestamps
+  share the macOS boot-time nanosecond clock. Do not apply the Mach timebase to
+  annotated-session timestamps. Physical HID-tap timestamps arrived as raw Mach
+  ticks on the tested Apple Silicon system, while some HID events already used
+  nanoseconds; changing tap location requires revalidating timestamp units.
+  Delayed press handling reconstructs the original onset from the timeline;
+  delayed release handling excludes audio captured after the physical release.
 - Active dictation capture is lossless with respect to Moonshine, event, UI,
   context, and worker stalls. Command recognition is explicitly best-effort:
   its backlog is bounded by duration, and pressure invalidates the generation,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,6 +343,7 @@ cargo run -- preview transcription-picker --language zh --model-state installed
 ./scripts/capture-preview.sh /tmp/hex-preview.png settings
 ./scripts/capture-preview.sh /tmp/hex-model-missing.png settings --model-missing
 ./scripts/capture-preview.sh /tmp/hex-command-model-missing.png settings --command-model-missing
+./scripts/capture-preview.sh /tmp/hex-microphone-confirmation.png settings --confirm-release-microphone
 ./scripts/capture-preview.sh /tmp/hex-history-retention.png history --open-history-retention
 ./scripts/capture-preview.sh /tmp/hex-modes.png modes
 ./scripts/capture-preview.sh /tmp/hex-modes-collapsed.png modes --collapse-mode-processing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8677,7 +8677,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voice-control"
-version = "2.1.7"
+version = "2.1.8"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice-control"
-version = "2.1.7"
+version = "2.1.8"
 edition = "2024"
 default-run = "voice-control"
 license = "MIT"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,12 +86,23 @@ cancellation, foreground insertion, and both reserved paste shortcuts.
 
 The first installed timestamped-timeline build regressed physical dictation:
 shortcut input arrived, but long captures discarded and one accepted job reached
-inference with zero milliseconds of audio. The source treated raw CGEvent Mach
-ticks as nanoseconds; on the development Mac's `125/3` timebase, a three-second
-hold appeared to last roughly 72 ms and CoreAudio release trimming removed the
-whole clip. Source timestamps now convert through the Mach timebase. Physically
-verify non-empty captures, exact delayed release boundaries, and immediate HUD
-onset before considering the new owner validated.
+inference with zero milliseconds of audio. At the HID tap, physical timestamps
+arrived as raw Mach ticks; on the development Mac's `125/3` timebase, treating
+them as nanoseconds made a three-second hold appear to last roughly 72 ms.
+The 2.1.7 move to annotated-session taps retained that conversion even though
+timestamps at this boundary are already nanoseconds. This stretched short taps
+by 41.67 times, breaking double-tap lock and admitting accidental short captures.
+A simultaneous passive HID/annotated probe confirmed the different units for
+real modifier events. Annotated-session timestamps now enter the audio timeline
+without scaling; callback-level regressions cover lock, short-tap discard, and
+exact delayed release trimming. Keep physical shortcuts, assistive modifier and
+key chords, non-empty captures, and immediate HUD onset in the release smoke
+checks; changing tap location requires revalidating the clock as well as routing.
+
+After this reliability fix, evaluate an explicit press-once-to-start,
+press-again-to-finish option, especially for key chords and standalone function
+keys. Keep it distinct from hold-to-dictate and double-tap-only activation;
+do not add new shortcut modes to the regression release.
 
 Keep the microphone and dictation model warm by default. Add an explicit
 `Release microphone while idle` option that is effective only when commands are

--- a/docs/releases/2.1.8.md
+++ b/docs/releases/2.1.8.md
@@ -11,6 +11,13 @@
   starting a capture are checked before the new capture is accepted.
 - Changing double-tap settings during a hold no longer abandons the active
   recording, and disabling lock takes effect before a pending second tap ends.
+- Fixes modifier shortcuts becoming unresponsive after a missed key release.
+  Once the keyboard is fully released and quiet, Hex repairs stale key tracking
+  without starting or finishing a recording. Programmatic captures also keep
+  observing key releases without activating shortcuts.
+- Microphone mode now distinguishes "Keep ready (fast)" from "Release when idle."
+  Releasing the microphone requires confirmation explaining the start-up delay,
+  loss of pre-roll, and disabled voice commands. Cancel keeps the existing mode.
 
 The annotated-session taps and passive modifier observation remain unchanged,
 preserving the assistive-input routing introduced in 2.1.7. This release adds no

--- a/docs/releases/2.1.8.md
+++ b/docs/releases/2.1.8.md
@@ -1,0 +1,22 @@
+## Hex 2.1.8
+
+- Fixes the 2.1.7 regression where double-tapping a dictation shortcut started
+  two short captures instead of locking. Annotated-session keyboard timestamps
+  are already nanoseconds and no longer receive a second Mach-time conversion.
+- Short taps are discarded at the intended 300 ms threshold again, and delayed
+  release handling trims microphone audio at the correct boundary.
+- Notifications from a superseded capture no longer reset a later shortcut
+  gesture or report a stale microphone failure, even after the later capture
+  finishes. Microphone failures discovered while
+  starting a capture are checked before the new capture is accepted.
+- Changing double-tap settings during a hold no longer abandons the active
+  recording, and disabling lock takes effect before a pending second tap ends.
+
+The annotated-session taps and passive modifier observation remain unchanged,
+preserving the assistive-input routing introduced in 2.1.7. This release adds no
+new shortcut modes.
+
+This macOS release uses build 20108. App identity, permissions, settings,
+signing key, and the Rust update feed are unchanged. The public transcription
+SDK remains at 0.2.2. No Linux binary is published, and the legacy Swift app
+and feed are unchanged.

--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -255,6 +255,7 @@ pub struct AppWindowPreview {
     pub model_missing: bool,
     pub command_model_missing: bool,
     pub open_history_retention: bool,
+    pub confirm_release_microphone: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -924,7 +925,8 @@ impl AppWindow {
         let preview_choices = crate::transcription_models::choices_for_runtime;
         let (settings, settings_load_error) = if let Some(preview) = &preview {
             let mut settings = AppSettings {
-                commands_enabled: preview.command_model_missing,
+                commands_enabled: preview.command_model_missing
+                    || preview.confirm_release_microphone,
                 ..AppSettings::default()
             };
             settings.voice_action.enabled = preview.voice_action_enabled;
@@ -1169,7 +1171,10 @@ impl AppWindow {
                 crate::recognition::command_model_status()
             },
             release_microphone_toggle: ToggleSpring::new(settings.release_microphone_while_idle),
-            pending_microphone_policy: None,
+            pending_microphone_policy: preview
+                .as_ref()
+                .filter(|preview| preview.confirm_release_microphone)
+                .map(|_| MicrophonePolicyChange::DisableCommandsAndRelease),
             double_tap_toggle: ToggleSpring::new(settings.double_tap_lock),
             double_tap_only_visibility: ToggleSpring::new(
                 settings.double_tap_lock && settings.dictation_hotkey.key.is_some(),
@@ -1353,6 +1358,7 @@ impl AppWindow {
         self.pane = pane;
         self.mode_context_menu = None;
         self.history_retention_open = false;
+        self.pending_microphone_policy = None;
         match pane {
             Pane::HudLab => self.apply_hud_lab(),
             Pane::Meetings => self.reload_meetings(),
@@ -3332,41 +3338,107 @@ impl AppWindow {
                         }))
                 }),
             );
-        let release_microphone_control = if self.pending_microphone_policy
-            == Some(MicrophonePolicyChange::DisableCommandsAndRelease)
-        {
-            compact_button("Disable Commands & Release Microphone")
-                .id("confirm-release-microphone")
-                .on_click(cx.listener(|this, _, _, cx| {
-                    if let Err(error) = this.update_microphone_policy(
-                        MicrophonePolicyChange::DisableCommandsAndRelease,
-                        cx,
-                    ) {
-                        tracing::error!(%error, "could not update microphone policy");
-                    }
-                }))
-                .into_any_element()
-        } else {
+        let microphone_mode = segmented_control()
+            .id("microphone-mode")
+            .relative()
+            .child(
+                div()
+                    .absolute()
+                    .left(px(2.0 + release_microphone_position * 114.0))
+                    .top(px(2.0))
+                    .w(px(114.0))
+                    .h(px(26.0))
+                    .rounded(px(4.0))
+                    .bg(rgb(SURFACE_SELECTED)),
+            )
+            .children(
+                [("Keep ready (fast)", false), ("Release when idle", true)]
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, (label, release))| {
+                        segmented_item(self.settings.release_microphone_while_idle == release)
+                            .id(("microphone-mode", index))
+                            .w(px(114.0))
+                            .px(px(0.0))
+                            .justify_center()
+                            .bg(rgba(0x00000000))
+                            .child(label)
+                            .on_click(cx.listener(move |this, _, _, cx| {
+                                if release && !this.settings.release_microphone_while_idle {
+                                    this.pending_microphone_policy =
+                                        Some(MicrophonePolicyChange::DisableCommandsAndRelease);
+                                    cx.notify();
+                                    return;
+                                }
+                                this.pending_microphone_policy = None;
+                                if this.settings.release_microphone_while_idle != release
+                                    && let Err(error) = this.update_microphone_policy(
+                                        MicrophonePolicyChange::SetReleaseWhileIdle(release),
+                                        cx,
+                                    )
+                                {
+                                    tracing::error!(%error, "could not update microphone policy");
+                                }
+                                cx.notify();
+                            }))
+                    }),
+            );
+        let microphone_confirmation = (self.pending_microphone_policy
+            == Some(MicrophonePolicyChange::DisableCommandsAndRelease))
+        .then(|| {
             div()
-                .id("release-microphone-while-idle")
-                .child(toggle(release_microphone_position))
-                .on_click(cx.listener(|this, _, _, cx| {
-                    let enabled = !this.settings.release_microphone_while_idle;
-                    if enabled && this.settings.commands_enabled {
-                        this.pending_microphone_policy =
-                            Some(MicrophonePolicyChange::DisableCommandsAndRelease);
-                        cx.notify();
-                        return;
-                    }
-                    if let Err(error) = this.update_microphone_policy(
-                        MicrophonePolicyChange::SetReleaseWhileIdle(enabled),
-                        cx,
-                    ) {
-                        tracing::error!(%error, "could not update microphone policy");
-                    }
-                }))
-                .into_any_element()
-        };
+                .px_4()
+                .py_3()
+                .flex()
+                .flex_col()
+                .gap_2()
+                .border_b_1()
+                .border_color(rgb(LINE))
+                .bg(rgb(CANVAS))
+                .child(settings_copy(
+                    "Release the microphone when idle?",
+                    "HEX will open the microphone when you press the shortcut. This adds a start-up delay and removes pre-roll, so the beginning of speech may be missed if you speak right away.",
+                ))
+                .child(
+                    div()
+                        .text_size(px(11.0))
+                        .text_color(rgb(MUTED))
+                        .child(if self.settings.commands_enabled {
+                            "Commands need an open microphone. Confirming will also turn Commands off. You can switch back to Keep ready at any time."
+                        } else {
+                            "Commands need an open microphone and will remain off. You can switch back to Keep ready at any time."
+                        }),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .justify_end()
+                        .gap_2()
+                        .child(
+                            compact_button("Cancel")
+                                .id("cancel-release-microphone")
+                                .on_click(cx.listener(|this, _, _, cx| {
+                                    this.pending_microphone_policy = None;
+                                    cx.notify();
+                                })),
+                        )
+                        .child(
+                            compact_button("Release microphone")
+                                .id("confirm-release-microphone")
+                                .border_1()
+                                .border_color(rgb(LINE))
+                                .bg(rgb(SURFACE_SELECTED))
+                                .on_click(cx.listener(|this, _, _, cx| {
+                                    if let Err(error) = this.update_microphone_policy(
+                                        MicrophonePolicyChange::DisableCommandsAndRelease,
+                                        cx,
+                                    ) {
+                                        tracing::error!(%error, "could not update microphone policy");
+                                    }
+                                })),
+                        ),
+                )
+        });
         div()
             .size_full()
             .flex()
@@ -3458,11 +3530,34 @@ impl AppWindow {
                                         )
                                         .id("recording-audio-setting"),
                                     )
-                                    .child(settings_row(
-                                        "Release microphone while idle",
-                                        "Adds first-capture latency and disables audio pre-roll",
-                                        release_microphone_control,
-                                    ))
+                                    .child(
+                                        div()
+                                            .w_full()
+                                            .min_h(px(72.0))
+                                            .px_4()
+                                            .py_3()
+                                            .flex()
+                                            .items_center()
+                                            .justify_between()
+                                            .gap_4()
+                                            .border_b_1()
+                                            .border_color(rgb(LINE))
+                                            .child(
+                                                div()
+                                                    .flex_1()
+                                                    .min_w_0()
+                                                    .child(settings_copy(
+                                                        "Microphone mode",
+                                                        if self.settings.release_microphone_while_idle {
+                                                            "Opens on the shortcut, with a start-up delay and no pre-roll. Commands are off."
+                                                        } else {
+                                                            "Default: keeps the microphone open for the fastest start. A short pre-roll helps catch the beginning of speech. Audio is not saved by default."
+                                                        },
+                                                    )),
+                                            )
+                                            .child(microphone_mode),
+                                    )
+                                    .children(microphone_confirmation)
                                     .child(
                                         settings_row(
                                             "Double-tap to lock",
@@ -7315,6 +7410,13 @@ impl Render for AppWindow {
                 if event.keystroke.key == "escape" && this.transcription_picker_language.is_some() {
                     cx.stop_propagation();
                     this.dismiss_transcription_picker(cx);
+                    return;
+                }
+                if event.keystroke.key == "escape"
+                    && this.pending_microphone_policy.take().is_some()
+                {
+                    cx.stop_propagation();
+                    cx.notify();
                 }
             }))
             .on_mouse_down(

--- a/src/dictation_audio.rs
+++ b/src/dictation_audio.rs
@@ -263,7 +263,7 @@ impl DictationAudio {
         self.state.recording.load(Ordering::Acquire)
     }
 
-    pub fn capture_generation(&self) -> u64 {
+    fn capture_generation(&self) -> u64 {
         self.state.capture_generation.load(Ordering::Acquire)
     }
 
@@ -364,7 +364,35 @@ impl DictationAudio {
     }
 
     pub fn try_recv_event(&self) -> Option<DictationAudioEvent> {
-        self.events.try_recv().ok()
+        while let Ok(event) = self.events.try_recv() {
+            let generation = match &event {
+                DictationAudioEvent::OpenFailed {
+                    capture_generation, ..
+                }
+                | DictationAudioEvent::ReadyIntentional { capture_generation }
+                | DictationAudioEvent::Interrupted {
+                    capture_generation, ..
+                }
+                | DictationAudioEvent::CaptureDiscontinuity {
+                    capture_generation, ..
+                } => Some(*capture_generation),
+                _ => None,
+            };
+            // Only accepted synchronous starts advance this generation. Finish/Cancel retain
+            // terminal failures. The sole control caller also consumes events, so no newer
+            // capture can start between this check and use.
+            if let Some(generation) = generation
+                && generation != self.capture_generation()
+            {
+                tracing::debug!(
+                    capture_generation = generation,
+                    "ignored stale capture notification"
+                );
+                continue;
+            }
+            return Some(event);
+        }
+        None
     }
 
     fn call<T>(&self, command: impl FnOnce(SyncSender<T>) -> Command) -> Result<T> {
@@ -431,6 +459,11 @@ impl Owner {
                 expected_recognition_generation,
                 reply,
             } => {
+                // Draining can discover a failure belonging to the previous capture or idle
+                // period. Validate and advance the new capture only after that drain.
+                if self.input.is_open() && !self.input.is_recovering() {
+                    self.drain_through(at);
+                }
                 if self.input.is_recovering()
                     || expected_recognition_generation.is_some_and(|generation| {
                         generation != self.recognition_generation
@@ -446,7 +479,6 @@ impl Owner {
                 }
                 self.state.capture_generation.fetch_add(1, Ordering::AcqRel);
                 if self.input.is_open() {
-                    self.drain_through(at);
                     if voice {
                         self.capture.start_voice_at(at)
                     } else if programmatic {
@@ -761,6 +793,365 @@ mod tests {
 
     fn capture_time() -> CaptureInstant {
         CaptureInstant::from_nanos(60_000_000_000)
+    }
+
+    // Drive the real serialized owner without a worker so input/control ordering is exact.
+    fn owner_for_test(open: bool) -> (Owner, DictationAudio, Sender<(Vec<f32>, CaptureInstant)>) {
+        let (mut input, opened) = RecoveringAudioInput::pending_for_test();
+        let (replacement, samples) = crate::audio::AudioInput::channel_for_test();
+        opened.send((0, Ok(replacement))).unwrap();
+        if open {
+            assert!(matches!(
+                input.recv_timeout(Duration::ZERO, true),
+                RecoveringAudioInputEvent::Reopened
+            ));
+        }
+        let state = Arc::new(State {
+            sample_rate: AtomicU64::new(if open { 48_000 } else { 0 }),
+            captured_through: AtomicU64::new(0),
+            device_name: Mutex::new("Test microphone".into()),
+            recording: AtomicBool::new(false),
+            recovering: AtomicBool::new(false),
+            recognition_generation: AtomicU64::new(0),
+            outstanding_recognition_frames: Arc::new(AtomicU64::new(0)),
+            capture_generation: AtomicU64::new(0),
+        });
+        let (commands, command_receiver) = mpsc::channel();
+        let (recognition_sender, recognition) = mpsc::sync_channel(RECOGNITION_QUEUE_CAPACITY);
+        let (events_sender, events) = mpsc::channel();
+        let recording_environment = RecordingEnvironmentController::start();
+        let owner = Owner {
+            input,
+            release_while_idle: false,
+            pending_capture: None,
+            capture: new_capture(if open { 48_000 } else { 16_000 }, &recording_environment),
+            recording_environment,
+            commands: command_receiver,
+            recognition: recognition_sender,
+            events: events_sender,
+            state: state.clone(),
+            dropped_recognition_frames: 0,
+            recognition_generation: 0,
+            recognition_overflowed: false,
+            pending_input: PendingInputEvents::default(),
+            last_captured_through: None,
+        };
+        let input = DictationAudio {
+            commands,
+            recognition,
+            events,
+            state,
+            worker: None,
+        };
+        (owner, input, samples)
+    }
+
+    fn control<T>(owner: &mut Owner, command: impl FnOnce(SyncSender<T>) -> Command) -> T {
+        let (reply, response) = mpsc::sync_channel(1);
+        assert!(owner.handle(command(reply)));
+        response.recv().unwrap()
+    }
+
+    fn start(owner: &mut Owner, at: CaptureInstant) {
+        assert!(control(owner, |reply| Command::Start {
+            at,
+            voice: false,
+            programmatic: false,
+            expected_recognition_generation: None,
+            reply,
+        }));
+    }
+
+    #[test]
+    fn capture_failures_survive_terminal_controls_but_not_a_new_capture() {
+        for interrupted in [false, true] {
+            for recording in [false, true] {
+                for boundary in ["current", "finish", "cancel", "start", "start-finish"] {
+                    let (mut owner, input, _samples) = owner_for_test(true);
+                    let at = capture_time();
+                    owner.handle_input(RecoveringAudioInputEvent::Chunk {
+                        samples: vec![0.25; 480],
+                        captured_through: at,
+                    });
+                    if recording {
+                        start(&mut owner, at);
+                    }
+                    if interrupted {
+                        owner.handle_input(RecoveringAudioInputEvent::Interrupted);
+                    } else {
+                        owner.handle_input(RecoveringAudioInputEvent::Chunk {
+                            samples: vec![0.25; 480],
+                            captured_through: at + Duration::from_millis(110),
+                        });
+                    }
+                    assert!(!input.is_recording());
+                    match boundary {
+                        "finish" => {
+                            control(&mut owner, |reply| Command::Finish { at, reply });
+                        }
+                        "cancel" => control(&mut owner, |reply| Command::Cancel { reply }),
+                        "start" | "start-finish" => {
+                            start(&mut owner, at);
+                            if boundary == "start-finish" {
+                                control(&mut owner, |reply| Command::Finish { at, reply });
+                            }
+                        }
+                        _ => {}
+                    }
+                    let event = input.try_recv_event();
+                    if matches!(boundary, "current" | "finish" | "cancel") {
+                        assert!(matches!(
+                            event,
+                            Some(DictationAudioEvent::Interrupted { was_recording, .. }
+                                | DictationAudioEvent::CaptureDiscontinuity { was_recording, .. })
+                                if was_recording == recording
+                        ));
+                    } else {
+                        assert!(
+                            event.is_none(),
+                            "interrupted={interrupted} recording={recording} {boundary}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn pending_capture_notifications_follow_control_boundaries() {
+        for ready in [false, true] {
+            for boundary in ["current", "finish", "cancel", "start"] {
+                let (mut owner, input, _samples) = owner_for_test(false);
+                let at = capture_time();
+                start(&mut owner, at);
+                control(&mut owner, |reply| Command::BecomeIntentional {
+                    at: at + crate::dictation::MINIMUM_HOLD_DURATION,
+                    reply,
+                });
+                if ready {
+                    let event = owner.input.recv_timeout(Duration::ZERO, false);
+                    owner.handle_input(event);
+                } else {
+                    owner
+                        .handle_input(RecoveringAudioInputEvent::OpenFailed("test failure".into()));
+                }
+                match boundary {
+                    "finish" => {
+                        control(&mut owner, |reply| Command::Finish { at, reply });
+                    }
+                    "cancel" => control(&mut owner, |reply| Command::Cancel { reply }),
+                    "start" => start(&mut owner, CaptureInstant::from_nanos(0)),
+                    _ => {}
+                }
+                if boundary != "start" {
+                    assert!(matches!(
+                        (ready, input.try_recv_event()),
+                        (true, Some(DictationAudioEvent::ReadyIntentional { .. }))
+                            | (false, Some(DictationAudioEvent::OpenFailed { .. }))
+                    ));
+                }
+                // Stream-wide events still pass through after a stale capture event.
+                if ready {
+                    assert!(matches!(
+                        input.try_recv_event(),
+                        Some(DictationAudioEvent::Reopened)
+                    ));
+                }
+                assert!(input.try_recv_event().is_none(), "ready={ready} {boundary}");
+            }
+        }
+    }
+
+    #[test]
+    fn cold_capture_restart_rejects_late_open_results_and_closes_after_finish() {
+        for cancel in [false, true] {
+            let (mut owner, input, _unused_samples) = owner_for_test(false);
+            owner.release_while_idle = true;
+            // Substitute only the asynchronous device opener, not owner events or captures.
+            let (first_input, first_opened) = RecoveringAudioInput::pending_for_test();
+            owner.input = first_input;
+            let at = capture_time();
+            start(&mut owner, at);
+            owner.reconcile_input();
+            let first_generation = input.capture_generation();
+            assert!(owner.input.is_opening());
+            if cancel {
+                control(&mut owner, |reply| Command::Cancel { reply });
+            } else {
+                assert!(matches!(
+                    control(&mut owner, |reply| Command::Finish {
+                        at: at + Duration::from_millis(80),
+                        reply,
+                    }),
+                    Finish::Discard
+                ));
+            }
+            owner.reconcile_input();
+            assert!(!input.is_recording());
+            assert!(!owner.input.is_opening());
+            assert!(!owner.input.is_open());
+            let idle_generation = input.capture_generation();
+            assert_eq!(idle_generation, first_generation);
+
+            let (second_input, second_opened) = RecoveringAudioInput::pending_for_test();
+            owner.input = second_input;
+            let second_press = at + Duration::from_millis(180);
+            start(&mut owner, second_press);
+            owner.reconcile_input();
+            let second_generation = input.capture_generation();
+            assert_ne!(second_generation, idle_generation);
+            assert_ne!(second_generation, first_generation);
+
+            let (late_input, late_samples) = crate::audio::AudioInput::channel_for_test();
+            assert!(first_opened.send((0, Ok(late_input))).is_err());
+            assert!(late_samples.send((vec![0.75; 480], second_press)).is_err());
+            let event = owner.input.recv_timeout(Duration::ZERO, false);
+            assert!(matches!(event, RecoveringAudioInputEvent::Timeout));
+            owner.handle_input(event);
+            assert!(input.try_recv_event().is_none());
+            assert!(input.is_recording());
+
+            // A locked second tap stays pending beyond its physical release. Readiness
+            // occurs later, but the intentional threshold must still use this press.
+            assert!(!control(&mut owner, |reply| Command::BecomeIntentional {
+                at: second_press + crate::dictation::MINIMUM_HOLD_DURATION,
+                reply,
+            }));
+            let (replacement, samples) = crate::audio::AudioInput::channel_for_test();
+            second_opened.send((0, Ok(replacement))).unwrap();
+            let event = owner.input.recv_timeout(Duration::ZERO, false);
+            assert!(matches!(event, RecoveringAudioInputEvent::Reopened));
+            owner.handle_input(event);
+            owner.reconcile_input();
+            assert!(owner.input.is_open());
+            assert!(input.is_recording());
+            assert!(matches!(
+                input.try_recv_event(),
+                Some(DictationAudioEvent::ReadyIntentional { capture_generation })
+                    if capture_generation == second_generation
+            ));
+            assert!(matches!(
+                input.try_recv_event(),
+                Some(DictationAudioEvent::Reopened)
+            ));
+
+            let finished_at = at + Duration::from_millis(700);
+            samples.send((vec![0.25; 4_800], finished_at)).unwrap();
+            let finish = control(&mut owner, |reply| Command::Finish {
+                at: finished_at,
+                reply,
+            });
+            let Finish::Transcribe(clip) = finish else {
+                panic!("second capture must preserve its original press and produce one clip");
+            };
+            assert_eq!(clip.duration_ms(), 100);
+            owner.reconcile_input();
+            assert!(!input.is_recording());
+            assert!(!owner.input.is_open());
+            assert!(!owner.input.is_opening());
+            assert!(samples.send((vec![0.25; 480], finished_at)).is_err());
+            assert!(matches!(
+                control(&mut owner, |reply| Command::Finish {
+                    at: finished_at,
+                    reply
+                }),
+                Finish::Discard
+            ));
+            assert!(input.try_recv_event().is_none());
+        }
+    }
+
+    #[test]
+    fn boundary_drain_preserves_finish_failure_but_does_not_fail_a_new_capture() {
+        for starting in [false, true] {
+            let (mut owner, input, samples) = owner_for_test(true);
+            let at = capture_time();
+            owner.handle_input(RecoveringAudioInputEvent::Chunk {
+                samples: vec![0.25; 480],
+                captured_through: at,
+            });
+            start(&mut owner, at);
+            owner.handle_input(RecoveringAudioInputEvent::Chunk {
+                samples: vec![0.25; 19_200],
+                captured_through: at + Duration::from_millis(400),
+            });
+            let boundary = at + Duration::from_millis(510);
+            samples.send((vec![0.25; 480], boundary)).unwrap();
+            if starting {
+                start(&mut owner, boundary);
+            } else {
+                assert!(matches!(
+                    control(&mut owner, |reply| Command::Finish {
+                        at: boundary,
+                        reply
+                    }),
+                    Finish::Discard
+                ));
+            }
+            assert_eq!(input.is_recording(), starting);
+            if starting {
+                assert!(input.try_recv_event().is_none());
+            } else {
+                assert!(matches!(
+                    input.try_recv_event(),
+                    Some(DictationAudioEvent::CaptureDiscontinuity {
+                        was_recording: true,
+                        ..
+                    })
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn start_revalidates_microphone_and_voice_generation_after_boundary_drain() {
+        for interrupted in [false, true] {
+            let (mut owner, input, samples) = owner_for_test(true);
+            let at = capture_time();
+            owner.handle_input(RecoveringAudioInputEvent::Chunk {
+                samples: vec![0.25; 480],
+                captured_through: at,
+            });
+            let boundary = at + Duration::from_millis(110);
+            if interrupted {
+                drop(samples);
+            } else {
+                samples.send((vec![0.25; 480], boundary)).unwrap();
+            }
+            let generation = input.capture_generation();
+            assert!(!control(&mut owner, |reply| Command::Start {
+                at: boundary,
+                voice: !interrupted,
+                programmatic: false,
+                expected_recognition_generation: (!interrupted)
+                    .then_some(input.recognition_generation()),
+                reply,
+            }));
+            assert_eq!(input.capture_generation(), generation);
+            assert!(!input.is_recording());
+            assert!(input.try_recv_event().is_some());
+        }
+    }
+
+    #[test]
+    fn capture_generation_advances_only_when_a_new_capture_is_accepted() {
+        let (mut owner, input, _samples) = owner_for_test(true);
+        let at = CaptureInstant::from_nanos(0);
+        for _ in 0..2 {
+            let generation = input.capture_generation();
+            control(&mut owner, |reply| Command::Cancel { reply });
+            assert_eq!(input.capture_generation(), generation);
+            let generation = input.capture_generation();
+            control(&mut owner, |reply| Command::Finish { at, reply });
+            assert_eq!(input.capture_generation(), generation);
+        }
+        let generation = input.capture_generation();
+        start(&mut owner, at);
+        assert_ne!(input.capture_generation(), generation);
+        let generation = input.capture_generation();
+        control(&mut owner, |reply| Command::Finish { at, reply });
+        control(&mut owner, |reply| Command::Cancel { reply });
+        assert_eq!(input.capture_generation(), generation);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,9 @@ enum Command {
         /// Open the explicit history retention choices in the History preview.
         #[arg(long)]
         open_history_retention: bool,
+        /// Show the idle microphone release confirmation with Commands enabled.
+        #[arg(long)]
+        confirm_release_microphone: bool,
     },
     /// Listen and transcribe until interrupted.
     Listen {
@@ -462,6 +465,7 @@ fn main() -> Result<()> {
             model_missing,
             command_model_missing,
             open_history_retention,
+            confirm_release_microphone,
         } => {
             if matches!(target, AppPreviewTarget::DictationHud) {
                 return meeting_watcher::run(&SHUTDOWN, false, None, true);
@@ -509,6 +513,7 @@ fn main() -> Result<()> {
                     model_missing,
                     command_model_missing,
                     open_history_retention,
+                    confirm_release_microphone,
                 },
             )
         }
@@ -748,6 +753,28 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn microphone_confirmation_requires_an_explicit_preview_flag() {
+        for (args, expected) in [
+            (vec!["hex", "preview", "settings"], false),
+            (
+                vec!["hex", "preview", "settings", "--confirm-release-microphone"],
+                true,
+            ),
+        ] {
+            let cli = Cli::try_parse_from(args).unwrap();
+            let Some(Command::Preview {
+                confirm_release_microphone,
+                ..
+            }) = cli.command
+            else {
+                panic!("expected preview command");
+            };
+            assert_eq!(confirm_release_microphone, expected);
+        }
+        assert!(Cli::try_parse_from(["hex", "app", "--confirm-release-microphone"]).is_err());
     }
 
     #[test]

--- a/src/recognition.rs
+++ b/src/recognition.rs
@@ -374,6 +374,10 @@ pub fn listen(
                         };
                         match input.start_programmatic(boundary) {
                             Ok(()) => {
+                                hotkey.disarm_pending_gesture();
+                                if let Some(edit) = &mut edit_hotkey {
+                                    edit.disarm_pending_gesture();
+                                }
                                 reset_command_recognizer(&input, &mut recognizer)?;
                                 tracing::info!(
                                     dictation_id = id,
@@ -763,6 +767,12 @@ pub fn listen(
             let _acknowledge = input_monitor.acknowledge_after(observed);
             let input_event = observed.event;
             let capture_at = observed.capture_at;
+            if programmatic.is_some() {
+                hotkey.track_key_state(input_event, capture_at);
+                if let Some(edit) = &mut edit_hotkey {
+                    edit.track_key_state(input_event, capture_at);
+                }
+            }
             if programmatic.is_some() && input_event.is_escape_down() {
                 let cancelled = programmatic
                     .take()
@@ -927,6 +937,16 @@ pub fn listen(
                         emit_state(&mut events, false, mode, &input.device_name())?;
                     }
                 }
+            }
+        }
+        if programmatic.is_none()
+            && voice_protocol.is_none()
+            && !hotkey_capture_suspended
+            && input_monitor.pending_events().oldest().is_none()
+        {
+            hotkey.recover_stale_keys();
+            if let Some(edit) = &mut edit_hotkey {
+                edit.recover_stale_keys();
             }
         }
         if hotkey.is_recording()

--- a/src/recognition.rs
+++ b/src/recognition.rs
@@ -1053,18 +1053,12 @@ pub fn listen(
 
         while let Some(audio_event) = input.try_recv_event() {
             match audio_event {
-                DictationAudioEvent::ReadyIntentional { capture_generation } => {
-                    if capture_generation == input.capture_generation() && input.is_recording() {
+                DictationAudioEvent::ReadyIntentional { .. } => {
+                    if input.is_recording() {
                         feedback::play(Tone::DictationStart);
                     }
                 }
-                DictationAudioEvent::OpenFailed {
-                    capture_generation,
-                    error,
-                } => {
-                    if capture_generation != input.capture_generation() {
-                        continue;
-                    }
+                DictationAudioEvent::OpenFailed { error, .. } => {
                     programmatic = None;
                     hotkey.suspend();
                     edit_hotkey.as_mut().and_then(DictationHotkey::suspend);
@@ -1096,17 +1090,6 @@ pub fn listen(
                     input.discard_recognition_backlog();
                     reset_recognizer(&mut recognizer)?;
                     recognition_origin = None;
-                }
-                DictationAudioEvent::CaptureDiscontinuity {
-                    was_recording: _,
-                    capture_generation,
-                    gap_ms,
-                } if input.is_recording() && input.capture_generation() != capture_generation => {
-                    tracing::debug!(
-                        capture_generation,
-                        gap_ms,
-                        "ignored stale audio discontinuity"
-                    );
                 }
                 DictationAudioEvent::CaptureDiscontinuity {
                     was_recording,
@@ -1149,12 +1132,6 @@ pub fn listen(
                     if !input.is_recording() {
                         emit_state(&mut events, false, mode, &input.device_name())?;
                     }
-                }
-                DictationAudioEvent::Interrupted {
-                    was_recording: _,
-                    capture_generation,
-                } if input.is_recording() && input.capture_generation() != capture_generation => {
-                    tracing::debug!(capture_generation, "ignored stale microphone interruption");
                 }
                 DictationAudioEvent::Interrupted { was_recording, .. } => {
                     if was_recording {

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -461,8 +461,10 @@ unsafe extern "C" fn event_callback(
         }
         _ => return event,
     };
+    // Both taps are annotated-session taps: their timestamps are nanoseconds.
+    // Physical HID events used raw Mach ticks on the tested Apple Silicon system.
     // SAFETY: CoreGraphics supplied a valid event to this callback.
-    let capture_at = CaptureInstant::from_mach_ticks(unsafe { CGEventGetTimestamp(event) });
+    let capture_at = CaptureInstant::from_nanos(unsafe { CGEventGetTimestamp(event) });
     if crate::app_settings::hotkey_capture_active() {
         context.activity.observe(input, false);
         context
@@ -736,20 +738,26 @@ impl DictationHotkey {
         self.double_tap_enabled = enabled;
         if !enabled {
             self.last_release_at = None;
+            if let State::Recording {
+                previous_release, ..
+            } = &mut self.state
+            {
+                *previous_release = None;
+            }
         }
     }
 
     pub fn set_double_tap_only(&mut self, enabled: bool) {
         self.double_tap_only =
             enabled && self.binding.key_code.is_some() && self.double_tap_enabled;
-        if (self.double_tap_only && matches!(self.state, State::Recording { .. }))
-            || (!self.double_tap_only
-                && matches!(
-                    self.state,
-                    State::FirstTapPressed
-                        | State::AwaitingSecondTap { .. }
-                        | State::SecondTapPressed { .. }
-                ))
+        // Active captures still need their release or Escape to reach the audio owner.
+        if !self.double_tap_only
+            && matches!(
+                self.state,
+                State::FirstTapPressed
+                    | State::AwaitingSecondTap { .. }
+                    | State::SecondTapPressed { .. }
+            )
         {
             self.state = State::Idle;
         }
@@ -1009,6 +1017,241 @@ fn trigger_is_physically_down(binding: RuntimeHotkey, exact_modifiers: bool) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    unsafe extern "C" {
+        fn CGEventCreate(source: *mut c_void) -> EventRef;
+        fn CGEventSetTimestamp(event: EventRef, timestamp: u64);
+        fn CGEventSetType(event: EventRef, event_type: u32);
+        fn CGEventSetFlags(event: EventRef, flags: u64);
+        fn CGEventSetIntegerValueField(event: EventRef, field: u32, value: i64);
+    }
+
+    // Drive the real callback without installing a tap or posting global input.
+    fn callback_input(timestamps_and_events: &[(u64, InputEvent)]) -> Vec<ObservedInputEvent> {
+        let (sender, receiver) = mpsc::channel();
+        let mut context = EventTapContext {
+            sender,
+            activity: InputActivity::default(),
+            escape_cancels: Arc::new(AtomicBool::new(false)),
+            key_tap: AtomicPtr::new(ptr::null_mut()),
+            observation_tap: AtomicPtr::new(ptr::null_mut()),
+            shortcut_suppression: Mutex::new(ShortcutSuppression::default()),
+            pending: PendingInputEvents::default(),
+            next_sequence: AtomicU64::new(0),
+        };
+        for &(timestamp, input) in timestamps_and_events {
+            // SAFETY: This locally owned event and context live through the callback.
+            unsafe {
+                let event = CGEventCreate(ptr::null_mut());
+                assert!(!event.is_null());
+                CGEventSetTimestamp(event, timestamp);
+                let event_type = match input {
+                    InputEvent::Flags(flags) => {
+                        CGEventSetType(event, EVENT_FLAGS_CHANGED);
+                        CGEventSetFlags(event, flags);
+                        EVENT_FLAGS_CHANGED
+                    }
+                    InputEvent::Key { code, down, flags } => {
+                        CGEventSetType(event, if down { EVENT_KEY_DOWN } else { EVENT_KEY_UP });
+                        CGEventSetFlags(event, flags);
+                        CGEventSetIntegerValueField(event, KEYBOARD_EVENT_KEYCODE, i64::from(code));
+                        assert_eq!(
+                            CGEventGetIntegerValueField(event, KEYBOARD_EVENT_KEYCODE),
+                            i64::from(code)
+                        );
+                        if down { EVENT_KEY_DOWN } else { EVENT_KEY_UP }
+                    }
+                    _ => panic!("expected a keyboard event"),
+                };
+                let returned = event_callback(
+                    ptr::null_mut(),
+                    event_type,
+                    event,
+                    (&mut context as *mut EventTapContext).cast(),
+                );
+                CFRelease(event.cast_const());
+                if matches!(input, InputEvent::Flags(_)) {
+                    assert_eq!(returned, event, "modifier observation must remain passive");
+                }
+            }
+        }
+        receiver.try_iter().collect()
+    }
+
+    #[test]
+    fn callback_timestamps_preserve_nanoseconds_and_short_tap_discard() {
+        let start = 60_000_000_000;
+        let edges = callback_input(&[
+            (start, InputEvent::Flags(OPTION_KEY_MASK)),
+            (start + 80_000_000, InputEvent::Flags(0)),
+        ]);
+        assert_eq!(edges.len(), 2);
+        let mut capture = crate::dictation::DictationCapture::new(16_000);
+        capture.start_at(edges[0].capture_at);
+        assert!(matches!(
+            capture.finish(edges[1].capture_at),
+            crate::dictation::Finish::Discard
+        ));
+        assert_eq!(edges[0].capture_at.as_nanos(), start);
+        assert_eq!(edges[1].capture_at.as_nanos(), start + 80_000_000);
+    }
+
+    #[test]
+    fn callback_release_trims_delayed_audio_at_the_physical_boundary() {
+        let start = 60_000_000_000;
+        let edges = callback_input(&[
+            (start, InputEvent::Flags(OPTION_KEY_MASK)),
+            (start + 1_000_000_000, InputEvent::Flags(0)),
+        ]);
+        let mut capture = crate::dictation::DictationCapture::new(16_000);
+        // Handle both edges late: the timeline already includes post-release audio.
+        capture.ingest(&vec![0.25; 16_000], CaptureInstant::from_nanos(start));
+        capture.ingest(
+            &vec![0.5; 16_000],
+            CaptureInstant::from_nanos(start + 1_000_000_000),
+        );
+        capture.ingest(
+            &vec![0.75; 8_000],
+            CaptureInstant::from_nanos(start + 1_500_000_000),
+        );
+        capture.start_at(edges[0].capture_at);
+        let crate::dictation::Finish::Transcribe(clip) = capture.finish(edges[1].capture_at) else {
+            panic!("one second hold must transcribe");
+        };
+        assert_eq!(clip.duration_ms(), 1_450);
+        let samples = clip.into_transcription_samples();
+        assert_eq!(&samples[..7_200], &[0.25; 7_200]);
+        assert_eq!(&samples[7_200..], &[0.5; 16_000]);
+    }
+
+    #[test]
+    fn callback_double_tap_locks_for_modifier_and_key_bindings() {
+        let command =
+            crate::app_settings::COMMAND_KEY_MASK | crate::app_settings::RIGHT_COMMAND_MASK;
+        let right_command = RuntimeHotkey {
+            modifiers: crate::app_settings::HotkeyModifiers {
+                command: Some(crate::app_settings::ModifierSide::Right),
+                ..Default::default()
+            },
+            key_code: None,
+        };
+        let key_chord = RuntimeHotkey {
+            key_code: Some(49),
+            ..right_command
+        };
+        for (binding, flags) in [
+            (option_binding(), OPTION_KEY_MASK),
+            (right_command, command),
+            (function_binding(), FUNCTION),
+            (key_chord, command),
+        ] {
+            let start = 60_000_000_000;
+            let mut hotkey =
+                DictationHotkey::with_binding(false, capture_time(), 42, true, binding);
+            let press = binding
+                .key_code
+                .map_or(InputEvent::Flags(flags), |code| InputEvent::Key {
+                    code,
+                    down: true,
+                    flags,
+                });
+            let release = binding
+                .key_code
+                .map_or(InputEvent::Flags(0), |code| InputEvent::Key {
+                    code,
+                    down: false,
+                    flags,
+                });
+            let edges = callback_input(&[
+                (start, press),
+                (start + 80_000_000, release),
+                (start + 180_000_000, press),
+                (start + 260_000_000, release),
+                (start + 1_000_000_000, press),
+                (start + 1_080_000_000, release),
+            ]);
+            let mut capture = crate::dictation::DictationCapture::new(16_000);
+            capture.ingest(&vec![0.25; 16_000], CaptureInstant::from_nanos(start));
+            capture.ingest(
+                &vec![0.5; 16_000],
+                CaptureInstant::from_nanos(start + 1_000_000_000),
+            );
+            capture.ingest(
+                &vec![0.75; 8_000],
+                CaptureInstant::from_nanos(start + 1_500_000_000),
+            );
+            let mut discarded = 0;
+            let mut clips = Vec::new();
+            let actions: Vec<_> = edges
+                .into_iter()
+                .map(|edge| {
+                    let action = hotkey.process(edge.event, edge.capture_at);
+                    match action {
+                        Some(HotkeyAction::Start) => capture.start_at(edge.capture_at),
+                        Some(HotkeyAction::Finish) => match capture.finish(edge.capture_at) {
+                            crate::dictation::Finish::Discard => discarded += 1,
+                            crate::dictation::Finish::Transcribe(clip) => clips.push(clip),
+                        },
+                        None => {}
+                        _ => panic!("unexpected hotkey action"),
+                    }
+                    assert_eq!(hotkey.is_recording(), capture.is_recording());
+                    action
+                })
+                .collect();
+            assert_eq!(
+                actions,
+                vec![
+                    Some(HotkeyAction::Start),
+                    Some(HotkeyAction::Finish),
+                    Some(HotkeyAction::Start),
+                    None,
+                    Some(HotkeyAction::Finish),
+                    None,
+                ]
+            );
+            assert!(!hotkey.is_recording());
+            assert_eq!(discarded, 1);
+            assert_eq!(clips.len(), 1);
+            let clip = clips.pop().unwrap();
+            assert_eq!(clip.duration_ms(), 1_270);
+            let samples = clip.into_transcription_samples();
+            assert_eq!(&samples[..4_320], &[0.25; 4_320]);
+            assert_eq!(&samples[4_320..], &[0.5; 16_000]);
+        }
+    }
+
+    #[test]
+    fn callback_hold_and_double_tap_boundaries_are_milliseconds() {
+        for duration_ms in [299, 300, 301] {
+            let start = 60_000_000_000;
+            let press = InputEvent::Flags(OPTION_KEY_MASK);
+            let release = InputEvent::Flags(0);
+            let edges =
+                callback_input(&[(start, press), (start + duration_ms * 1_000_000, release)]);
+            let mut capture = crate::dictation::DictationCapture::new(16_000);
+            capture.start_at(edges[0].capture_at);
+            assert_eq!(
+                matches!(
+                    capture.finish(edges[1].capture_at),
+                    crate::dictation::Finish::Discard
+                ),
+                duration_ms < 300
+            );
+            let edges = callback_input(&[
+                (start, press),
+                (start + 80_000_000, release),
+                (start + 180_000_000, press),
+                (start + (80 + duration_ms) * 1_000_000, release),
+            ]);
+            let mut hotkey = test_hotkey(false, capture_time());
+            for edge in edges {
+                hotkey.process(edge.event, edge.capture_at);
+            }
+            assert_eq!(hotkey.is_recording(), duration_ms < 300);
+        }
+    }
 
     const NO_FLAGS: u64 = 0;
     const SHIFT: u64 = 1 << 17;
@@ -1710,6 +1953,111 @@ mod tests {
             Some(HotkeyAction::Finish)
         );
         assert!(!hotkey.is_recording());
+    }
+
+    #[test]
+    fn live_double_tap_only_change_preserves_capture_until_release_or_escape() {
+        use crate::dictation::{DictationCapture, Finish};
+
+        let now = capture_time();
+        let binding = RuntimeHotkey {
+            modifiers: crate::app_settings::modifiers_from_flags(SHIFT_KEY_MASK),
+            key_code: Some(49),
+        };
+        for cancel in [false, true] {
+            let mut hotkey = DictationHotkey::with_binding(false, now, 42, true, binding);
+            let mut capture = DictationCapture::new(16_000);
+            let key = |code, down| InputEvent::Key {
+                code,
+                down,
+                flags: SHIFT_KEY_MASK,
+            };
+            assert_eq!(
+                hotkey.process(key(49, true), now),
+                Some(HotkeyAction::Start)
+            );
+            capture.start_at(now);
+            capture.ingest(&[0.5; 8_000], now + Duration::from_millis(500));
+
+            hotkey.set_double_tap_only(true);
+            hotkey.set_double_tap_only(true);
+            assert!(hotkey.is_recording());
+            assert!(capture.is_recording());
+
+            let ended_at = now + Duration::from_millis(600);
+            capture.ingest(&[0.5; 1_600], ended_at);
+            let event = if cancel {
+                key(ESCAPE_KEY_CODE, true)
+            } else {
+                key(49, false)
+            };
+            let action = hotkey.process(event, ended_at);
+            if cancel {
+                assert_eq!(action, Some(HotkeyAction::Cancel));
+                capture.cancel();
+                hotkey.process(key(ESCAPE_KEY_CODE, false), ended_at);
+                hotkey.process(key(49, false), ended_at);
+            } else {
+                assert_eq!(action, Some(HotkeyAction::Finish));
+                let Finish::Transcribe(clip) = capture.finish(ended_at) else {
+                    panic!("the active hold must finish after changing double-tap-only");
+                };
+                assert_eq!(clip.duration_ms(), 600);
+            }
+            assert!(!hotkey.is_recording());
+            assert!(!capture.is_recording());
+
+            hotkey.process(InputEvent::Flags(0), ended_at);
+            assert_eq!(
+                hotkey.process(key(49, true), now + Duration::from_secs(1)),
+                None,
+                "the next gesture must use double-tap-only"
+            );
+            assert!(!hotkey.is_recording());
+        }
+    }
+
+    #[test]
+    fn live_double_tap_disable_prevents_the_second_release_from_locking() {
+        use crate::dictation::{DictationCapture, Finish};
+
+        let now = capture_time();
+        let mut hotkey = test_hotkey(false, now);
+        let mut capture = DictationCapture::new(16_000);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), now),
+            Some(HotkeyAction::Start)
+        );
+        capture.start_at(now);
+        let first_release = now + Duration::from_millis(80);
+        capture.ingest(&[0.5; 1_280], first_release);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(0), first_release),
+            Some(HotkeyAction::Finish)
+        );
+        assert!(matches!(capture.finish(first_release), Finish::Discard));
+
+        let second_press = now + Duration::from_millis(180);
+        capture.ingest(&[0.5; 1_600], second_press);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), second_press),
+            Some(HotkeyAction::Start)
+        );
+        capture.start_at(second_press);
+        hotkey.set_double_tap_enabled(false);
+        hotkey.set_double_tap_only(false);
+        assert!(hotkey.is_recording());
+        assert!(capture.is_recording());
+
+        let second_release = now + Duration::from_millis(260);
+        capture.ingest(&[0.5; 1_280], second_release);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(0), second_release),
+            Some(HotkeyAction::Finish)
+        );
+        assert!(matches!(capture.finish(second_release), Finish::Discard));
+        assert!(!hotkey.is_recording());
+        assert!(!capture.is_recording());
     }
 
     #[test]

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -41,6 +41,8 @@ const SHIFT_KEY_MASK: u64 = 1 << 17;
 #[cfg(test)]
 const CONTROL_KEY_MASK: u64 = 1 << 18;
 const HID_SYSTEM_STATE: u32 = 1;
+const COMBINED_SESSION_STATE: u32 = 0;
+const STALE_KEY_NEUTRAL_DURATION: Duration = Duration::from_millis(100);
 
 type EventRef = *mut c_void;
 type EventTapCallback = unsafe extern "C" fn(
@@ -666,6 +668,9 @@ pub struct DictationHotkey {
     binding: RuntimeHotkey,
     paste_actions_enabled: bool,
     ignore_before: Option<CaptureInstant>,
+    stale_keys_neutral_since: Option<CaptureInstant>,
+    recovery_ignore_through: Option<CaptureInstant>,
+    recovery_updated_keys: HashSet<u16>,
 }
 
 impl DictationHotkey {
@@ -723,6 +728,9 @@ impl DictationHotkey {
             binding,
             paste_actions_enabled: true,
             ignore_before: None,
+            stale_keys_neutral_since: None,
+            recovery_ignore_through: None,
+            recovery_updated_keys: HashSet::new(),
         }
     }
 
@@ -775,7 +783,23 @@ impl DictationHotkey {
         self.state = State::Idle;
         self.pressed_keys.clear();
         self.last_release_at = None;
+        self.stale_keys_neutral_since = None;
         was_recording.then_some(HotkeyAction::Cancel)
+    }
+
+    pub fn disarm_pending_gesture(&mut self) {
+        if !self.is_recording() {
+            if matches!(
+                self.state,
+                State::FirstTapPressed
+                    | State::AwaitingSecondTap { .. }
+                    | State::SecondTapPressed { .. }
+            ) {
+                self.state = State::Idle;
+            }
+            self.last_release_at = None;
+            self.stale_keys_neutral_since = None;
+        }
     }
 
     pub fn wait_for_release(&mut self) {
@@ -793,6 +817,56 @@ impl DictationHotkey {
     pub fn suppress_until_release(&mut self) {
         self.state = State::Dirty;
         self.last_release_at = None;
+        self.stale_keys_neutral_since = None;
+    }
+
+    // Call only after draining input. Polling repairs bookkeeping, never capture boundaries.
+    pub fn recover_stale_keys(&mut self) {
+        self.recover_stale_keys_with(
+            CaptureInstant::now,
+            // Match the annotated-session tap, including assistive keyboard input.
+            || unsafe { CGEventSourceFlagsState(COMBINED_SESSION_STATE) },
+            |code| unsafe { CGEventSourceKeyState(COMBINED_SESSION_STATE, code) },
+        );
+    }
+
+    fn recover_stale_keys_with(
+        &mut self,
+        now: impl FnOnce() -> CaptureInstant,
+        mut flags: impl FnMut() -> u64,
+        mut key_down: impl FnMut(u16) -> bool,
+    ) {
+        if !matches!(self.state, State::Idle | State::Dirty) || self.pressed_keys.is_empty() {
+            self.stale_keys_neutral_since = None;
+            return;
+        }
+        // Only scan the full keyboard when a tracked key disagrees with native state.
+        if flags() & HOTKEY_MODIFIERS_MASK != 0
+            || !self.pressed_keys.iter().any(|&code| !key_down(code))
+            || (0..128).any(&mut key_down)
+            || flags() & HOTKEY_MODIFIERS_MASK != 0
+        {
+            self.stale_keys_neutral_since = None;
+            return;
+        }
+        let sampled_through = now();
+        let Some(neutral_since) = self.stale_keys_neutral_since else {
+            self.stale_keys_neutral_since = Some(sampled_through);
+            return;
+        };
+        if sampled_through.duration_since(neutral_since) < STALE_KEY_NEUTRAL_DURATION {
+            return;
+        }
+        tracing::warn!(
+            key_count = self.pressed_keys.len(),
+            "resynchronized stale input tracking after neutral keyboard"
+        );
+        self.pressed_keys.clear();
+        self.last_release_at = None;
+        self.state = State::Idle;
+        self.stale_keys_neutral_since = None;
+        self.recovery_ignore_through = Some(sampled_through);
+        self.recovery_updated_keys.clear();
     }
 
     fn wait_for_release_with_state(&mut self, now: CaptureInstant, flags: u64, key_down: bool) {
@@ -806,7 +880,35 @@ impl DictationHotkey {
         }
     }
 
+    // Suspended shortcut matching must still observe releases of previously held keys.
+    pub fn track_key_state(&mut self, event: InputEvent, at: CaptureInstant) -> Option<bool> {
+        self.stale_keys_neutral_since = None;
+        if let InputEvent::Key { code, .. } = event
+            && let Some(fence) = self.recovery_ignore_through
+        {
+            // A delayed pre-recovery release must not erase a newer press of that key.
+            if at <= fence && self.recovery_updated_keys.contains(&code) {
+                return None;
+            }
+            if at > fence {
+                self.recovery_updated_keys.insert(code);
+            }
+        }
+        Some(match event {
+            InputEvent::Key { code, down, .. } => {
+                if down {
+                    self.pressed_keys.insert(code)
+                } else {
+                    self.pressed_keys.remove(&code);
+                    false
+                }
+            }
+            InputEvent::Flags(_) | InputEvent::MouseDown | InputEvent::TapDisabled => false,
+        })
+    }
+
     pub fn process(&mut self, event: InputEvent, now: CaptureInstant) -> Option<HotkeyAction> {
+        self.stale_keys_neutral_since = None;
         if matches!(event, InputEvent::TapDisabled) {
             let was_recording = self.is_recording();
             self.state = State::Dirty;
@@ -820,17 +922,19 @@ impl DictationHotkey {
         {
             return None;
         }
-        let fresh_key_down = match event {
-            InputEvent::Key { code, down, .. } => {
-                if down {
-                    self.pressed_keys.insert(code)
-                } else {
-                    self.pressed_keys.remove(&code);
-                    false
-                }
+        let fresh_key_down = self.track_key_state(event, now)?;
+
+        if self
+            .recovery_ignore_through
+            .is_some_and(|sampled_through| now <= sampled_through)
+        {
+            // A key can go down during the non-atomic scan. Retain its edge but
+            // require a later neutral event before accepting another gesture.
+            if matches!(self.state, State::Idle | State::Dirty) {
+                self.state = State::Dirty;
             }
-            InputEvent::Flags(_) | InputEvent::MouseDown | InputEvent::TapDisabled => false,
-        };
+            return None;
+        }
 
         if self.paste_actions_enabled
             && fresh_key_down
@@ -1098,6 +1202,92 @@ mod tests {
     }
 
     #[test]
+    fn suspended_key_tracking_preserves_held_keys_and_observes_releases() {
+        let now = capture_time();
+        let ordinary = |down| InputEvent::Key {
+            code: 0,
+            down,
+            flags: 0,
+        };
+        for paste_enabled in [false, true] {
+            for pressed_before in [false, true] {
+                for released_during in [false, true] {
+                    let mut hotkey = test_hotkey(false, now);
+                    hotkey.paste_actions_enabled = paste_enabled;
+                    if pressed_before {
+                        assert_eq!(hotkey.process(ordinary(true), now), None);
+                    } else {
+                        assert_eq!(hotkey.track_key_state(ordinary(true), now), Some(true));
+                    }
+                    hotkey.track_key_state(InputEvent::Flags(OPTION_KEY_MASK), now);
+                    hotkey.track_key_state(InputEvent::Flags(0), now);
+                    if released_during {
+                        hotkey.track_key_state(ordinary(false), now);
+                    }
+                    assert!(!hotkey.is_recording());
+                    assert_eq!(
+                        hotkey.process(
+                            InputEvent::Flags(OPTION_KEY_MASK),
+                            now + Duration::from_secs(1)
+                        ),
+                        released_during.then_some(HotkeyAction::Start)
+                    );
+                    if !released_during {
+                        hotkey.process(InputEvent::Flags(0), now + Duration::from_secs(1));
+                        hotkey.process(ordinary(false), now + Duration::from_secs(1));
+                        assert_eq!(
+                            hotkey.process(
+                                InputEvent::Flags(OPTION_KEY_MASK),
+                                now + Duration::from_secs(2)
+                            ),
+                            Some(HotkeyAction::Start)
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn suspended_escape_and_double_taps_never_activate_a_gesture() {
+        let now = capture_time();
+        let mut hotkey = test_hotkey(false, now);
+        for event in [
+            InputEvent::Flags(OPTION_KEY_MASK),
+            InputEvent::Flags(0),
+            InputEvent::Flags(OPTION_KEY_MASK),
+            InputEvent::Flags(0),
+            InputEvent::Key {
+                code: ESCAPE_KEY_CODE,
+                down: true,
+                flags: 0,
+            },
+        ] {
+            hotkey.track_key_state(event, now);
+            assert!(!hotkey.is_recording());
+        }
+        assert_eq!(
+            hotkey.process(
+                InputEvent::Key {
+                    code: ESCAPE_KEY_CODE,
+                    down: false,
+                    flags: 0
+                },
+                now
+            ),
+            None
+        );
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), now),
+            Some(HotkeyAction::Start)
+        );
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(0), now + Duration::from_millis(80)),
+            Some(HotkeyAction::Finish)
+        );
+    }
+
+    #[test]
     fn callback_release_trims_delayed_audio_at_the_physical_boundary() {
         let start = 60_000_000_000;
         let edges = callback_input(&[
@@ -1359,6 +1549,394 @@ mod tests {
             true,
             option_binding(),
         )
+    }
+
+    #[test]
+    fn stale_key_recovery_restores_a_fresh_hold_without_changing_its_boundaries() {
+        let now = capture_time();
+        let mut hotkey = test_hotkey(false, now);
+        let down = InputEvent::Key {
+            code: 0,
+            down: true,
+            flags: 0,
+        };
+        assert_eq!(hotkey.process(down, now), None);
+        // The ordinary key's release never reached the reducer.
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), now),
+            None
+        );
+        let first = now + Duration::from_secs(1);
+        hotkey.recover_stale_keys_with(|| first, || 0, |_| false);
+        hotkey.recover_stale_keys_with(|| first + Duration::from_millis(99), || 0, |_| false);
+        assert!(hotkey.pressed_keys.contains(&0));
+        let repaired = first + STALE_KEY_NEUTRAL_DURATION;
+        hotkey.recover_stale_keys_with(|| repaired, || 0, |_| false);
+        assert!(hotkey.pressed_keys.is_empty());
+        let press = repaired + Duration::from_millis(1);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), press),
+            Some(HotkeyAction::Start)
+        );
+        let mut capture = crate::dictation::DictationCapture::new(16_000);
+        capture.start_at(press);
+        capture.ingest(&vec![0.5; 16_000], press + Duration::from_secs(1));
+        let release = press + Duration::from_millis(500);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(0), release),
+            Some(HotkeyAction::Finish)
+        );
+        let crate::dictation::Finish::Transcribe(clip) = capture.finish(release) else {
+            panic!("the fresh hold must transcribe");
+        };
+        assert_eq!(clip.duration_ms(), 500);
+    }
+
+    #[test]
+    fn stale_key_recovery_does_not_reinterpret_delayed_chords() {
+        let now = capture_time();
+        let mut hotkey = test_hotkey(false, now);
+        let key = |down| InputEvent::Key {
+            code: 0,
+            down,
+            flags: OPTION_KEY_MASK,
+        };
+        hotkey.process(key(true), now);
+        let first = now + Duration::from_secs(1);
+        let repaired = first + STALE_KEY_NEUTRAL_DURATION;
+        hotkey.recover_stale_keys_with(|| first, || 0, |_| false);
+        hotkey.recover_stale_keys_with(|| repaired, || 0, |_| false);
+        for (offset, event) in [
+            (10, key(true)),
+            (20, InputEvent::Flags(OPTION_KEY_MASK)),
+            (30, key(false)),
+            (40, InputEvent::Flags(0)),
+        ] {
+            assert_eq!(
+                hotkey.process(event, now + Duration::from_millis(offset)),
+                None
+            );
+        }
+        assert!(!hotkey.is_recording());
+        assert!(hotkey.pressed_keys.is_empty());
+        assert_eq!(
+            hotkey.process(
+                InputEvent::Flags(OPTION_KEY_MASK),
+                repaired + Duration::from_millis(1)
+            ),
+            None
+        );
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(0), repaired + Duration::from_millis(2)),
+            None
+        );
+        assert_eq!(
+            hotkey.process(
+                InputEvent::Flags(OPTION_KEY_MASK),
+                repaired + Duration::from_millis(3)
+            ),
+            Some(HotkeyAction::Start)
+        );
+    }
+
+    #[test]
+    fn stale_key_recovery_retains_edges_inside_the_sample_window() {
+        let now = capture_time();
+        let mut hotkey = test_hotkey(false, now);
+        hotkey.process(
+            InputEvent::Key {
+                code: 0,
+                down: true,
+                flags: 0,
+            },
+            now,
+        );
+        let repaired = now + STALE_KEY_NEUTRAL_DURATION;
+        hotkey.recover_stale_keys_with(|| now, || 0, |_| false);
+        hotkey.recover_stale_keys_with(|| repaired, || 0, |_| false);
+        // This new key went down after its native query but before sampling ended.
+        let key = |down| InputEvent::Key {
+            code: 1,
+            down,
+            flags: 0,
+        };
+        assert_eq!(hotkey.process(key(true), repaired), None);
+        assert!(hotkey.pressed_keys.contains(&1));
+        let later = repaired + Duration::from_millis(1);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), later),
+            None
+        );
+        assert_eq!(hotkey.process(InputEvent::Flags(0), later), None);
+        assert!(matches!(hotkey.state, State::Dirty));
+        assert_eq!(hotkey.process(key(false), later), None);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), later),
+            Some(HotkeyAction::Start)
+        );
+    }
+
+    #[test]
+    fn stale_key_recovery_old_release_cannot_erase_a_fresh_press() {
+        for binding in [
+            option_binding(),
+            RuntimeHotkey {
+                modifiers: Default::default(),
+                key_code: Some(97),
+            },
+        ] {
+            let now = capture_time();
+            let mut hotkey = DictationHotkey::with_binding(false, now, 42, true, binding);
+            let key = |down| InputEvent::Key {
+                code: 97,
+                down,
+                flags: 0,
+            };
+            hotkey.process(
+                InputEvent::Key {
+                    code: 0,
+                    down: true,
+                    flags: 0,
+                },
+                now,
+            );
+            let fence = now + STALE_KEY_NEUTRAL_DURATION;
+            hotkey.recover_stale_keys_with(|| now, || 0, |_| false);
+            hotkey.recover_stale_keys_with(|| fence, || 0, |_| false);
+            let fresh = fence + Duration::from_millis(1);
+            hotkey.process(key(true), fresh);
+            assert_eq!(hotkey.process(key(false), now), None);
+            assert!(hotkey.pressed_keys.contains(&97));
+            assert_eq!(hotkey.process(InputEvent::Flags(0), fresh), None);
+            if binding.key_code.is_none() {
+                assert_eq!(
+                    hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), fresh),
+                    None
+                );
+            } else {
+                assert!(hotkey.is_recording());
+                assert_eq!(
+                    hotkey.process(key(false), fresh + Duration::from_secs(1)),
+                    Some(HotkeyAction::Finish)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn stale_key_recovery_protects_programmatic_key_transitions() {
+        for down in [false, true] {
+            let now = capture_time();
+            let key = |down| InputEvent::Key {
+                code: 0,
+                down,
+                flags: 0,
+            };
+            let mut hotkey = test_hotkey(false, now);
+            hotkey.process(key(true), now);
+            let fence = now + STALE_KEY_NEUTRAL_DURATION;
+            hotkey.recover_stale_keys_with(|| now, || 0, |_| false);
+            hotkey.recover_stale_keys_with(|| fence, || 0, |_| false);
+            hotkey.track_key_state(key(down), fence + Duration::from_millis(1));
+            assert_eq!(hotkey.track_key_state(key(!down), now), None);
+            assert_eq!(hotkey.pressed_keys.contains(&0), down);
+        }
+    }
+
+    #[test]
+    fn programmatic_ownership_disarms_pending_double_taps_without_losing_held_keys() {
+        let now = capture_time();
+        let binding = RuntimeHotkey {
+            modifiers: Default::default(),
+            key_code: Some(97),
+        };
+        let mut hotkey = DictationHotkey::with_binding(false, now, 42, true, binding);
+        hotkey.set_double_tap_only(true);
+        let key = |code, down| InputEvent::Key {
+            code,
+            down,
+            flags: 0,
+        };
+        assert_eq!(hotkey.process(key(97, true), now), None);
+        assert!(matches!(hotkey.state, State::FirstTapPressed));
+        hotkey.disarm_pending_gesture();
+        assert!(hotkey.pressed_keys.contains(&97));
+        hotkey.track_key_state(key(97, false), now + Duration::from_millis(80));
+        let later = now + Duration::from_secs(5);
+        for (offset, event) in [
+            (0, key(0, true)),
+            (10, key(0, false)),
+            (20, key(97, true)),
+            (80, key(97, false)),
+        ] {
+            assert_eq!(
+                hotkey.process(event, later + Duration::from_millis(offset)),
+                None
+            );
+        }
+        assert!(!hotkey.is_recording());
+        assert_eq!(
+            hotkey.process(key(97, true), later + Duration::from_millis(180)),
+            None
+        );
+        assert_eq!(
+            hotkey.process(key(97, false), later + Duration::from_millis(260)),
+            Some(HotkeyAction::Start)
+        );
+        hotkey.disarm_pending_gesture();
+        assert!(
+            hotkey.is_recording(),
+            "disarming pending gestures must not end a capture"
+        );
+    }
+
+    #[test]
+    fn programmatic_ownership_preserves_dirty_chord_suppression() {
+        let now = capture_time();
+        let mut hotkey = test_hotkey(false, now);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), now),
+            Some(HotkeyAction::Start)
+        );
+        assert_eq!(
+            hotkey.process(
+                InputEvent::Flags(OPTION_KEY_MASK | SHIFT_KEY_MASK),
+                now + Duration::from_millis(50)
+            ),
+            Some(HotkeyAction::Discard)
+        );
+        hotkey.disarm_pending_gesture();
+        let later = now + Duration::from_secs(1);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), later),
+            None
+        );
+        assert_eq!(hotkey.process(InputEvent::Flags(0), later), None);
+        assert_eq!(
+            hotkey.process(InputEvent::Flags(OPTION_KEY_MASK), later),
+            Some(HotkeyAction::Start)
+        );
+    }
+
+    #[test]
+    fn stale_key_recovery_requires_complete_neutrality_and_no_intervening_input() {
+        let now = capture_time();
+        let mut hotkey = test_hotkey(false, now);
+        hotkey.process(
+            InputEvent::Key {
+                code: 0,
+                down: true,
+                flags: 0,
+            },
+            now,
+        );
+        hotkey.recover_stale_keys_with(|| now, || 0, |_| false);
+        let later = now + Duration::from_secs(1);
+        // An untracked held key must prevent repair as well.
+        hotkey.recover_stale_keys_with(|| later, || 0, |code| code == 1);
+        assert!(hotkey.stale_keys_neutral_since.is_none());
+        assert!(hotkey.pressed_keys.contains(&0));
+        hotkey.recover_stale_keys_with(|| later, || 0, |_| false);
+        hotkey.process(InputEvent::MouseDown, later);
+        hotkey.recover_stale_keys_with(|| later + STALE_KEY_NEUTRAL_DURATION, || 0, |_| false);
+        assert!(hotkey.pressed_keys.contains(&0));
+        let mut flags = [0, OPTION_KEY_MASK].into_iter();
+        hotkey.recover_stale_keys_with(
+            || later + Duration::from_secs(1),
+            || flags.next().unwrap(),
+            |_| false,
+        );
+        assert!(hotkey.stale_keys_neutral_since.is_none());
+        assert!(hotkey.pressed_keys.contains(&0));
+    }
+
+    #[test]
+    fn stale_key_recovery_never_polls_active_or_pending_gestures() {
+        let now = capture_time();
+        for state in [
+            State::Recording {
+                started_at: now,
+                previous_release: None,
+            },
+            State::Locked,
+            State::FirstTapPressed,
+            State::AwaitingSecondTap { released_at: now },
+            State::SecondTapPressed {
+                first_released_at: now,
+            },
+        ] {
+            let mut hotkey = test_hotkey(false, now);
+            hotkey.state = state;
+            hotkey.pressed_keys.insert(0);
+            let was_recording = hotkey.is_recording();
+            hotkey.recover_stale_keys_with(
+                || panic!("clock must not be polled"),
+                || panic!("flags must not be polled"),
+                |_| panic!("keys must not be polled"),
+            );
+            assert_eq!(hotkey.is_recording(), was_recording);
+            assert!(hotkey.pressed_keys.contains(&0));
+        }
+    }
+
+    #[test]
+    fn stale_key_recovery_does_not_scan_a_held_key_or_disturb_a_normal_double_tap() {
+        let now = capture_time();
+        let binding = RuntimeHotkey {
+            modifiers: Default::default(),
+            key_code: Some(96),
+        };
+        let mut hotkey = DictationHotkey::with_binding(false, now, 42, true, binding);
+        hotkey.process(
+            InputEvent::Key {
+                code: 0,
+                down: true,
+                flags: 0,
+            },
+            now,
+        );
+        let mut queried = Vec::new();
+        hotkey.recover_stale_keys_with(
+            || now,
+            || 0,
+            |code| {
+                queried.push(code);
+                true
+            },
+        );
+        assert_eq!(queried, vec![0]);
+        hotkey.process(
+            InputEvent::Key {
+                code: 0,
+                down: false,
+                flags: 0,
+            },
+            now,
+        );
+        let key = |down| InputEvent::Key {
+            code: 96,
+            down,
+            flags: 0,
+        };
+        assert_eq!(hotkey.process(key(true), now), Some(HotkeyAction::Start));
+        assert_eq!(
+            hotkey.process(key(false), now + Duration::from_millis(50)),
+            Some(HotkeyAction::Finish)
+        );
+        hotkey.recover_stale_keys_with(
+            || panic!("no stale key"),
+            || panic!("no stale key"),
+            |_| panic!("no stale key"),
+        );
+        assert_eq!(
+            hotkey.process(key(true), now + Duration::from_millis(100)),
+            Some(HotkeyAction::Start)
+        );
+        assert_eq!(
+            hotkey.process(key(false), now + Duration::from_millis(150)),
+            None
+        );
+        assert!(hotkey.is_recording());
     }
 
     #[test]


### PR DESCRIPTION
## Why

In 2.1.7, a quick double-tap could start and finish two short captures instead of locking. Even an 80 ms tap could reach transcription. The tap moved from HID to the annotated session, but its timestamp conversion did not change with it.

Addresses #47 and #48. Thanks to the investigation in #49 for narrowing this to the input boundary and identifying stale audio notifications.

## What Changes

| Interaction | Before | After |
| --- | --- | --- |
| 80 ms tap | Interpreted as about 3.33 seconds on the tested Apple Silicon timebase | Discarded as a short tap |
| Quick double-tap | Two short captures | First tap discarded, second capture locks, next press finishes |
| Delayed release handling | Timestamp no longer aligned with audio | Trims at the release boundary |
| Old capture failure after a newer capture finishes | Could reset the next gesture | Ignored as superseded |
| Enable double-tap-only while holding a key chord | Hotkey state went idle while audio kept recording | Active hold still finishes on release or cancels on Escape |
| Disable lock during the second tap | Second release could still lock | Pending lock is cleared |
| Missed ordinary-key release | Modifier shortcuts could remain blocked indefinitely | Inactive tracking recovers after two complete-neutral observations 100 ms apart |
| Release microphone while idle | Consequences compressed into a button label | Explicit fast/idle modes and confirmation explaining delay, pre-roll, and Commands |

## Timestamp Boundary

A simultaneous, listen-only HID/annotated probe recorded 126 modifier events at each boundary while testing physical Option and Right Command. Physical HID timestamps used raw Mach ticks on this Mac; annotated timestamps used nanoseconds. Some HID events were already nanosecond-valued, so moving all modifier handling back to HID is not a uniform clock fix either.

The correction keeps both annotated-session taps and their existing passive-modifier behavior. It removes the extra conversion at that boundary rather than losing assistive modifier events injected downstream of HID. CoreAudio and the shortcut callback now use the same nanosecond timeline.

Capture notifications are filtered by generation in the audio owner, including while idle. Start drains earlier audio before validating and advancing the new generation. Finish/cancel do not advance it: genuine failures from the current capture must still be reported, including failures discovered during release draining.

## Lost Release Recovery

An installed-app smoke test caught a second failure: correct Left Option events reached an idle reducer that still tracked one ordinary key as held. This blocked modifier-only activation even though native keyboard state was fully released.

`recover_stale_keys` runs only after draining input and only for inactive reducers. Two complete-neutral observations with no intervening delivered input repair bookkeeping, never synthesize a capture boundary. Queued pre-recovery edges cannot activate a gesture or overwrite a newer key transition. Programmatic capture continues tracking keys while disarming pending double-taps without clearing an existing dirty-chord guard.

Microphone mode now exposes `Keep ready (fast)` and `Release when idle`. Release requires an inline explanation plus confirmation; Cancel, Escape, or pane navigation preserves the existing policy. Returning to fast mode does not silently enable Commands.

## Scope

Prepares macOS 2.1.8, build 20108. No new shortcut modes, Linux binary, transcription SDK, app identity, signing, or update-feed changes. Press-once toggle mode remains follow-up work.

## Verification

```sh
cargo fmt --check
cargo test --locked --all-features -- --quiet
cargo clippy --locked --all-targets --all-features -- -D warnings
./scripts/test-app-identity.sh
git diff --check
```

Callback regressions invoke the real callback with locally constructed Quartz events, never global input injection. They cover modifier/key bindings, 299/300/301 ms thresholds, first-tap discard, one nonempty clip after locking, and exact delayed release trimming. Owner tests use channel-backed audio and the actual command/event handlers, including stale failures, current failures, boundary-drain rejection, and late cold-opener results.

417 tests passed, with 9 existing ignored tests. Formatting, Clippy, app-identity guards, and diff checks passed. The timestamp, live-setting, stale-edge overwrite, and dirty-chord regressions failed before their fixes. Cargo used a working local CMake installation and the shared target cache.

Installed the final signed, notarized 2.1.8 candidate and verified its executable hash matches the prepared bundle. Physical Left Option hold/release and double-tap locking both passed from another application, including single paste on finish and short-tap discard. Runtime logs also confirm neutral-key recovery executing successfully on the installed build. Temporary diagnostic instrumentation is removed.

Actual Accessibility Keyboard interaction remains unverified; its tap routing is unchanged. Both normal Settings and confirmation preview windows launched; screenshots were blocked by missing macOS Screen Recording access, so no visual-layout verification is claimed.
