### PR TITLE
fix(opencode): discover V2 installs and isolate audio tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8677,7 +8677,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voice-control"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice-control"
-version = "2.1.8"
+version = "2.1.9"
 edition = "2024"
 default-run = "voice-control"
 license = "MIT"

--- a/docs/releases/2.1.9.md
+++ b/docs/releases/2.1.9.md
@@ -1,0 +1,16 @@
+## Hex 2.1.9
+
+- Finds OpenCode V2 installed by the official installer at
+  `~/.opencode/bin/opencode2`, even when a Finder-launched app does not inherit
+  the shell's PATH. An explicit CLI override and PATH entries retain priority.
+- Modes now explains how to set up OpenCode transformations instead of showing
+  Voice Action instructions when OpenCode is missing or still connecting.
+
+Shortcut and recording behavior are unchanged from 2.1.8. Developer audio tests
+now exercise recording-environment ownership without changing system volume,
+pausing media, or preventing sleep.
+
+This macOS release uses build 20109. App identity, permissions, settings,
+signing key, and the Rust update feed are unchanged. The public transcription
+SDK remains at 0.2.2. No Linux binary is published, and the legacy Swift app
+and feed are unchanged.

--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -564,19 +564,45 @@ struct OpenCodeUnavailableCopy<'a> {
     can_open_setup: bool,
 }
 
