### PR TITLE
feat(sdk): add ready model-bound transcribers

### DIFF
--- a/sdk/.changeset/ready-transcriber.md
+++ b/sdk/.changeset/ready-transcriber.md
@@ -1,0 +1,16 @@
+---
+"@kitlangton/hex": minor
+---
+
+Add a model-bound `create({ model, language, onProgress })` API that returns a
+ready transcriber for WAV bytes. The Promise transcriber provides explicit,
+idempotent cleanup; the Effect transcriber is scope-owned. Failed creation and
+in-flight transcription cancellation wait for helper cleanup. Existing low-level
+`create()` and desktop `connect()` remain available.
+
+Effect scope cleanup failures now surface as defects instead of being logged and
+discarded. The low-level and model-bound option types are distinct so shared
+configuration cannot accidentally change the returned resource's shape.
+
+Embedded use still requires an explicit native helper command until bundled
+platform artifacts are published.

--- a/sdk/.changeset/ready-transcriber.md
+++ b/sdk/.changeset/ready-transcriber.md
@@ -12,5 +12,8 @@ Effect scope cleanup failures now surface as defects instead of being logged and
 discarded. The low-level and model-bound option types are distinct so shared
 configuration cannot accidentally change the returned resource's shape.
 
+Startup cleanup failures are surfaced instead of hiding a potentially live child.
+Cancellation also takes precedence over a buffered result that has not settled.
+
 Embedded use still requires an explicit native helper command until bundled
 platform artifacts are published.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,22 +1,144 @@
 # HEX TypeScript Client
 
-`@kitlangton/hex` connects TypeScript applications to the locally installed HEX
-desktop app. HEX owns its warm microphone and local transcription engine; the
-client controls capture and receives transcripts, levels, and optional PCM.
+`@kitlangton/hex` provides local transcription through a native HEX helper, with
+Promise and optional Effect APIs. The host application owns recording, microphone
+permission, settings, and what happens to the resulting text. HEX owns model
+preparation and inference.
 
-Host the native HEX transcription helper as a direct child process. The host
-application owns microphone capture and settings; HEX owns local model
-preparation and transcription. Model artifacts remain shared per user while the
-helper process and warm model belong to the host.
+**Distribution status:** a bundled native helper is not published yet. Embedded
+consumers must currently supply an explicit native command. The examples below
+use the HEX executable's `service --embedded` mode; users do not need to launch
+the HEX desktop app. This package alone is not yet a turnkey native distribution.
 
-Alternatively, connect to the running HEX desktop app to use its already-warm
-native microphone and recognition engine:
+## Promise API
+
+Pass a model to `create()` to get a ready-to-use transcriber:
+
+```ts
+import * as Hex from "@kitlangton/hex"
+
+const transcriber = await Hex.create({
+  command: ["/path/to/hex-service", "service", "--embedded"],
+  model: "parakeet_unified_en",
+  language: "en",
+  onProgress: console.log,
+})
+
+try {
+  // WAV is an ArrayBuffer or Uint8Array supplied by your recording code.
+  const result = await transcriber.transcribe(wav, {
+    signal: abortController.signal,
+  })
+  console.log(result.transcript, result.durationMs)
+} finally {
+  await transcriber.close()
+}
+```
+
+`create({ model })` starts the helper and waits for download (if necessary),
+verification, and model loading. Progress reports `downloading`, `verifying`, and
+`loading`. Model and language are captured when creation starts; language defaults
+to `en`, independently of desktop settings. A failed or cancelled creation closes
+the helper before rejecting. The optional creation `signal` covers startup and
+preparation, not the returned transcriber's entire lifetime.
+
+Keep the transcriber alive across recordings to reuse its loaded model. It exposes
+the bound `model`, `language`, and diagnostic `pid`; audio requests need only WAV
+bytes. `transcribe()` never initiates a download. Inference remains bounded by the
+native service's admission limits; simultaneous requests can receive a busy error
+instead of entering an unbounded client queue.
+
+### Cancellation and ownership
+
+`close()` is idempotent. It closes the helper's stdin lease, waits for graceful
+shutdown, then terminates the exact child if it does not exit within the bounded
+deadline. Close when the feature or application shuts down, not after every clip.
+No model files are deleted.
+
+Cancelling an **in-flight** `transcribe()` closes this transcriber's helper before
+rejecting. This is intentional: aborting HTTP alone cannot interrupt native
+inference. All other work on that transcriber also ends; create a new transcriber
+before the next recording. An already-aborted request is rejected without closing
+an otherwise usable transcriber. Ordinary request errors do not close it.
+
+This distinction lets hosts that retain recording resources until cancellation
+settles know that native inference has stopped. Cleanup failures remain visible;
+they are not reported as successful cancellation. The host owns temporary audio
+cleanup and any operation deadline, for example through `AbortSignal.timeout()`.
+
+## Effect API
+
+Effect is an optional peer. Use Effect `>=4.0.0-rc.112 <5.0.0` for this entrypoint;
+older v4 betas are not supported. Promise-only consumers do not need Effect and
+can adapt the Promise API to their own framework/runtime version.
+
+```ts
+import { Effect } from "effect"
+import * as Hex from "@kitlangton/hex/effect"
+
+const program = Effect.scoped(Effect.gen(function* () {
+  const transcriber = yield* Hex.create({
+    command: ["/path/to/hex-service", "service", "--embedded"],
+    model: "parakeet_unified_en",
+    language: "en",
+    onProgress: console.log,
+  })
+
+  return yield* transcriber.transcribe(wav)
+}))
+
+const result = await Effect.runPromise(program)
+```
+
+The scope owns helper cleanup; there is no manual `close()` on the Effect
+transcriber. Put that scope around the voice feature's lifetime when reusing the
+model. Model preparation is interruptible after bounded helper startup, and
+interrupting active transcription waits for helper cleanup even when the owning
+scope remains open. Errors are schema-backed tagged failures; a scope finalizer
+that cannot close the helper fails as a defect rather than silently leaking it.
+The progress callback is synchronous, as in the Promise API.
+
+## Low-Level Client
+
+Existing `create()` calls **without a model** still return `{ pid, client, close }`
+in the Promise API and a scoped `{ pid, client }` in the Effect API. This is useful
+for catalog browsing and explicit model management:
+
+```ts
+const host = await Hex.create({
+  command: ["/path/to/hex-service", "service", "--embedded"],
+})
+try {
+  const models = await host.client.models.list()
+  await host.client.models.prepare("parakeet_unified_en", {
+    language: "en",
+    onProgress: console.log,
+  })
+  const result = await host.client.transcribe({
+    audio: { data: wav, contentType: "audio/wav" },
+    model: "parakeet_unified_en",
+    language: "en",
+  })
+} finally {
+  await host.close()
+}
+```
+
+The low-level client retains request-only cancellation; callers own helper
+shutdown if native work must stop. Effect's low-level `client.models.prepare()`
+remains a progress `Stream`. `Hex.layer(options)` still supplies the low-level
+`Hex.Service` and owns its helper for the layer scope.
+
+## Connect to HEX Desktop
+
+Alternatively, reuse the microphone and engine owned by the running HEX desktop
+app through the Promise entrypoint:
 
 ```ts
 import { connect } from "@kitlangton/hex"
 
 const hex = await connect()
-const recording = await hex.dictation.start({ source: "tp7" })
+const recording = await hex.dictation.start({ source: "my-app" })
 
 void (async () => {
   for await (const { rmsDb, peakDb } of recording.levels) {
@@ -24,109 +146,27 @@ void (async () => {
   }
 })()
 
-// Optional: subscribing activates a bounded best-effort mono Float32 PCM tap.
-void (async () => {
-  for await (const samples of recording.audio) {
-    consumePcm(samples, recording.sampleRate)
-  }
-})()
-
 const { transcript, durationMs } = await recording.finish()
 ```
 
