### PR TITLE
feat(macos): surface sidebar updates and fix Settings clipping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,7 @@ cargo run -- app --preview-dictation
 cargo run -- preview onboarding
 cargo run -- preview transcription-picker --language zh --model-state installed
 ./scripts/capture-preview.sh /tmp/hex-preview.png settings
+./scripts/capture-preview.sh /tmp/hex-update.png settings --update-available
 ./scripts/capture-preview.sh /tmp/hex-model-missing.png settings --model-missing
 ./scripts/capture-preview.sh /tmp/hex-command-model-missing.png settings --command-model-missing
 ./scripts/capture-preview.sh /tmp/hex-microphone-confirmation.png settings --confirm-release-microphone

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,6 +3003,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3143,6 +3156,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "ashpd 0.11.1",
  "async-task",
+ "backtrace",
  "bindgen",
  "blade-graphics",
  "blade-macros",
@@ -3371,12 +3385,15 @@ dependencies = [
  "dunce",
  "futures",
  "futures-lite 1.13.0",
+ "git2",
  "globset",
  "gpui_collections",
+ "gpui_util_macros",
  "itertools 0.14.0",
  "libc",
  "log",
  "nix 0.29.0",
+ "rand 0.9.5",
  "regex",
  "rust-embed",
  "schemars",
@@ -4285,6 +4302,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.7+1.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4327,6 +4356,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -8677,7 +8718,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voice-control"
-version = "2.1.9"
+version = "2.1.10"
 dependencies = [
  "arboard",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice-control"
-version = "2.1.9"
+version = "2.1.10"
 edition = "2024"
 default-run = "voice-control"
 license = "MIT"
@@ -59,6 +59,9 @@ objc2-quartz-core = { version = "0.3.2", features = ["CALayer"] }
 objc2-service-management = { version = "0.3.2", features = ["SMAppService"] }
 raw-window-handle = "0.6.2"
 screencapturekit = { version = "=8.0.1", features = ["macos_15_0"] }
+
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+gpui = { version = "0.2.2", default-features = false, features = ["test-support"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 base64 = "0.22.1"

--- a/docs/releases/2.1.10.md
+++ b/docs/releases/2.1.10.md
@@ -1,0 +1,15 @@
+## Hex 2.1.10
+
+- Keeps the version number visible at the bottom of the sidebar, without
+  scrolling through Settings.
+- Shows a prominent Update button beside the version only when an update is
+  available. With no update available, only the version is shown. Manual
+  checks remain available through Check for Updates in the app and menu-bar
+  menus.
+- Fixes Settings content being clipped on either side of the pane. Long
+  descriptions now wrap instead of pushing controls out of view.
+
+This macOS release uses build 20110. Recording behavior, app identity,
+permissions, settings, signing key, and the Rust update feed are unchanged.
+The public transcription SDK remains at 0.2.2. No Linux binary is published,
+and the legacy Swift app and feed are unchanged.

--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -78,6 +78,53 @@ const MAX_OPENCODE_ERROR_BYTES: usize = 4 * 1024;
 const ACTIVITY_LIMIT: usize = 100;
 const OPENCODE_BETA_DOCS_URL: &str = "https://v2.opencode.ai/";
 
+fn sidebar_update_button(status: crate::sparkle::UpdateStatus) -> Option<Div> {
+    (status == crate::sparkle::UpdateStatus::UpdateAvailable).then(|| {
+        div()
+            .h(px(30.0))
+            .px_3()
+            .flex()
+            .items_center()
+            .rounded_sm()
+            .text_size(px(12.0))
+            .flex_none()
+            .bg(rgb(ACCENT))
+            .text_color(rgb(TEXT))
+            .font_weight(FontWeight::SEMIBOLD)
+            .cursor_pointer()
+            .hover(|button| button.bg(mix_color(rgb(ACCENT), rgb(TEXT), 0.12)))
+            .child("Update")
+    })
+}
+
+fn settings_pane(content: Div) -> AnyElement {
+    div()
+        .size_full()
+        .flex()
+        .flex_col()
+        .child(pane_header("Settings"))
+        .child(
+            div()
+                .id("settings-scroll")
+                .flex_1()
+                .overflow_y_scroll()
+                .px_8()
+                .pt_1()
+                .pb_7()
+                .child(
+                    div().w_full().flex().justify_center().child(
+                        content
+                            .w_full()
+                            .max_w(px(PANE_CONTENT_WIDTH))
+                            .min_w_0()
+                            .relative()
+                            .debug_selector(|| "settings-content".into()),
+                    ),
+                ),
+        )
+        .into_any_element()
+}
+
 actions!(
     hex,
     [
@@ -256,6 +303,7 @@ pub struct AppWindowPreview {
     pub command_model_missing: bool,
     pub open_history_retention: bool,
     pub confirm_release_microphone: bool,
+    pub update_available: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -905,7 +953,11 @@ impl AppWindow {
                         let personal_commands_changed = window.poll_personal_commands();
                         let personal_workspace_changed = window.poll_personal_workspace();
                         let history_changed = window.poll_history(cx);
-                        let update_status = crate::sparkle::status();
+                        let update_status = if window.preview {
+                            window.update_status
+                        } else {
+                            crate::sparkle::status()
+                        };
                         let update_status_changed = window.update_status != update_status;
                         if update_status_changed {
                             window.update_status = update_status;
@@ -1183,7 +1235,15 @@ impl AppWindow {
             launch_at_login_toggle: ToggleSpring::new(
                 launch_at_login_status == LoginItemStatus::Enabled,
             ),
-            update_status: crate::sparkle::status(),
+            update_status: if let Some(preview) = &preview {
+                if preview.update_available {
+                    crate::sparkle::UpdateStatus::UpdateAvailable
+                } else {
+                    crate::sparkle::UpdateStatus::Idle
+                }
+            } else {
+                crate::sparkle::status()
+            },
             update_status_changed_at: Instant::now(),
             commands_toggle: ToggleSpring::new(settings.commands_enabled),
             command_model_status: if preview
@@ -2375,6 +2435,37 @@ impl AppWindow {
             .flex_col()
             .child(div().flex().flex_col().gap(px(2.0)).children(items))
             .child(div().flex_1())
+            .child(
+                div()
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .gap_2()
+                    .h(px(30.0))
+                    .mt_3()
+                    .child(
+                        div()
+                            .flex_none()
+                            .pl_2()
+                            .text_size(px(11.0))
+                            .text_color(rgb(MUTED))
+                            .child(format!("Version {}", env!("CARGO_PKG_VERSION"))),
+                    )
+                    .when_some(
+                        sidebar_update_button(self.update_status),
+                        |footer, button| {
+                            footer.child(button.id("check-for-updates-sidebar").on_click(
+                                cx.listener(|this, _, _, cx| {
+                                    if !this.preview {
+                                        cx.dispatch_action(&CheckForUpdates);
+                                        cx.notify();
+                                    }
+                                }),
+                            ))
+                        },
+                    ),
+            )
             .into_any_element()
     }
 
@@ -3313,18 +3404,6 @@ impl AppWindow {
         let recording_audio_position = self.recording_audio_spring.render_position(window);
         let audio_widths = [50.0, 90.0, 80.0];
         let (audio_left, audio_width) = segmented_geometry(recording_audio_position, audio_widths);
-        let update_button_label = match self.update_status {
-            crate::sparkle::UpdateStatus::Checking => "Checking…",
-            crate::sparkle::UpdateStatus::UpToDate
-                if self.update_status_changed_at.elapsed() < Duration::from_secs(4) =>
-            {
-                "Up to date"
-            }
-            crate::sparkle::UpdateStatus::UpdateAvailable => "Update available",
-            crate::sparkle::UpdateStatus::Unavailable
-            | crate::sparkle::UpdateStatus::Idle
-            | crate::sparkle::UpdateStatus::UpToDate => "Check now",
-        };
         let audio_behavior = segmented_control()
             .relative()
             .child(
@@ -3465,29 +3544,8 @@ impl AppWindow {
                         ),
                 )
         });
-        div()
-            .size_full()
-            .flex()
-            .flex_col()
-            .child(pane_header("Settings"))
-            .child(
-                div()
-                    .id("settings-scroll")
-                    .flex_1()
-                    .overflow_y_scroll()
-                    .px_8()
-                    .pt_1()
-                    .pb_7()
-                    .child(
-                        div()
-                            .w_full()
-                            .flex()
-                            .justify_center()
-                            .child(
-                                div()
-                                    .w_full()
-                                    .max_w(px(PANE_CONTENT_WIDTH))
-                                    .relative()
+        settings_pane(
+            div()
                                     .children(permission_warnings)
                                     .child(settings_section_label("DICTATION"))
                                     .child(
@@ -3650,35 +3708,6 @@ impl AppWindow {
                             .child(settings_section_label("APPLICATION"))
                             .child(
                                 settings_panel()
-                                    .child(settings_row(
-                                        "HEX",
-                                        if self.settings.commands_enabled {
-                                            "Local voice commands and private dictation"
-                                        } else {
-                                            "Private local dictation for your Mac"
-                                        },
-                                        div()
-                                            .text_size(px(11.0))
-                                            .text_color(rgb(MUTED))
-                                            .child(format!(
-                                                "Version {}",
-                                                env!("CARGO_PKG_VERSION")
-                                            )),
-                                    ))
-                                    .child(settings_row(
-                                        "Software updates",
-                                        "Check for signed updates automatically in the background",
-                                        compact_button(update_button_label)
-                                            .id("check-for-updates-setting")
-                                            .h(px(32.0))
-                                            .border_1()
-                                            .border_color(rgb(LINE))
-                                            .bg(rgb(CANVAS))
-                                            .on_click(cx.listener(|_this, _, _, cx| {
-                                                cx.dispatch_action(&CheckForUpdates);
-                                                cx.notify();
-                                            })),
-                                    ))
                                     .child(
                                         settings_row(
                                             "Launch at login",
@@ -3744,11 +3773,8 @@ impl AppWindow {
                                         .id("sound-effects-setting"),
                                     ),
                             )
-                            .children(microphone_picker),
-                    ),
-            )
-            )
-            .into_any_element()
+                             .children(microphone_picker),
+        )
     }
 
     fn render_setup(&mut self, cx: &mut Context<Self>) -> AnyElement {
@@ -8694,6 +8720,49 @@ mod tests {
     use super::*;
     use crate::personal_commands::StatusExecution;
 
+    #[gpui::test]
+    fn settings_content_stays_inside_the_pane_at_supported_widths(cx: &mut gpui::TestAppContext) {
+        struct SettingsLayout;
+
+        impl Render for SettingsLayout {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                window_frame()
+                    .child(sidebar_frame().w(px(SIDEBAR_WIDTH)))
+                    .child(
+                        div().flex_1().min_w_0().h_full().child(settings_pane(
+                            div()
+                                .child(settings_panel().child(settings_row(
+                                    "Microphone",
+                                    "Automatically chooses the preferred available input",
+                                    disclosure_button("Automatic"),
+                                )))
+                                .child(settings_copy(
+                                    "Release the microphone when idle?",
+                                    "HEX will open the microphone when you press the shortcut. This adds a start-up delay and removes pre-roll, so the beginning of speech may be missed if you speak right away.",
+                                )),
+                        )),
+                    )
+            }
+        }
+
+        let (_, cx) = cx.add_window_view(|_, _| SettingsLayout);
+        for width in [MINIMUM_WIDTH, WINDOW_WIDTH, 1400.0] {
+            cx.simulate_resize(size(px(width), px(MINIMUM_HEIGHT)));
+            cx.update(|window, _| window.refresh());
+            cx.run_until_parked();
+            let column = cx
+                .debug_bounds("settings-content")
+                .expect("content was rendered");
+            let available = width - SIDEBAR_WIDTH - 64.0;
+            let expected_width = available.min(PANE_CONTENT_WIDTH);
+            assert_eq!(column.size.width, px(expected_width));
+            assert_eq!(
+                column.origin.x,
+                px(SIDEBAR_WIDTH + 32.0 + (available - expected_width) / 2.0)
+            );
+        }
+    }
+
     #[test]
     fn command_model_failure_has_recovery_without_blocking_dictation() {
         assert!(command_model_notice(&CommandModelStatus::Ready).is_none());
@@ -8767,6 +8836,21 @@ mod tests {
         // Permission failures have their own setup UI.
         status.microphone = PermissionState::NeedsRequest;
         assert!(dictation_model_notice(status, false).is_none());
+    }
+
+    #[test]
+    fn sidebar_update_button_only_appears_for_an_available_update() {
+        use crate::sparkle::UpdateStatus;
+
+        for (status, visible) in [
+            (UpdateStatus::Unavailable, false),
+            (UpdateStatus::Idle, false),
+            (UpdateStatus::Checking, false),
+            (UpdateStatus::UpToDate, false),
+            (UpdateStatus::UpdateAvailable, true),
+        ] {
+            assert_eq!(sidebar_update_button(status).is_some(), visible);
+        }
     }
 
     #[test]

--- a/src/desktop_ui.rs
+++ b/src/desktop_ui.rs
@@ -416,6 +416,7 @@ pub(crate) fn settings_section_label(label: &'static str) -> AnyElement {
 #[allow(dead_code)]
 pub(crate) fn settings_copy(title: &'static str, description: &'static str) -> AnyElement {
     div()
+        .debug_selector(|| "settings-copy".into())
         .flex()
         .flex_col()
         .gap_1()
@@ -542,9 +543,15 @@ pub(crate) fn settings_row(
         .flex()
         .items_center()
         .justify_between()
+        .gap_4()
         .border_b_1()
         .border_color(rgb(LINE))
-        .child(settings_copy(title, description))
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .child(settings_copy(title, description)),
+        )
         .child(control)
 }
 
@@ -635,5 +642,66 @@ mod tests {
         assert_eq!(split_sided_keycap("L⌥"), (Some("L"), "⌥".into()));
         assert_eq!(split_sided_keycap("R⌘"), (Some("R"), "⌘".into()));
         assert_eq!(split_sided_keycap("Return"), (None, "Return".into()));
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod layout_tests {
+    use super::*;
+    use gpui::{Context, Render, TestAppContext, Window, size};
+
+    struct SettingsRow;
+
+    impl Render for SettingsRow {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div().w_full().child(
+                settings_row(
+                    "Microphone mode",
+                    "Default: keeps the microphone open for the fastest start. A short pre-roll helps catch the beginning of speech. Audio is not saved by default.",
+                    div()
+                        .debug_selector(|| "settings-control".into())
+                        .w(px(220.0))
+                        .h(px(CONTROL_HEIGHT))
+                        .flex_none(),
+                )
+                .debug_selector(|| "settings-row".into()),
+            )
+        }
+    }
+
+    #[gpui::test]
+    fn settings_row_wraps_copy_without_displacing_fixed_control(cx: &mut TestAppContext) {
+        // Real GPUI/Taffy layout with deterministic test-platform text metrics.
+        let (_, cx) = cx.add_window_view(|_, _| SettingsRow);
+        let mut heights = Vec::new();
+        for width in [940.0, 756.0, 576.0] {
+            cx.simulate_resize(size(px(width), px(400.0)));
+            cx.run_until_parked();
+            let row = cx.debug_bounds("settings-row").unwrap();
+            let copy = cx.debug_bounds("settings-copy").unwrap();
+            let control = cx.debug_bounds("settings-control").unwrap();
+            assert_eq!(row.size.width, px(width));
+            assert_eq!(control.size.width, px(220.0));
+            assert_eq!(control.size.height, px(CONTROL_HEIGHT));
+            assert!(
+                control.right() <= row.right(),
+                "{width}: {control:?} outside {row:?}"
+            );
+            assert!(copy.left() >= row.left());
+            assert!(
+                copy.right() + px(16.0) <= control.left(),
+                "{width}: gap between {copy:?} and {control:?} is below 16px"
+            );
+            assert!(copy.top() >= row.top() && copy.bottom() <= row.bottom());
+            heights.push((row.size.height, copy.size.height));
+        }
+        assert!(
+            heights[2].0 > heights[0].0,
+            "narrow row must grow: {heights:?}"
+        );
+        assert!(
+            heights[2].1 > heights[0].1,
+            "narrow copy must wrap: {heights:?}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,6 +211,9 @@ enum Command {
         /// Show the idle microphone release confirmation with Commands enabled.
         #[arg(long)]
         confirm_release_microphone: bool,
+        /// Show the sidebar update action without starting the updater.
+        #[arg(long)]
+        update_available: bool,
     },
     /// Listen and transcribe until interrupted.
     Listen {
@@ -466,6 +469,7 @@ fn main() -> Result<()> {
             command_model_missing,
             open_history_retention,
             confirm_release_microphone,
+            update_available,
         } => {
             if matches!(target, AppPreviewTarget::DictationHud) {
                 return meeting_watcher::run(&SHUTDOWN, false, None, true);
@@ -514,6 +518,7 @@ fn main() -> Result<()> {
                     command_model_missing,
                     open_history_retention,
                     confirm_release_microphone,
+                    update_available,
                 },
             )
         }
@@ -775,6 +780,27 @@ mod tests {
             assert_eq!(confirm_release_microphone, expected);
         }
         assert!(Cli::try_parse_from(["hex", "app", "--confirm-release-microphone"]).is_err());
+    }
+
+    #[test]
+    fn available_update_requires_an_explicit_preview_flag() {
+        for (args, expected) in [
+            (vec!["hex", "preview", "settings"], false),
+            (
+                vec!["hex", "preview", "settings", "--update-available"],
+                true,
+            ),
+        ] {
+            let cli = Cli::try_parse_from(args).unwrap();
+            let Some(Command::Preview {
+                update_available, ..
+            }) = cli.command
+            else {
+                panic!("expected preview command");
+            };
+            assert_eq!(update_available, expected);
+        }
+        assert!(Cli::try_parse_from(["hex", "app", "--update-available"]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Why

The version number and update control were buried in the scrollable Settings section, making it hard to find the installed version when reporting a problem (#54). Reviewing the new sidebar footer also exposed Settings content overflowing its pane and clipping both labels and controls.

## What Changes

- Keeps the version in the sidebar footer across panes, without a divider.
- Shows a filled Update button only when Sparkle reports an available update. The button opens the existing updater; no new update mechanism is introduced.
- Removes the duplicate version/update rows from Settings. Check for Updates remains available in the app and menu-bar menus.
- Allows the Settings content column to shrink to its available width and wraps row descriptions beside fixed controls.
- Adds a preview-only `--update-available` flag and prepares macOS 2.1.10, build 20110.

| Updater state | Sidebar footer |
| --- | --- |
| Unavailable, idle, checking, or up to date | Version only |
| Update available | Version and primary Update button |

## Demo

Manually reviewed the isolated native release preview, including the update-available state and corrected Settings layout. Automated screenshot capture is blocked by macOS Screen Recording permission, so no screenshot comparison is attached.

Native bounds instrumentation reproduced a 940-point column centered inside 756 points of available space. With the fix, the column occupies exactly those 756 points. Temporary instrumentation was removed.

## Scope

This owns sidebar update presentation and Settings layout. Recording behavior and Sparkle lifecycle are unchanged. No Linux binary or SDK release is included; the shared row-layout fix also applies to Linux UI. GPUI test support is a macOS-only development dependency.

## Verification

```sh
cargo fmt --check
cargo test --locked --all-features -- --quiet
cargo clippy --locked --all-targets --all-features -- -D warnings
./scripts/test-app-identity.sh
git diff --check
```

427 tests passed with 9 existing ignored tests. Formatting, Clippy, app-identity guards, and diff checks passed using the working local CMake installation and macOS deployment target 15.0.

Both GPUI layout regressions failed before their fixes and passed afterward: content width/centering at 860, 1040, and 1400-point windows, plus row wrapping and fixed-control containment at 576, 756, and 940-point content widths. These tests use deterministic GPUI test-font metrics; native bounds measurement and manual preview review provide separate runtime evidence. The update-button test covers every updater state, and the parser rejects the simulated-update flag for the production app command.

The packaged binary reports 2.1.10. Both the app and DMG are Developer ID signed, notarized, and stapled. A non-dereferencing manifest comparison verified all 207 entries match between the prepared app, DMG, and update ZIP. The ZIP's exact size and Ed25519 signature were independently verified against the appcast and the public key pinned in the app. Linux CI and the full Nix package build/test both passed: https://github.com/anomalyco/hex/actions/runs/33411057332.

Published macOS 2.1.10/build 20110 after merge. The public DMG, update ZIP, and latest-download alias match the validated local SHA-256 hashes; the public appcast exactly matches the verified local feed.