-fn opencode_unavailable_copy(state: &ModelCatalogState) -> Option<OpenCodeUnavailableCopy<'_>> {
+#[derive(Clone, Copy)]
+enum OpenCodeFeature {
+    VoiceAction,
+    Transformation,
+}
+
+fn opencode_unavailable_copy(
+    state: &ModelCatalogState,
+    feature: OpenCodeFeature,
+) -> Option<OpenCodeUnavailableCopy<'_>> {
     match state {
         ModelCatalogState::Loading => Some(OpenCodeUnavailableCopy {
             title: "Checking for OpenCode",
-            description: "Voice Action will be available after HEX connects to OpenCode.",
+            description: match feature {
+                OpenCodeFeature::VoiceAction => {
+                    "Voice Action will be available after HEX connects to OpenCode."
+                }
+                OpenCodeFeature::Transformation => {
+                    "OpenCode transformation will be available after HEX connects to OpenCode."
+                }
+            },
             error: None,
             can_retry: false,
             retry_label: "Retry",
             can_open_setup: false,
         }),
         ModelCatalogState::Missing => Some(OpenCodeUnavailableCopy {
-            title: "Voice Action requires OpenCode",
-            description: "Install and configure OpenCode to turn spoken instructions into paste-ready text.",
+            title: match feature {
+                OpenCodeFeature::VoiceAction => "Voice Action requires OpenCode",
+                OpenCodeFeature::Transformation => "Transformation requires OpenCode",
+            },
+            description: match feature {
+                OpenCodeFeature::VoiceAction => {
+                    "Install and configure OpenCode to turn spoken instructions into paste-ready text."
+                }
+                OpenCodeFeature::Transformation => {
+                    "Install and configure OpenCode to transform dictated text."
+                }
+            },
             error: None,
             can_retry: true,
             retry_label: "Check again",
@@ -3935,7 +3961,9 @@ impl AppWindow {
         let hotkey = self.render_hotkey_setting_control(HotkeyKind::Edit, window, cx);
         let processing = if !enabled {
             None
-        } else if let Some(copy) = opencode_unavailable_copy(&self.model_catalog) {
+        } else if let Some(copy) =
+            opencode_unavailable_copy(&self.model_catalog, OpenCodeFeature::VoiceAction)
+        {
             let error = copy.error.map(str::to_owned);
             let show_actions = copy.can_retry || copy.can_open_setup;
             let retry_label = copy.retry_label;
@@ -4502,16 +4530,19 @@ impl AppWindow {
         };
         let processing_enabled = self.selected_mode_settings().post_processing.enabled;
         let processing_can_toggle = processing_enabled || self.opencode_available();
-        let processing_unavailable = opencode_unavailable_copy(&self.model_catalog).map(|copy| {
-            (
-                copy.title,
-                copy.description,
-                copy.error.map(str::to_owned),
-                copy.can_retry,
-                copy.retry_label,
-                copy.can_open_setup,
-            )
-        });
+        let processing_unavailable =
+            opencode_unavailable_copy(&self.model_catalog, OpenCodeFeature::Transformation).map(
+                |copy| {
+                    (
+                        copy.title,
+                        copy.description,
+                        copy.error.map(str::to_owned),
+                        copy.can_retry,
+                        copy.retry_label,
+                        copy.can_open_setup,
+                    )
+                },
+            );
         let corrections = self.render_mode_replacements(selection, cx);
         let transformations = self.render_mode_transformations(selection, cx);
         let application_picker =
@@ -9091,7 +9122,7 @@ mod tests {
             "OpenCode /api/model failed: config.providers was invalid".into(),
         );
 
-        let copy = opencode_unavailable_copy(&state).unwrap();
+        let copy = opencode_unavailable_copy(&state, OpenCodeFeature::VoiceAction).unwrap();
 
         assert_eq!(copy.title, "OpenCode is unavailable");
         assert_eq!(
@@ -9108,12 +9139,59 @@ mod tests {
 
     #[test]
     fn opencode_missing_copy_offers_setup_without_an_error() {
-        let copy = opencode_unavailable_copy(&ModelCatalogState::Missing).unwrap();
+        let copy =
+            opencode_unavailable_copy(&ModelCatalogState::Missing, OpenCodeFeature::VoiceAction)
+                .unwrap();
 
         assert_eq!(copy.title, "Voice Action requires OpenCode");
         assert_eq!(copy.error, None);
         assert!(copy.can_retry);
         assert!(copy.can_open_setup);
+    }
+
+    #[test]
+    fn opencode_transformation_copy_describes_modes_without_changing_actions() {
+        let loading =
+            opencode_unavailable_copy(&ModelCatalogState::Loading, OpenCodeFeature::Transformation)
+                .unwrap();
+        assert_eq!(loading.title, "Checking for OpenCode");
+        assert_eq!(
+            loading.description,
+            "OpenCode transformation will be available after HEX connects to OpenCode."
+        );
+        assert!(!loading.can_retry);
+        assert!(!loading.can_open_setup);
+
+        let missing =
+            opencode_unavailable_copy(&ModelCatalogState::Missing, OpenCodeFeature::Transformation)
+                .unwrap();
+        assert_eq!(missing.title, "Transformation requires OpenCode");
+        assert_eq!(
+            missing.description,
+            "Install and configure OpenCode to transform dictated text."
+        );
+        assert_eq!(missing.error, None);
+        assert!(missing.can_retry);
+        assert_eq!(missing.retry_label, "Check again");
+        assert!(missing.can_open_setup);
+
+        let failed = ModelCatalogState::Failed("catalog failure".into());
+        let error = opencode_unavailable_copy(&failed, OpenCodeFeature::Transformation).unwrap();
+        assert_eq!(error.title, "OpenCode is unavailable");
+        assert_eq!(error.error, Some("catalog failure"));
+        assert!(error.can_retry);
+        assert!(!error.can_open_setup);
+        let loaded = ModelCatalogState::Loaded(ModelCatalog {
+            models: Vec::new(),
+            default_key: None,
+            default_name: None,
+        });
+        for feature in [
+            OpenCodeFeature::VoiceAction,
+            OpenCodeFeature::Transformation,
+        ] {
+            assert!(opencode_unavailable_copy(&loaded, feature).is_none());
+        }
     }
 
     #[test]

--- a/src/dictation_audio.rs
+++ b/src/dictation_audio.rs
@@ -819,7 +819,7 @@ mod tests {
         let (commands, command_receiver) = mpsc::channel();
         let (recognition_sender, recognition) = mpsc::sync_channel(RECOGNITION_QUEUE_CAPACITY);
         let (events_sender, events) = mpsc::channel();
-        let recording_environment = RecordingEnvironmentController::start();
+        let recording_environment = RecordingEnvironmentController::for_test();
         let owner = Owner {
             input,
             release_while_idle: false,
@@ -1160,7 +1160,7 @@ mod tests {
             Some("HEX nonexistent microphone for startup recovery test"),
             0,
             None,
-            RecordingEnvironmentController::start(),
+            RecordingEnvironmentController::for_test(),
             PendingInputEvents::default(),
             false,
         )
@@ -1209,7 +1209,7 @@ mod tests {
             let input = DictationAudio::with_input(
                 input,
                 "Test microphone".into(),
-                RecordingEnvironmentController::start(),
+                RecordingEnvironmentController::for_test(),
                 pending_input,
                 false,
             )
@@ -1246,7 +1246,7 @@ mod tests {
         let input = DictationAudio::with_input(
             input,
             "Missing microphone".into(),
-            RecordingEnvironmentController::start(),
+            RecordingEnvironmentController::for_test(),
             PendingInputEvents::default(),
             false,
         )

--- a/src/dictation_processor.rs
+++ b/src/dictation_processor.rs
@@ -935,6 +935,7 @@ fn find_opencode_executable(
         .map(|directory| absolute_path(directory.join("opencode2"), current_directory));
     let home_candidates = home.into_iter().flat_map(|home| {
         [
+            home.join(".opencode/bin/opencode2"),
             home.join(".bun/bin/opencode2"),
             home.join("Library/pnpm/opencode2"),
             home.join("Library/pnpm/bin/opencode2"),
@@ -1037,28 +1038,30 @@ mod tests {
     }
 
     #[test]
-    fn standard_package_manager_location_finds_opencode_outside_the_gui_path() {
+    fn standard_install_location_finds_opencode_outside_the_gui_path() {
         let root = std::env::temp_dir().join(format!(
             "hex-opencode-discovery-{}-{:?}",
             std::process::id(),
             thread::current().id()
         ));
-        let executable = root.join("Library/pnpm/bin/opencode2");
-        std::fs::create_dir_all(executable.parent().unwrap()).unwrap();
-        std::fs::write(&executable, "#!/bin/sh\n").unwrap();
-        let mut permissions = executable.metadata().unwrap().permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&executable, permissions).unwrap();
+        for location in [".opencode/bin/opencode2", "Library/pnpm/bin/opencode2"] {
+            let executable = root.join(location);
+            std::fs::create_dir_all(executable.parent().unwrap()).unwrap();
+            std::fs::write(&executable, "#!/bin/sh\n").unwrap();
+            let mut permissions = executable.metadata().unwrap().permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&executable, permissions).unwrap();
 
-        let found = find_opencode_executable(
-            None,
-            Some(OsStr::new("/usr/bin:/bin")),
-            Some(&root),
-            Some(&root),
-        );
+            let found = find_opencode_executable(
+                None,
+                Some(OsStr::new("/usr/bin:/bin")),
+                Some(&root),
+                Some(&root),
+            );
 
-        assert_eq!(found, Some(executable));
-        std::fs::remove_dir_all(root).unwrap();
+            assert_eq!(found, Some(executable));
+            std::fs::remove_dir_all(&root).unwrap();
+        }
     }
 
     #[test]
@@ -1176,6 +1179,38 @@ mod tests {
         );
 
         assert_eq!(found, Some(current.join("bin/opencode2")));
+    }
+
+    #[test]
+    fn official_install_preserves_override_path_and_executable_checks() {
+        let root = std::env::temp_dir().join(format!(
+            "hex-opencode-precedence-{}-{:?}",
+            std::process::id(),
+            thread::current().id()
+        ));
+        let official = root.join(".opencode/bin/opencode2");
+        let path_executable = root.join("path/opencode2");
+        let fallback = root.join(".bun/bin/opencode2");
+        for executable in [&official, &path_executable, &fallback] {
+            fs::create_dir_all(executable.parent().unwrap()).unwrap();
+            fs::write(executable, "#!/bin/sh\n").unwrap();
+            fs::set_permissions(executable, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let path = root.join("path");
+        let find =
+            |configured, path| find_opencode_executable(configured, path, Some(&root), Some(&root));
+        assert_eq!(
+            find(Some("override/opencode2".into()), Some(path.as_os_str())),
+            Some(root.join("override/opencode2"))
+        );
+        assert_eq!(find(None, Some(path.as_os_str())), Some(path_executable));
+        assert_eq!(find(None, None), Some(official.clone()));
+        fs::set_permissions(&official, fs::Permissions::from_mode(0o644)).unwrap();
+        assert_eq!(find(None, None), Some(fallback.clone()));
+        fs::remove_file(&official).unwrap();
+        fs::create_dir(&official).unwrap();
+        assert_eq!(find(None, None), Some(fallback));
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/recording_environment.rs
+++ b/src/recording_environment.rs
@@ -69,6 +69,8 @@ impl RecordingEnvironment {
 enum EnvironmentCommand {
     Start,
     Stop,
+    #[cfg(test)]
+    Barrier(Sender<()>),
 }
 
 #[derive(Clone)]
@@ -78,6 +80,15 @@ pub struct RecordingEnvironmentController {
 
 impl RecordingEnvironmentController {
     pub fn start() -> Self {
+        Self::with_environment(RecordingEnvironment::start)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test() -> Self {
+        Self::with_environment(|| ())
+    }
+
+    fn with_environment<E>(start: impl Fn() -> E + Send + 'static) -> Self {
         let (commands, receiver) = mpsc::channel();
         thread::spawn(move || {
             let mut sessions = 0_u32;
@@ -87,7 +98,7 @@ impl RecordingEnvironmentController {
                     EnvironmentCommand::Start => {
                         sessions = sessions.saturating_add(1);
                         if sessions == 1 {
-                            _environment = Some(RecordingEnvironment::start());
+                            _environment = Some(start());
                         }
                     }
                     EnvironmentCommand::Stop => {
@@ -95,6 +106,10 @@ impl RecordingEnvironmentController {
                         if sessions == 0 {
                             _environment = None;
                         }
+                    }
+                    #[cfg(test)]
+                    EnvironmentCommand::Barrier(reply) => {
+                        let _ = reply.send(());
                     }
                 }
             }
@@ -334,5 +349,106 @@ fn resume_media(players: &[String]) {
             "could not resume media after dictation"
         ),
         Err(error) => tracing::warn!(%error, "could not resume media after dictation"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc::{Receiver, RecvTimeoutError};
+    use std::time::Duration;
+
+    #[derive(Debug, PartialEq)]
+    enum Event {
+        Started,
+        Restored,
+    }
+
+    struct ObservedEnvironment(Sender<Event>);
+
+    impl Drop for ObservedEnvironment {
+        fn drop(&mut self) {
+            let _ = self.0.send(Event::Restored);
+        }
+    }
+
+    fn observed_controller() -> (RecordingEnvironmentController, Receiver<Event>) {
+        let (events, receiver) = mpsc::channel();
+        let controller = RecordingEnvironmentController::with_environment(move || {
+            let _ = events.send(Event::Started);
+            ObservedEnvironment(events.clone())
+        });
+        (controller, receiver)
+    }
+
+    fn assert_events(
+        commands: &Sender<EnvironmentCommand>,
+        events: &Receiver<Event>,
+        expected: &[Event],
+    ) {
+        let (reply, response) = mpsc::channel();
+        commands.send(EnvironmentCommand::Barrier(reply)).unwrap();
+        response.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert_eq!(events.try_iter().collect::<Vec<_>>(), expected);
+    }
+
+    #[test]
+    fn overlapping_sessions_restore_only_after_the_last_session() {
+        let (controller, events) = observed_controller();
+        assert_events(&controller.commands, &events, &[]);
+
+        let first = controller.begin();
+        let second = controller.begin();
+        assert_events(&controller.commands, &events, &[Event::Started]);
+
+        drop(first);
+        assert_events(&controller.commands, &events, &[]);
+
+        let third = controller.begin();
+        drop(second);
+        assert_events(&controller.commands, &events, &[]);
+
+        drop(third);
+        assert_events(&controller.commands, &events, &[Event::Restored]);
+    }
+
+    #[test]
+    fn a_new_session_reacquires_the_environment_after_restoration() {
+        let (controller, events) = observed_controller();
+        for _ in 0..2 {
+            let session = controller.begin();
+            assert_events(&controller.commands, &events, &[Event::Started]);
+            drop(session);
+            assert_events(&controller.commands, &events, &[Event::Restored]);
+        }
+    }
+
+    #[test]
+    fn controller_moves_and_clones_do_not_restore_a_live_session() {
+        let (controller, events) = observed_controller();
+        let session = controller.begin();
+        assert_events(&controller.commands, &events, &[Event::Started]);
+
+        let cloned = controller.clone();
+        let moved = controller;
+        drop(moved);
+        assert_events(&cloned.commands, &events, &[]);
+
+        let overlapping = cloned.begin();
+        drop(cloned);
+        assert_events(&session.commands, &events, &[]);
+
+        drop(session);
+        assert_events(&overlapping.commands, &events, &[]);
+
+        drop(overlapping);
+        assert_eq!(
+            events.recv_timeout(Duration::from_secs(2)).unwrap(),
+            Event::Restored
+        );
+        assert_eq!(
+            events.recv_timeout(Duration::from_secs(2)),
+            Err(RecvTimeoutError::Disconnected)
+        );
     }
 }

--- a/src/suppression.rs
+++ b/src/suppression.rs
@@ -1202,6 +1202,18 @@ mod tests {
     }
 
     #[test]
+    fn callback_press_reaches_intentional_hold_on_the_audio_clock() {
+        let now = capture_time();
+        let press = callback_input(&[(now.as_nanos(), InputEvent::Flags(OPTION_KEY_MASK))])[0];
+        // This capture has no recording environment, so threshold checks cannot mute audio.
+        let mut capture = crate::dictation::DictationCapture::new(16_000);
+        capture.start_at(press.capture_at);
+        assert!(!capture.become_intentional(now + Duration::from_millis(299)));
+        assert!(capture.become_intentional(now + Duration::from_millis(300)));
+        assert!(!capture.become_intentional(now + Duration::from_millis(301)));
+    }
+
+    #[test]
     fn suspended_key_tracking_preserves_held_keys_and_observes_releases() {
         let now = capture_time();
         let ordinary = |down| InputEvent::Key {


### PR DESCRIPTION
## Why

The official OpenCode V2 installer writes `~/.opencode/bin/opencode2`, but Hex's GUI discovery omitted that location. An otherwise valid install could therefore appear missing when Hex was launched from Finder.

Separately, audio-owner tests used the production recording environment. Crossing the intentional-hold threshold could change the developer's system volume and launch sleep prevention.

## What Changes

- Adds the official V2 installer location while preserving explicit override and PATH precedence. Non-executable files and directories still fall through to existing candidates.
- Gives Modes transformation-specific OpenCode setup text, without changing Voice Action text or retry/setup behavior. Incorporates the discovery and copy fixes proposed in #46, with regression coverage.
- Runs audio-owner tests through the real serialized controller using a side-effect-free environment factory. Production acquisition and restoration remain unchanged.
- Adds deterministic lifecycle tests for overlapping sessions, reacquisition, and controller moves/clones. Adds a callback-to-audio-clock test for the 300 ms intentional threshold without native audio effects.
- Prepares macOS 2.1.9, build 20109.

## Scope

No shortcut timing, microphone policy, production mute adapter, OpenCode service protocol, Linux binary, or transcription SDK changes. The test seam and synchronization barrier are not release controls. App identity, signing, and the update feed are unchanged.

## Verification

```sh
cargo fmt --check
cargo test --locked --all-features -- --quiet
cargo clippy --locked --all-targets --all-features -- -D warnings
./scripts/test-app-identity.sh
git diff --check
```

The official-install discovery regression failed before adding the path. Isolated before/after checks also verified override/PATH precedence and rejection of non-executable files and directories. Current official V2 installer source confirms `INSTALL_DIR=$HOME/.opencode/bin` and `APP=opencode2`.

423 tests passed with 9 existing ignored tests. Formatting, Clippy, app-identity guards, and diff checks passed. Cargo used a working local CMake installation and the existing target cache.

Modes copy is covered for loading, missing, failed, and loaded states. An isolated release Modes preview launched, but capture failed because macOS Screen Recording access is unavailable; no screenshot verification is claimed.

The packaged binary reports 2.1.9. The app and DMG are Developer ID signed, notarized, and stapled. A non-dereferencing manifest comparison verified all 207 entries match between the prepared app, DMG, and signed update ZIP. Linux CI passed; the separate Nix packaging job remains in progress.