-Call `recording.cancel()` to discard instead. Desktop capture returns the raw
-local transcript and never pastes into the focused application. Check
-`capabilities().serviceCapture`: it is true only for a running desktop endpoint,
-and false for the direct-child transcription helper.
-
-The handle maintains a short server lease while capture is active. If its
-process exits, HEX cancels the abandoned capture after lease expiry. Every
-capture operation and observation stream is scoped by the handle's unguessable
-`ownerToken`; callers normally do not need to use it directly.
-
-Embedded hosting is also available for callers that provide an explicit native
-service command. A bundled native helper is not published yet.
-
-## Promise API
-
-```ts
-import { create } from "@kitlangton/hex"
-
-const host = await create({ command: ["/path/to/hex-service", "service", "--embedded"] })
-
-try {
-  const models = await host.client.models.list()
-  await host.client.models.prepare("parakeet_unified_en", {
-    language: "en",
-    onProgress: console.log,
-  })
-
-  const result = await host.client.transcribe({
-    audio: { data: wav, contentType: "audio/wav" },
-    model: "parakeet_unified_en",
-    language: "en",
-  })
-  console.log(result.transcript)
-} finally {
-  await host.close()
-}
-```
-
-`close()` is idempotent. It closes the helper's stdin lease, waits for graceful
-shutdown, then terminates the exact child if it does not exit within the bounded
-deadline.
-
-## Effect API
-
-Install Effect 4.0.0-rc.112 or newer within v4 to use `@kitlangton/hex/effect`.
-Effect remains optional for the Promise API.
-
-The Effect entrypoint exposes scoped acquisition, typed schema-backed errors,
-Effect operations, and a progress `Stream`:
-
-```ts
-import { Effect, Stream } from "effect"
-import * as Hex from "@kitlangton/hex/effect"
-
-const program = Effect.scoped(Effect.gen(function* () {
-  const host = yield* Hex.create({ command: ["/path/to/hex-service", "service", "--embedded"] })
-
-  yield* host.client.models.prepare("parakeet_unified_en", {
-    language: "en",
-  }).pipe(Stream.runForEach((progress) => Effect.logInfo(progress)))
-
-  return yield* host.client.transcribe({
-    audio: { data: wav, contentType: "audio/wav" },
-    model: "parakeet_unified_en",
-    language: "en",
-  })
-}))
-
-const result = await Effect.runPromise(program)
-```
-
-For dependency injection, `Hex.layer(options)` provides `Hex.Service` and owns
-the helper for the layer's scope.
-
-## Permissions
-
-The direct-child helper needs zero macOS TCC permissions. The host application captures
-microphone audio itself and sends encoded WAV, so the microphone prompt,
-`NSMicrophoneUsageDescription`, orange-dot indicator, and Privacy & Security
-entry all belong to the host's own bundle and signature. There is no second
-permission identity to sign, prompt for, or keep in sync.
-
-This is a deliberate decomposition: direct-child hosts own capture and consent,
-while clients connected to the desktop app reuse capture owned by HEX's signed
-desktop process. Neither mode opens a second microphone stream.
+Call `recording.cancel()` to discard. Subscribing to `recording.audio` enables a
+bounded best-effort mono Float32 PCM tap at `recording.sampleRate`. Desktop capture
+returns raw text and never pastes. `capabilities().serviceCapture` distinguishes
+desktop capture from the transcription-only helper. The recording handle renews
+a short lease; abandoned captures expire. Its unguessable `ownerToken` scopes
+capture operations and observations automatically.
 
 ## Host Boundary
 
-- Use from Node or Electron main/preload code, not an untrusted renderer.
-- The client automatically selects and locates its installed native helper
-  package. Applications do not provide an executable path.
-- Capture and encode audio in the host application.
-- Persist model selection in the host application.
-- Keep the helper executable signed and spawn it directly. Do not use
-  LaunchServices, `open`, or `NSWorkspace`.
-- Never expose the startup bearer token to renderer or web content.
+- Use the SDK in Node or Electron main code, not an untrusted renderer. Expose
+  only narrow, validated recording/model operations across the renderer bridge.
+- The direct-child helper does not capture microphone audio. Permissions,
+  `NSMicrophoneUsageDescription`, the recording indicator, and recording consent
+  belong to the host application. Desktop `connect()` instead uses HEX's capture.
+- Encode PCM WAV in the host. Do not send compressed recordings such as M4A or
+  WebM and label them as WAV.
+- Persist the host's model selection in the host, not in HEX desktop preferences.
+- Spawn the signed helper directly. Do not use LaunchServices, `open`, or
+  `NSWorkspace`. Validate native packaging/signing in the final consuming app.
+- Never expose the startup bearer token to renderer or web content. Credentials
+  are exchanged over the child pipe and used for authenticated loopback requests.

--- a/sdk/typescript/src/effect.ts
+++ b/sdk/typescript/src/effect.ts
@@ -1,4 +1,4 @@
-import { Cause, Context, Effect, Layer, Queue, Schema, Scope, Stream } from "effect"
+import { Context, Effect, Layer, Queue, Schema, Scope, Stream } from "effect"
 import { HexError as PromiseHexError } from "./errors.js"
 import { prepareTranscriber, startHost as createPromiseHost } from "./host.js"
 import type {
@@ -151,28 +151,14 @@ const makeClient = (client: Awaited<ReturnType<typeof createPromiseHost>>["clien
       }))
     }),
     prepare: (id, options) => Stream.callback<ModelProgress, HexError>(
-      (queue) =>
-        Effect.acquireRelease(
-          Effect.sync(() => {
-            const controller = new AbortController()
-            void client.models.prepare(id, {
-              ...(options?.language === undefined ? {} : { language: options.language }),
-              signal: controller.signal,
-              onProgress: (progress) => {
-                Queue.offerUnsafe(queue, progress)
-              },
-            }).then(
-              () => {
-                Queue.endUnsafe(queue)
-              },
-              (error: unknown) => {
-                Queue.failCauseUnsafe(queue, Cause.fail(toHexError(error)))
-              },
-            )
-            return controller
-          }),
-          (controller) => Effect.sync(() => controller.abort()),
-        ),
+      (queue) => fromPromise((signal) => client.models.prepare(id, {
+        ...options,
+        signal,
+        onProgress: (progress) => { Queue.offerUnsafe(queue, progress) },
+      })).pipe(Effect.matchEffect({
+        onFailure: (error) => Queue.fail(queue, error),
+        onSuccess: () => Queue.end(queue),
+      })),
       { bufferSize: 32, strategy: "sliding" },
     ),
   },

--- a/sdk/typescript/src/effect.ts
+++ b/sdk/typescript/src/effect.ts
@@ -1,15 +1,17 @@
 import { Cause, Context, Effect, Layer, Queue, Schema, Scope, Stream } from "effect"
 import { HexError as PromiseHexError } from "./errors.js"
-import { create as createPromiseHost } from "./host.js"
+import { prepareTranscriber, startHost as createPromiseHost } from "./host.js"
 import type {
   Capabilities,
   CreateOptions as PromiseCreateOptions,
   Health,
+  HexHost,
   ModelId,
   ModelInfo,
   ModelProgress,
   TranscriptionRequest,
   TranscriptionResult,
+  TranscriberOptions as PromiseTranscriberOptions,
 } from "./types.js"
 
 const ErrorFields = {
@@ -58,6 +60,15 @@ export type HexError =
   | CancellationError
 
 export type CreateOptions = Omit<PromiseCreateOptions, "signal">
+
+export type TranscriberOptions = Omit<PromiseTranscriberOptions, "signal">
+
+export interface Transcriber {
+  readonly pid: number
+  readonly model: ModelId
+  readonly language: string
+  readonly transcribe: (audio: ArrayBuffer | Uint8Array) => Effect.Effect<TranscriptionResult, HexError>
+}
 
 export interface PrepareModelOptions {
   readonly language?: string
@@ -170,14 +181,43 @@ const makeClient = (client: Awaited<ReturnType<typeof createPromiseHost>>["clien
   }),
 })
 
-export const create = (options: CreateOptions = {}): Effect.Effect<Host, HexError, Scope.Scope> =>
-  Effect.acquireRelease(
-    fromPromise((signal) => createPromiseHost({ ...options, signal })),
-    (host) =>
-      Effect.tryPromise({ try: () => host.close(), catch: toHexError }).pipe(
-        Effect.catch((error) => Effect.logError(error)),
-      ),
-  ).pipe(Effect.map((host) => ({ pid: host.pid, client: makeClient(host.client) })))
+export function create(options: TranscriberOptions): Effect.Effect<Transcriber, HexError, Scope.Scope>
+export function create(options?: CreateOptions): Effect.Effect<Host, HexError, Scope.Scope>
+export function create(options: CreateOptions | TranscriberOptions = {}): Effect.Effect<Host | Transcriber, HexError, Scope.Scope> {
+  const snapshot = { ...options }
+  return withHost(snapshot, (host) => {
+    if (snapshot.model === undefined) {
+      return Effect.succeed<Host | Transcriber>({ pid: host.pid, client: makeClient(host.client) })
+    }
+    return fromPromise((signal) => prepareTranscriber(host, { ...snapshot, signal })).pipe(
+      Effect.map((transcriber): Host | Transcriber => ({
+        pid: transcriber.pid,
+        model: transcriber.model,
+        language: transcriber.language,
+        transcribe: (audio) => fromPromise((signal) => transcriber.transcribe(audio, { signal })).pipe(
+          Effect.onInterrupt(() => closeHost(transcriber)),
+        ),
+      })),
+    )
+  })
+}
+
+const closeHost = (host: Pick<HexHost, "close">) =>
+  Effect.tryPromise({ try: host.close, catch: toHexError }).pipe(Effect.orDie)
+
+const withHost = <A>(
+  options: Omit<CreateOptions, "model">,
+  use: (host: HexHost) => Effect.Effect<A, HexError>,
+): Effect.Effect<A, HexError, Scope.Scope> => Effect.uninterruptibleMask((restore) =>
+  Effect.gen(function* () {
+    const host = yield* Effect.acquireRelease(
+      fromPromise((signal) => createPromiseHost({ ...options, signal })),
+      closeHost,
+    )
+    // Install cleanup before restoring interruption, including interruption during startup.
+    return yield* restore(use(host)).pipe(Effect.onInterrupt(() => closeHost(host)))
+  }),
+)
 
 export const layer = (options: CreateOptions = {}): Layer.Layer<Service, HexError> =>
-  Layer.effect(Service, create(options).pipe(Effect.map((host) => Service.of(host.client))))
+  Layer.effect(Service, withHost(options, (host) => Effect.succeed(Service.of(makeClient(host.client)))))

--- a/sdk/typescript/src/helper.ts
+++ b/sdk/typescript/src/helper.ts
@@ -38,6 +38,6 @@ const packagedExecutable = (): string => {
 }
 
 export const resolveCommand = (
-  options: CreateOptions,
+  options: Pick<CreateOptions, "command">,
 ): readonly [executable: string, ...arguments: readonly string[]] =>
   options.command ?? [packagedExecutable(), "service", "--embedded"]

--- a/sdk/typescript/src/host.ts
+++ b/sdk/typescript/src/host.ts
@@ -148,11 +148,7 @@ export const startHost = async (options: Omit<CreateOptions, "model"> = {}): Pro
     const client = makeClient(endpoint, options.fetch ?? globalThis.fetch, lifetime.signal)
     return { pid: endpoint.pid, client, close }
   } catch (error) {
-    try {
-      await close()
-    } catch {
-      // Preserve the startup failure; close reports shutdown failures after acquisition.
-    }
+    await close()
     throw error
   }
 }
@@ -180,10 +176,12 @@ export const prepareTranscriber = async (host: HexHost, options: TranscriberOpti
         throw new HexError("cancelled", "HEX transcription was cancelled", { cause: signal.reason })
       }
       try {
-        return await host.client.transcribe({
+        const result = await host.client.transcribe({
           audio: { data: audio, contentType: "audio/wav" }, model, language,
           ...(signal === undefined ? {} : { signal }),
         })
+        if (signal?.aborted) throw new HexError("cancelled", "HEX transcription was cancelled", { cause: signal.reason })
+        return result
       } catch (error) {
         // Socket cancellation alone cannot stop native inference. Wait for its owner to exit.
         if (signal?.aborted || error instanceof HexError && error.code === "service-exited") {

--- a/sdk/typescript/src/host.ts
+++ b/sdk/typescript/src/host.ts
@@ -6,7 +6,7 @@ import { HexError } from "./errors.js"
 import { makeClient } from "./client.js"
 import { resolveCommand } from "./helper.js"
 import { decodeEndpoint } from "./protocol.js"
-import type { ConnectOptions, CreateOptions, HexClient, HexHost } from "./types.js"
+import type { ConnectOptions, CreateOptions, HexClient, HexHost, Transcriber, TranscriberOptions } from "./types.js"
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 10_000
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 5_500
@@ -109,7 +109,10 @@ const readHandshake = (
   if (signal?.aborted === true) onAbort()
 })
 
-export const create = async (options: CreateOptions = {}): Promise<HexHost> => {
+export const startHost = async (options: Omit<CreateOptions, "model"> = {}): Promise<HexHost> => {
+  if (options.signal?.aborted) {
+    throw new HexError("cancelled", "HEX startup was cancelled", { cause: options.signal.reason })
+  }
   const [executable, ...arguments_] = resolveCommand(options)
   const child = spawn(executable, arguments_, {
     cwd: options.cwd,
@@ -132,12 +135,16 @@ export const create = async (options: CreateOptions = {}): Promise<HexHost> => {
       throw new HexError("invalid-handshake", "HEX reported a different process identifier")
     }
     child.stderr.resume()
+    child.stdout.resume()
     child.once("exit", (code, exitSignal) => {
       lifetime.abort(new HexError(
         "service-exited",
         `Embedded HEX exited (${code ?? exitSignal ?? "unknown"})`,
       ))
     })
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new HexError("service-exited", "HEX exited after its startup handshake")
+    }
     const client = makeClient(endpoint, options.fetch ?? globalThis.fetch, lifetime.signal)
     return { pid: endpoint.pid, client, close }
   } catch (error) {
@@ -148,6 +155,54 @@ export const create = async (options: CreateOptions = {}): Promise<HexHost> => {
     }
     throw error
   }
+}
+
+export const prepareTranscriber = async (host: HexHost, options: TranscriberOptions): Promise<Transcriber> => {
+  const { model, language = "en", signal, onProgress } = options
+  try {
+    await host.client.models.prepare(model, {
+      language,
+      ...(signal === undefined ? {} : { signal }),
+      ...(onProgress === undefined ? {} : { onProgress }),
+    })
+    if (signal?.aborted) throw new HexError("cancelled", "HEX preparation was cancelled", { cause: signal.reason })
+  } catch (error) {
+    await host.close()
+    throw error
+  }
+  return {
+    pid: host.pid,
+    model,
+    language,
+    close: host.close,
+    async transcribe(audio, { signal } = {}) {
+      if (signal?.aborted) {
+        throw new HexError("cancelled", "HEX transcription was cancelled", { cause: signal.reason })
+      }
+      try {
+        return await host.client.transcribe({
+          audio: { data: audio, contentType: "audio/wav" }, model, language,
+          ...(signal === undefined ? {} : { signal }),
+        })
+      } catch (error) {
+        // Socket cancellation alone cannot stop native inference. Wait for its owner to exit.
+        if (signal?.aborted || error instanceof HexError && error.code === "service-exited") {
+          await host.close()
+        }
+        throw error
+      }
+    },
+  }
+}
+
+export function create(options: TranscriberOptions): Promise<Transcriber>
+export function create(options?: CreateOptions): Promise<HexHost>
+export async function create(options: CreateOptions | TranscriberOptions = {}): Promise<HexHost | Transcriber> {
+  if (options.model !== undefined) {
+    const snapshot = { ...options }
+    return prepareTranscriber(await startHost(snapshot), snapshot)
+  }
+  return startHost(options)
 }
 
 export const connect = async (options: ConnectOptions = {}): Promise<HexClient> => {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -20,4 +20,6 @@ export type {
   RequestOptions,
   TranscriptionRequest,
   TranscriptionResult,
+  Transcriber,
+  TranscriberOptions,
 } from "./types.js"

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -103,7 +103,9 @@ export interface HexClient {
 }
 
 export interface CreateOptions {
-  /** Advanced override for development and tests. Normal consumers omit this. */
+  /** Omit the model for the low-level host. */
+  readonly model?: never
+  /** Required until bundled native helper packages are published. */
   readonly command?: readonly [executable: string, ...arguments: readonly string[]]
   readonly cwd?: string
   readonly env?: Readonly<Record<string, string | undefined>>
@@ -112,6 +114,23 @@ export interface CreateOptions {
   readonly signal?: AbortSignal
   /** Platform transport override, primarily for tests and Electron adapters. */
   readonly fetch?: typeof globalThis.fetch
+}
+
+/** Creates a ready, model-bound transcriber. Preparation may download the model. */
+export interface TranscriberOptions extends Omit<CreateOptions, "model"> {
+  readonly model: ModelId
+  /** Defaults to English, independently of the desktop app's settings. */
+  readonly language?: string
+  readonly onProgress?: (progress: ModelProgress) => void
+}
+
+export interface Transcriber {
+  readonly pid: number
+  readonly model: ModelId
+  readonly language: string
+  /** PCM WAV bytes. Cancelling in-flight work closes this transcriber before rejecting. */
+  transcribe(audio: ArrayBuffer | Uint8Array, options?: RequestOptions): Promise<TranscriptionResult>
+  close(): Promise<void>
 }
 
 export interface ConnectOptions extends RequestOptions {

--- a/sdk/typescript/test/create.types.ts
+++ b/sdk/typescript/test/create.types.ts
@@ -1,0 +1,31 @@
+import type { Effect, Scope } from "effect"
+import * as Hex from "../src/index.js"
+import * as EffectHex from "../src/effect.js"
+
+// Compile-only consumer checks: never start a helper from a type assertion.
+export function createTypes(
+  low: Hex.CreateOptions,
+  ready: Hex.TranscriberOptions,
+  ambiguous: Omit<Hex.CreateOptions, "model"> & { model?: Hex.ModelId },
+) {
+  const host: Promise<Hex.HexHost> = Hex.create(low)
+  const transcriber: Promise<Hex.Transcriber> = Hex.create(ready)
+  const effectHost: Effect.Effect<EffectHex.Host, EffectHex.HexError, Scope.Scope> = EffectHex.create(low)
+  const effectTranscriber: Effect.Effect<EffectHex.Transcriber, EffectHex.HexError, Scope.Scope> = EffectHex.create(ready)
+  const invalid = { model: "fictional-model" }
+
+  // @ts-expect-error A model-bound transcriber cannot masquerade as a low-level host.
+  const widened: Hex.CreateOptions = ready
+  // @ts-expect-error Optional models cannot determine which resource is returned.
+  Hex.create(ambiguous)
+  // @ts-expect-error Optional models cannot determine which resource is returned.
+  EffectHex.create(ambiguous)
+  // @ts-expect-error Invalid model variables must not fall back to the low-level overload.
+  Hex.create(invalid)
+  // @ts-expect-error Invalid model variables must not fall back to the low-level overload.
+  EffectHex.create(invalid)
+  // @ts-expect-error The existing service layer deliberately provides only the low-level client.
+  EffectHex.layer(ready)
+
+  return { host, transcriber, effectHost, effectTranscriber, widened }
+}

--- a/sdk/typescript/test/effect.test.ts
+++ b/sdk/typescript/test/effect.test.ts
@@ -153,10 +153,15 @@ describe("Effect client", () => {
 
   it("interrupts an in-flight preparation when its stream scope closes", async () => {
     let pid = 0
+    let requestSignal: AbortSignal | null | undefined
     await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
       const host = yield* Hex.create({
         ...options(),
         env: { HEX_FAKE_PREPARE_HANG: "1" },
+        fetch: (url, init) => {
+          if (String(url).includes("/prepare")) requestSignal = init?.signal
+          return fetch(url, init)
+        },
       })
       pid = host.pid
       const progress = yield* Deferred.make<void>()
@@ -167,8 +172,22 @@ describe("Effect client", () => {
       )
       yield* Deferred.await(progress)
       yield* Fiber.interrupt(fiber)
+      expect(requestSignal?.aborted).toBe(true)
+      expect(processIsAlive(host.pid)).toBe(true)
+      expect((yield* host.client.health()).apiVersion).toBe("2")
     })))
 
     expect(processIsAlive(pid)).toBe(false)
+  })
+
+  it("preserves typed preparation failures through the progress stream", async () => {
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const host = yield* Hex.create({ ...options(), env: { HEX_FAKE_PREPARE_ERROR: "1" } })
+      const error = yield* host.client.models.prepare("parakeet_v2").pipe(Stream.runDrain, Effect.flip)
+      expect(error).toMatchObject({
+        _tag: "Hex.ModelPreparationError", code: "model-prepare-failed", remoteCode: "load-failed",
+      })
+      expect(processIsAlive(host.pid)).toBe(true)
+    })))
   })
 })

--- a/sdk/typescript/test/effect.test.ts
+++ b/sdk/typescript/test/effect.test.ts
@@ -1,9 +1,102 @@
 import { Deferred, Effect, Fiber, Stream } from "effect"
+import { watch } from "node:fs"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import * as Hex from "../src/effect.js"
 import { options, processIsAlive } from "./support.js"
 
 describe("Effect client", () => {
+  it("creates a ready transcriber with scope-owned cleanup", async () => {
+    let pid = 0
+    const progress: string[] = []
+    const result = await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const transcriber = yield* Hex.create({
+        ...options(), model: "parakeet_v2", language: "en",
+        onProgress: (event) => { progress.push(event.type) },
+      })
+      pid = transcriber.pid
+      expect(transcriber.language).toBe("en")
+      return yield* transcriber.transcribe(new Uint8Array([1, 2, 3]))
+    })))
+    expect(result.transcript).toBe("hello from hex")
+    expect(progress).toEqual(["downloading", "verifying", "loading"])
+    expect(processIsAlive(pid)).toBe(false)
+  })
+
+  it("interrupts model preparation and waits for helper cleanup", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "hex-effect-ready-"))
+    const pidPath = join(directory, "pid")
+    let markStarted = () => {}
+    const started = new Promise<void>((resolve) => { markStarted = resolve })
+    try {
+      await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+        const fiber = yield* Hex.create({
+          ...options(), model: "parakeet_v2",
+          env: { HEX_FAKE_PID_PATH: pidPath, HEX_FAKE_PREPARE_HANG: "1" },
+          shutdownTimeoutMs: 100,
+          onProgress: markStarted,
+        }).pipe(Effect.forkScoped)
+        yield* Effect.promise(() => started)
+        yield* Fiber.interrupt(fiber)
+        const pid = yield* Effect.promise(() => readFile(pidPath, "utf8"))
+        expect(processIsAlive(Number(pid))).toBe(false)
+      })))
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("waits for interrupted inference to stop even while the owning scope stays open", async () => {
+    let markStarted = () => {}
+    const started = new Promise<void>((resolve) => { markStarted = resolve })
+    await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+      const transcriber = yield* Hex.create({
+        ...options(), model: "parakeet_v2", shutdownTimeoutMs: 100,
+        env: { HEX_FAKE_TRANSCRIBE_HANG: "1" },
+        fetch: async (url, init) => {
+          const response = await fetch(url, init)
+          if (String(url).includes("/transcriptions")) markStarted()
+          return response
+        },
+      })
+      const fiber = yield* transcriber.transcribe(new Uint8Array(4)).pipe(Effect.forkScoped)
+      yield* Effect.promise(() => started)
+      yield* Fiber.interrupt(fiber)
+      expect(processIsAlive(transcriber.pid)).toBe(false)
+    })))
+  })
+
+  it("cleans up pending startup interruption before returning to an open parent scope", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "hex-effect-start-"))
+    const pidPath = join(directory, "pid")
+    const gate = join(directory, "handshake")
+    const watcher = watch(directory)
+    const started = new Promise<void>((resolve) => {
+      watcher.on("change", (_event, file) => {
+        if (file === "pid") resolve()
+      })
+    })
+    try {
+      await Effect.runPromise(Effect.scoped(Effect.gen(function* () {
+        const fiber = yield* Hex.create({
+          ...options(), model: "parakeet_v2",
+          env: { HEX_FAKE_PID_PATH: pidPath, HEX_FAKE_HANDSHAKE_GATE: gate },
+        }).pipe(Effect.forkScoped)
+        yield* Effect.promise(() => started)
+        fiber.interruptUnsafe()
+        yield* Effect.promise(() => writeFile(gate, "ready"))
+        yield* Fiber.interrupt(fiber)
+        const pid = yield* Effect.promise(() => readFile(pidPath, "utf8"))
+        expect(processIsAlive(Number(pid))).toBe(false)
+      })))
+    } finally {
+      watcher.close()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
   it.each([
     Hex.StartupError,
     Hex.ProtocolError,

--- a/sdk/typescript/test/fixtures/fake-helper.mjs
+++ b/sdk/typescript/test/fixtures/fake-helper.mjs
@@ -7,7 +7,10 @@ if (process.env.HEX_FAKE_MODE === "exit-before-ready") process.exit(23)
 if (process.env.HEX_FAKE_MODE === "bad-handshake") {
   process.stdout.write('{"type":"ready","url":"https://example.com"}\n')
   process.stdin.resume()
-  process.stdin.on("end", () => process.exit(0))
+  process.stdin.on("end", () => {
+    if (process.env.HEX_FAKE_IGNORE_LEASE === "1") setInterval(() => {}, 1_000)
+    else process.exit(0)
+  })
 } else {
   const token = "hex_0000000000000000000000000000000000000000000000000000000000000000"
   const models = [{

--- a/sdk/typescript/test/fixtures/fake-helper.mjs
+++ b/sdk/typescript/test/fixtures/fake-helper.mjs
@@ -1,6 +1,8 @@
 import http from "node:http"
 import fs from "node:fs"
+import path from "node:path"
 
+if (process.env.HEX_FAKE_PID_PATH) fs.writeFileSync(process.env.HEX_FAKE_PID_PATH, String(process.pid))
 if (process.env.HEX_FAKE_MODE === "exit-before-ready") process.exit(23)
 if (process.env.HEX_FAKE_MODE === "bad-handshake") {
   process.stdout.write('{"type":"ready","url":"https://example.com"}\n')
@@ -84,6 +86,11 @@ if (process.env.HEX_FAKE_MODE === "bad-handshake") {
       request.on("data", (chunk) => chunks.push(chunk))
       request.on("end", () => {
         response.setHeader("content-type", "application/json")
+        if (process.env.HEX_FAKE_TRANSCRIBE_HANG === "1") {
+          response.writeHead(200)
+          response.flushHeaders()
+          return
+        }
         response.end(JSON.stringify({ transcript: "hello from hex", durationMs: 750 }))
       })
       return
@@ -163,13 +170,25 @@ if (process.env.HEX_FAKE_MODE === "bad-handshake") {
           pid: process.pid,
         }))
       }
-      process.stdout.write(`${JSON.stringify({
+      const announce = () => process.stdout.write(`${JSON.stringify({
         type: "ready",
         url: `http://127.0.0.1:${address.port}`,
         token,
         apiVersion: "2",
         pid: process.pid,
       })}\n`)
+      const gate = process.env.HEX_FAKE_HANDSHAKE_GATE
+      if (gate) {
+        const check = () => {
+          if (!fs.existsSync(gate)) return
+          watcher.close()
+          announce()
+        }
+        const watcher = fs.watch(path.dirname(gate), check)
+        check()
+      } else {
+        announce()
+      }
     }
   })
 

--- a/sdk/typescript/test/transcriber.test.ts
+++ b/sdk/typescript/test/transcriber.test.ts
@@ -1,7 +1,9 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { describe, expect, it } from "vitest"
+import { ChildProcess } from "node:child_process"
+import { once } from "node:events"
+import { describe, expect, it, vi } from "vitest"
 import { create, type ModelProgress } from "../src/index.js"
 import { options, processIsAlive } from "./support.js"
 
@@ -69,6 +71,54 @@ describe("ready transcriber", () => {
       expect((await transcriber.transcribe(new Uint8Array(4))).transcript).toBe("hello from hex")
     } finally {
       await transcriber.close()
+    }
+  })
+
+  it("does not let buffered success overtake cancellation", async () => {
+    const controller = new AbortController()
+    const transcriber = await create({
+      ...options(), model: "parakeet_v2",
+      fetch: async (url, init) => {
+        const response = await fetch(url, init)
+        if (String(url).includes("/transcriptions")) {
+          const json = response.json.bind(response)
+          response.json = async () => {
+            const result: unknown = await json()
+            controller.abort()
+            return result
+          }
+        }
+        return response
+      },
+    })
+    try {
+      await expect(transcriber.transcribe(new Uint8Array(4), { signal: controller.signal }))
+        .rejects.toMatchObject({ code: "cancelled" })
+      expect(processIsAlive(transcriber.pid)).toBe(false)
+    } finally {
+      await transcriber.close()
+    }
+  })
+
+  it("reports failed startup cleanup instead of implying the child stopped", async () => {
+    const children: ChildProcess[] = []
+    const kill = vi.spyOn(ChildProcess.prototype, "kill").mockImplementation(function (this: ChildProcess) {
+      children.push(this)
+      throw new Error("Termination denied")
+    })
+    try {
+      await expect(create({
+        ...options(), model: "parakeet_v2", shutdownTimeoutMs: 1,
+        env: { HEX_FAKE_MODE: "bad-handshake", HEX_FAKE_IGNORE_LEASE: "1" },
+      })).rejects.toMatchObject({ code: "shutdown-failed" })
+    } finally {
+      kill.mockRestore()
+      for (const child of children) {
+        if (child.exitCode !== null || child.signalCode !== null) continue
+        const exited = once(child, "exit")
+        child.kill("SIGKILL")
+        await exited
+      }
     }
   })
 

--- a/sdk/typescript/test/transcriber.test.ts
+++ b/sdk/typescript/test/transcriber.test.ts
@@ -1,0 +1,142 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import { create, type ModelProgress } from "../src/index.js"
+import { options, processIsAlive } from "./support.js"
+
+describe("ready transcriber", () => {
+  it("prepares once and binds the model and language across recordings", async () => {
+    const progress: ModelProgress[] = []
+    const requests: string[] = []
+    const input = {
+      ...options(), model: "parakeet_v2" as const, language: "en",
+      onProgress: (event: ModelProgress) => { progress.push(event) },
+      fetch: async (url: string | URL | Request, init?: RequestInit) => {
+        requests.push(String(url))
+        return fetch(url, init)
+      },
+    }
+    const creating = create(input)
+    input.language = "fr"
+    const transcriber = await creating
+    try {
+      expect(progress.map((event) => event.type)).toEqual(["downloading", "verifying", "loading"])
+      expect(transcriber.model).toBe("parakeet_v2")
+      expect(transcriber.language).toBe("en")
+      for (const audio of [new Uint8Array([1, 2, 3]), new ArrayBuffer(4)]) {
+        expect(await transcriber.transcribe(audio)).toEqual({ transcript: "hello from hex", durationMs: 750 })
+      }
+      expect(requests.filter((url) => url.includes("/prepare"))).toHaveLength(1)
+      expect(requests.filter((url) => url.includes("/transcriptions")).map((url) => new URL(url).search))
+        .toEqual(["?model=parakeet_v2&language=en", "?model=parakeet_v2&language=en"])
+    } finally {
+      await transcriber.close()
+    }
+    await transcriber.close()
+    expect(processIsAlive(transcriber.pid)).toBe(false)
+    await expect(transcriber.transcribe(new Uint8Array(4))).rejects.toMatchObject({ code: "service-exited" })
+  })
+
+  it.each(["error", "cancel", "callback"])("closes the helper before failed creation settles: %s", async (mode) => {
+    const directory = await mkdtemp(join(tmpdir(), "hex-ready-"))
+    const pidPath = join(directory, "pid")
+    const controller = new AbortController()
+    try {
+      await expect(create({
+        ...options(), model: "parakeet_v2",
+        env: { HEX_FAKE_PID_PATH: pidPath, HEX_FAKE_PREPARE_ERROR: "1" },
+        signal: controller.signal,
+        onProgress: () => {
+          if (mode === "cancel") controller.abort()
+          if (mode === "callback") throw new Error("UI callback failed")
+        },
+      })).rejects.toMatchObject({
+        code: mode === "error" ? "model-prepare-failed" : mode === "cancel" ? "cancelled" : "request-failed",
+      })
+      expect(processIsAlive(Number(await readFile(pidPath, "utf8")))).toBe(false)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("does not close a ready transcriber for an already-aborted request", async () => {
+    const transcriber = await create({ ...options(), model: "parakeet_v2" })
+    try {
+      await expect(transcriber.transcribe(new Uint8Array(4), { signal: AbortSignal.abort() }))
+        .rejects.toMatchObject({ code: "cancelled" })
+      expect(processIsAlive(transcriber.pid)).toBe(true)
+      expect((await transcriber.transcribe(new Uint8Array(4))).transcript).toBe("hello from hex")
+    } finally {
+      await transcriber.close()
+    }
+  })
+
+  it.each(["abort", "close", "replaced-signal"])("waits for native ownership to end on %s", async (mode) => {
+    let markStarted = () => {}
+    const started = new Promise<void>((resolve) => { markStarted = resolve })
+    const controller = new AbortController()
+    const transcriber = await create({
+      ...options(), model: "parakeet_v2",
+      env: { HEX_FAKE_TRANSCRIBE_HANG: "1" },
+      fetch: async (url, init) => {
+        const response = await fetch(url, init)
+        if (String(url).includes("/transcriptions")) markStarted()
+        return response
+      },
+    })
+    try {
+      const request = { signal: controller.signal }
+      const result = expect(transcriber.transcribe(new Uint8Array(4), request))
+        .rejects.toMatchObject({ code: mode === "close" ? "service-exited" : "cancelled" })
+      await started
+      if (mode === "replaced-signal") request.signal = new AbortController().signal
+      if (mode === "close") void transcriber.close()
+      else controller.abort()
+      await result
+      expect(processIsAlive(transcriber.pid)).toBe(false)
+    } finally {
+      await transcriber.close()
+    }
+  })
+
+  it("keeps the helper alive after an ordinary request failure", async () => {
+    const transcriber = await create({
+      ...options(), model: "parakeet_v2", env: { HEX_FAKE_TRANSCRIBE_ERROR: "1" },
+    })
+    try {
+      await expect(transcriber.transcribe(new Uint8Array(4)))
+        .rejects.toMatchObject({ code: "request-failed", remoteCode: "model-not-ready" })
+      expect(processIsAlive(transcriber.pid)).toBe(true)
+    } finally {
+      await transcriber.close()
+    }
+  })
+
+  it("settles every pending request when one cancellation closes their helper", async () => {
+    let markStarted = () => {}
+    const started = new Promise<void>((resolve) => { markStarted = resolve })
+    let uploads = 0
+    const controller = new AbortController()
+    const transcriber = await create({
+      ...options(), model: "parakeet_v2", env: { HEX_FAKE_TRANSCRIBE_HANG: "1" },
+      fetch: async (url, init) => {
+        const response = await fetch(url, init)
+        if (String(url).includes("/transcriptions") && ++uploads === 2) markStarted()
+        return response
+      },
+    })
+    try {
+      const first = expect(transcriber.transcribe(new Uint8Array(4), { signal: controller.signal }))
+        .rejects.toMatchObject({ code: "cancelled" })
+      const second = expect(transcriber.transcribe(new Uint8Array(4)))
+        .rejects.toMatchObject({ code: "service-exited" })
+      await started
+      controller.abort()
+      await Promise.all([first, second])
+      expect(processIsAlive(transcriber.pid)).toBe(false)
+    } finally {
+      await transcriber.close()
+    }
+  })
+})


### PR DESCRIPTION
## Why

Applications that own recording currently have to coordinate helper startup,
model preparation, and repeated model/language arguments before receiving text.
They also cannot treat an aborted HTTP request as proof that native inference
has stopped using the recording.

## What Changes

Passing a model to `create()` now returns a ready, model-bound transcriber:

```ts
import * as Hex from "@kitlangton/hex"

const transcriber = await Hex.create({
  command: ["/path/to/hex-service", "service", "--embedded"],
  model: "parakeet_unified_en",
  language: "en",
  onProgress: console.log,
})

try {
  const { transcript } = await transcriber.transcribe(wav, { signal })
} finally {
  await transcriber.close()
}
```

The Effect entrypoint exposes the same ready-transcriber shape, with scoped
cleanup rather than a manual `close()`. Keep either resource alive across
recordings to reuse its loaded model.

| Operation | Contract |
| --- | --- |
| `create({ model })` | Captures selection, starts the helper, waits for preparation, reports progress. |
| `transcribe(wav)` | Sends PCM WAV with the bound selection; never initiates a download. |
| In-flight cancellation | Waits for owned-helper shutdown before settling; recreate before the next recording. Other pending requests also end. |
| Already-aborted request | Rejects without closing a healthy transcriber. |
| Ordinary request failure | Leaves the helper available. |
| `create()` without a model | Retains the existing low-level host contract. Desktop `connect()` is unchanged. |

Low-level and ready options are structurally distinct to prevent overloads from
returning a different resource shape than the caller's types promise. Effect
cleanup is installed before restoring interruption, including pending startup
interruption. Cleanup failures surface as defects instead of being logged and
discarded. A minor Changeset and updated integration documentation are included.

The low-level progress stream reuses the existing Effect Promise bridge instead
of managing a second abort controller. Cancellation takes precedence over buffered
success, and failed startup cleanup reports `shutdown-failed` rather than hiding
a potentially live child.

## Scope

This PR owns the SDK API and lifecycle behavior. The native helper package is
still unpublished, so an explicit native command is required. It does not claim
turnkey signed distribution or add microphone/UI integration.

T3 Code changes used for verification remain in a local experiment worktree;
there is no T3 Code PR. T3 uses the Promise entrypoint without changing its older
Effect version.

## Verification

```sh
# Hex SDK workspace
bun install --frozen-lockfile

# sdk/typescript
bun run check
bun run test
bun run build
npm pack --silent --pack-destination "$HEX_PROOF/package-simplified"

# Hex native helper, reusing the existing clone's build cache
CARGO_TARGET_DIR="$HEX_SOURCE/target" cargo build --release --locked
git diff --check

# Local T3 worktree, with opt-in helper/support/WAV fixture variables configured
T3_HEX_INTEGRATION=1 T3_HEX_MODEL=parakeet_unified_en T3_HEX_LANGUAGE=en \
ELECTRON_RUN_AS_NODE=1 \
./apps/desktop/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron \
node_modules/vite-plus/bin/vp test run \
apps/desktop/src/voice-input/hexVoiceTranscriber.test.ts \
packages/client-runtime/src/voice-input/controller.test.ts

# Clean consumer outside both repositories, using the packed artifact
bun install --ignore-scripts
node promise-smoke.mjs
bun add --exact --ignore-scripts effect@4.0.0-rc.112
node effect-smoke.mjs
```

- SDK: **45 tests pass**, including startup/preparation interruption with the parent scope still open, mutable-input regressions, concurrent cancellation, buffered-success cancellation, failed startup cleanup, and progress-stream error/interrupt behavior. Compile-only checks cover valid and ambiguous overloads.
- Local T3: **36 tests pass** under its Electron Node runtime. The real shared `VoiceInputController` and local adapter used the packed SDK to transcribe a synthetic WAV twice with one helper, insert both results into the draft, then verify the captured helper PID exited. Failed acquisition cleanup also blocks replacement.
- Clean consumer: the Promise API transcribed twice with **no Effect installed**. After adding the supported Effect peer, the Effect API transcribed successfully and scope cleanup stopped its helper too. Install scripts were disabled.
- Real expected output: `Local transcription puts these words into the draft.` The 2.88-second fixture was synthesized, not captured from a user's microphone. Tests used an isolated model-copy/support directory, not live T3 or Hex data.
- Native release build succeeds with an existing unused `call_developer` warning. No Rust code changed. The local consumer harnesses and T3 prototype are not part of this PR.

Read-only simplification reviews found lifecycle/type issues that were fixed
and regression-tested, then rechecked. This verifies SDK/native connectivity and
draft behavior, not a live microphone UI or signed clean-machine distribution.
