### PR TITLE
refactor: remove unused desktop and capture bookkeeping

### DIFF
--- a/docs/specs/local-transcription-service.md
+++ b/docs/specs/local-transcription-service.md
@@ -204,50 +204,10 @@ are not exposed by this protocol.
 
 ### Low-Level TypeScript Surface
 
-```typescript
-export function create(options?: CreateOptions): Promise<HexHost>;
-
-export interface HexHost {
-  pid: number;
-  client: HexClient;
-  close(): Promise<void>;
-}
-
-export interface HexClient {
-  health(): Promise<Health>;
-  capabilities(): Promise<Capabilities>;
-  models: {
-    list(options?: { language?: string; signal?: AbortSignal }): Promise<ModelInfo[]>;
-    prepare(
-      id: ModelId,
-      options?: {
-        language?: string;
-        onProgress?: (progress: ModelProgress) => void;
-        signal?: AbortSignal;
-      },
-    ): Promise<void>;
-  };
-  transcribe(request: TranscriptionRequest): Promise<TranscriptionResult>;
-}
-
-export interface AudioClip {
-  /** PCM WAV bytes. */
-  data: ArrayBuffer | Uint8Array;
-  contentType: "audio/wav";
-}
-
-export interface TranscriptionRequest {
-  audio: AudioClip;
-  model: ModelId;
-  language?: string;
-  signal?: AbortSignal;
-}
-
-export interface TranscriptionResult {
-  transcript: string;
-  durationMs: number;
-}
-```
+The [SDK README](../../sdk/typescript/README.md) documents host creation and
+client usage. The [public types](../../sdk/typescript/src/types.ts) define the
+complete client, audio, progress, and result contracts; this spec owns the wire
+protocol and lifecycle guarantees rather than a second copy of those interfaces.
 
 The common host flow is explicit about preparation:
 

--- a/sdk/typescript/test/fixtures/fake-helper.mjs
+++ b/sdk/typescript/test/fixtures/fake-helper.mjs
@@ -85,8 +85,7 @@ if (process.env.HEX_FAKE_MODE === "bad-handshake") {
         response.end(JSON.stringify({ code: "model-not-ready" }))
         return
       }
-      const chunks = []
-      request.on("data", (chunk) => chunks.push(chunk))
+      request.resume()
       request.on("end", () => {
         response.setHeader("content-type", "application/json")
         if (process.env.HEX_FAKE_TRANSCRIBE_HANG === "1") {

--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -7310,7 +7310,6 @@ impl DesktopHost for AppWindow {
     }
 
     fn snapshot(&self) -> DesktopSnapshot {
-        let dictation_shortcut = self.settings.dictation_hotkey.keycaps();
         let update_status = match self.update_status {
             crate::sparkle::UpdateStatus::Unavailable => DesktopUpdateStatus::Unavailable,
             crate::sparkle::UpdateStatus::Checking => DesktopUpdateStatus::Checking,
@@ -7321,18 +7320,11 @@ impl DesktopHost for AppWindow {
         };
         DesktopSnapshot {
             activity: self.activity.clone(),
-            dictation_shortcut_label: dictation_shortcut.join("+"),
-            dictation_shortcut,
+            dictation_shortcut: self.settings.dictation_hotkey.keycaps(),
             double_tap_lock: self.settings.double_tap_lock,
             double_tap_only: self.settings.double_tap_only,
-            paste_last_shortcut: self
-                .settings
-                .paste_last_hotkey
-                .as_ref()
-                .map(HotkeyBinding::keycaps),
             listener: None,
             operation_error: self.settings_load_error.clone(),
-            observations_path: self.event_reader.path().display().to_string(),
             transcription: DesktopTranscriptionSnapshot {
                 downloaded_bytes: self.transcription_downloaded_bytes,
                 error: self.transcription_picker_error.clone(),

--- a/src/command_grammar.rs
+++ b/src/command_grammar.rs
@@ -474,8 +474,7 @@ fn schema_capture_pattern(
         parse: Box::new(move |heard| {
             let mut values = BTreeMap::new();
             let mut word_index = 0;
-            let phrase_parts = phrase.split_whitespace().collect::<Vec<_>>();
-            for part in phrase_parts {
+            for part in phrase.split_whitespace() {
                 if part.starts_with('{') {
                     let name = &part[1..part.len() - 1];
                     match parse_captures.get(name)? {

--- a/src/desktop_activity.rs
+++ b/src/desktop_activity.rs
@@ -1,13 +1,10 @@
-use crate::events::{DictationPhase, EventReader, TranscriptPhase, VoiceEvent, VoiceState};
-
-const TRANSCRIPT_LIMIT: usize = 8;
+use crate::events::{DictationPhase, EventReader, VoiceEvent, VoiceState};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct DesktopActivity {
     pub(crate) session_started_at: Option<u64>,
     pub(crate) state: Option<VoiceState>,
     pub(crate) device: Option<String>,
-    pub(crate) transcripts: Vec<String>,
     pub(crate) error: Option<String>,
     pub(crate) last_failure: Option<(u64, String)>,
 }
@@ -44,13 +41,6 @@ impl DesktopActivity {
                     activity.state = Some(*state);
                     activity.device = Some(device.clone());
                 }
-                VoiceEvent::Transcript {
-                    phase: TranscriptPhase::Completed,
-                    text,
-                    ..
-                } if activity.transcripts.len() < TRANSCRIPT_LIMIT && !text.trim().is_empty() => {
-                    activity.transcripts.push(text.clone());
-                }
                 VoiceEvent::Dictation {
                     timestamp_ms,
                     phase: DictationPhase::Failed(message),
@@ -59,12 +49,6 @@ impl DesktopActivity {
                     activity.last_failure = Some((*timestamp_ms, message.clone()));
                 }
                 _ => {}
-            }
-            if activity.session_started_at.is_some()
-                && activity.state.is_some()
-                && activity.transcripts.len() == TRANSCRIPT_LIMIT
-            {
-                break;
             }
         }
         activity
@@ -76,69 +60,51 @@ mod tests {
     use super::*;
 
     #[test]
-    fn projects_latest_state_and_completed_transcripts() {
-        let mut events = vec![
+    fn projects_latest_state_and_device() {
+        let events = [
             VoiceEvent::SessionStarted { timestamp_ms: 1 },
             VoiceEvent::State {
                 timestamp_ms: 2,
                 state: VoiceState::Listening,
                 device: "Old microphone".into(),
             },
+            VoiceEvent::State {
+                timestamp_ms: 3,
+                state: VoiceState::Dictating,
+                device: "Current microphone".into(),
+            },
         ];
-        events.extend((0..10).map(|index| VoiceEvent::Transcript {
-            timestamp_ms: index + 3,
-            phase: TranscriptPhase::Completed,
-            latency_ms: 10,
-            text: format!("Transcript {index}"),
-        }));
-        events.push(VoiceEvent::State {
-            timestamp_ms: 13,
-            state: VoiceState::Dictating,
-            device: "Current microphone".into(),
-        });
-        events.push(VoiceEvent::Transcript {
-            timestamp_ms: 14,
-            phase: TranscriptPhase::Updated,
-            latency_ms: 10,
-            text: "Partial".into(),
-        });
 
         let activity = DesktopActivity::from_events(events.iter().rev());
 
         assert_eq!(activity.session_started_at, Some(1));
         assert_eq!(activity.state, Some(VoiceState::Dictating));
         assert_eq!(activity.device.as_deref(), Some("Current microphone"));
-        assert_eq!(activity.transcripts.len(), TRANSCRIPT_LIMIT);
-        assert_eq!(activity.transcripts[0], "Transcript 9");
-        assert_eq!(activity.transcripts[7], "Transcript 2");
     }
 
     #[test]
-    fn session_boundary_excludes_older_transcripts() {
-        let events = [
-            VoiceEvent::Transcript {
+    fn session_boundary_excludes_older_state_and_device() {
+        let mut events = vec![
+            VoiceEvent::State {
                 timestamp_ms: 1,
-                phase: TranscriptPhase::Completed,
-                latency_ms: 10,
-                text: "Old session".into(),
+                state: VoiceState::Dictating,
+                device: "Old microphone".into(),
             },
             VoiceEvent::SessionStarted { timestamp_ms: 2 },
-            VoiceEvent::State {
-                timestamp_ms: 3,
-                state: VoiceState::Listening,
-                device: "Microphone".into(),
-            },
-            VoiceEvent::Transcript {
-                timestamp_ms: 4,
-                phase: TranscriptPhase::Completed,
-                latency_ms: 10,
-                text: "Current session".into(),
-            },
         ];
-
         let activity = DesktopActivity::from_events(events.iter().rev());
+        assert_eq!(activity.session_started_at, Some(2));
+        assert_eq!(activity.state, None);
+        assert_eq!(activity.device, None);
 
-        assert_eq!(activity.transcripts, ["Current session"]);
+        events.push(VoiceEvent::State {
+            timestamp_ms: 3,
+            state: VoiceState::Listening,
+            device: "Current microphone".into(),
+        });
+        let activity = DesktopActivity::from_events(events.iter().rev());
+        assert_eq!(activity.state, Some(VoiceState::Listening));
+        assert_eq!(activity.device.as_deref(), Some("Current microphone"));
     }
 
     #[test]

--- a/src/desktop_host.rs
+++ b/src/desktop_host.rs
@@ -59,13 +59,10 @@ impl DesktopCapabilities {
 pub(crate) struct DesktopSnapshot {
     pub(crate) activity: DesktopActivity,
     pub(crate) dictation_shortcut: Vec<String>,
-    pub(crate) dictation_shortcut_label: String,
     pub(crate) double_tap_lock: bool,
     pub(crate) double_tap_only: bool,
-    pub(crate) paste_last_shortcut: Option<Vec<String>>,
     pub(crate) listener: Option<DesktopListenerSnapshot>,
     pub(crate) operation_error: Option<String>,
-    pub(crate) observations_path: String,
     pub(crate) transcription: DesktopTranscriptionSnapshot,
     pub(crate) update_status: DesktopUpdateStatus,
 }
@@ -143,13 +140,10 @@ mod tests {
             DesktopSnapshot {
                 activity: DesktopActivity::default(),
                 dictation_shortcut: Vec::new(),
-                dictation_shortcut_label: String::new(),
                 double_tap_lock: false,
                 double_tap_only: false,
-                paste_last_shortcut: None,
                 listener: None,
                 operation_error: None,
-                observations_path: String::new(),
                 transcription: DesktopTranscriptionSnapshot {
                     downloaded_bytes: 0,
                     error: None,

--- a/src/dictation.rs
+++ b/src/dictation.rs
@@ -641,7 +641,7 @@ impl DictationCapture {
     }
 
     #[cfg(any(test, target_os = "linux"))]
-    pub fn ingest(&mut self, samples: &[f32], captured_through: CaptureInstant) -> bool {
+    pub fn ingest(&mut self, samples: &[f32], captured_through: CaptureInstant) {
         self.ingest_with_pending(samples, captured_through, None)
     }
 
@@ -650,7 +650,7 @@ impl DictationCapture {
         samples: &[f32],
         captured_through: CaptureInstant,
         oldest_pending: Option<CaptureInstant>,
-    ) -> bool {
+    ) {
         if let Some(recording) = &mut self.recording {
             recording.push_through(samples, captured_through);
         }
@@ -664,7 +664,6 @@ impl DictationCapture {
             .unwrap_or(TIMELINE_BUFFER_DURATION);
         self.keep_warm_for(samples, retention);
         self.ring_captured_through = Some(captured_through);
-        false
     }
 
     pub fn become_intentional(&mut self, now: CaptureInstant) -> bool {

--- a/src/linux_app.rs
+++ b/src/linux_app.rs
@@ -926,10 +926,8 @@ impl DesktopHost for LinuxDesktopHost {
         DesktopSnapshot {
             activity: self.activity.clone(),
             dictation_shortcut: self.settings.dictation_hotkey.keycaps(),
-            dictation_shortcut_label: self.settings.dictation_hotkey.label(),
             double_tap_lock: self.settings.double_tap_lock,
             double_tap_only: false,
-            paste_last_shortcut: None,
             listener: Some(DesktopListenerSnapshot {
                 running: self.is_running(),
                 status: self.status.clone(),
@@ -945,7 +943,6 @@ impl DesktopHost for LinuxDesktopHost {
                         .filter(|(at, _)| Some(*at) != self.dismissed_failure_at)
                         .map(|(_, message)| message.clone())
                 }),
-            observations_path: self.event_path.display().to_string(),
             transcription: DesktopTranscriptionSnapshot {
                 downloaded_bytes: self
                     .transcription_preparation

--- a/src/recording_environment.rs
+++ b/src/recording_environment.rs
@@ -118,24 +118,20 @@ impl RecordingEnvironmentController {
     }
 
     pub fn begin(&self) -> RecordingEnvironmentSession {
-        let active = self.commands.send(EnvironmentCommand::Start).is_ok();
+        let _ = self.commands.send(EnvironmentCommand::Start);
         RecordingEnvironmentSession {
             commands: self.commands.clone(),
-            active,
         }
     }
 }
 
 pub struct RecordingEnvironmentSession {
     commands: Sender<EnvironmentCommand>,
-    active: bool,
 }
 
 impl Drop for RecordingEnvironmentSession {
     fn drop(&mut self) {
-        if self.active {
-            let _ = self.commands.send(EnvironmentCommand::Stop);
-        }
+        let _ = self.commands.send(EnvironmentCommand::Stop);
     }
 }
 
@@ -390,6 +386,14 @@ mod tests {
         commands.send(EnvironmentCommand::Barrier(reply)).unwrap();
         response.recv_timeout(Duration::from_secs(2)).unwrap();
         assert_eq!(events.try_iter().collect::<Vec<_>>(), expected);
+    }
+
+    #[test]
+    fn sessions_are_harmless_after_the_environment_worker_disconnects() {
+        let (commands, receiver) = mpsc::channel();
+        drop(receiver);
+        let controller = RecordingEnvironmentController { commands };
+        drop(controller.begin());
     }
 
     #[test]

--- a/src/spoken_text.rs
+++ b/src/spoken_text.rs
@@ -5,7 +5,8 @@ pub(crate) fn normalize(text: &str) -> String {
             if word.is_empty() {
                 return None;
             }
-            Some(match word.to_ascii_lowercase().as_str() {
+            let word = word.to_ascii_lowercase();
+            Some(match word.as_str() {
                 "zero" => "0".to_string(),
                 "one" => "1".to_string(),
                 "two" => "2".to_string(),
@@ -16,7 +17,7 @@ pub(crate) fn normalize(text: &str) -> String {
                 "seven" => "7".to_string(),
                 "eight" => "8".to_string(),
                 "nine" => "9".to_string(),
-                _ => word.to_ascii_lowercase(),
+                _ => word,
             })
         })
         .collect::<Vec<_>>()


### PR DESCRIPTION
## Why

Several internal paths maintain state or allocate values that no caller uses. Removing those obligations makes the capture and desktop interfaces easier to follow without changing their behavior.

## What Changes

| Area | Simplification | Preserved behavior |
| --- | --- | --- |
| Desktop activity | Remove the unread recent-transcript cache and unreachable early-exit condition | Current-session state, device, and latest failure remain available; the Activity pane still reads events directly |
| Desktop snapshots | Remove three write-only shortcut/path fields from both platform adapters | Saved shortcuts, displayed controls, and event paths are unchanged |
| Audio ingestion | Remove Boolean returns that were always `false` and ignored by every caller | `become_intentional` remains the explicit hold-threshold transition |
| Recording environment | Remove the session's redundant `active` flag | Balanced start/stop ownership and harmless disconnected-worker cleanup remain intact |
| Command parsing | Iterate phrase parts directly and reuse the lowercase string | Grammar, normalization, and capture values are unchanged |
| SDK fixture | Drain uploads rather than retaining unused chunks | Responses still wait for upload completion |
| Service specification | Link to authoritative SDK types instead of duplicating their declarations | Wire-protocol and lifecycle documentation remains in the spec |

The desktop tests now assert current-session state/device isolation rather than an unused transcript cache. A disconnected-worker test covers the recording-session cleanup path.

## Scope

These are selected behavior-preserving changes from a repository-wide simplification review. The review covered native capture/inference, desktop and Linux adapters, commands, SDKs, iOS, the site, and tooling. Large presentation sections, historical documents, and binary assets were sampled or inventoried rather than exhaustively audited. Larger lifecycle/platform refactors were deferred.

This PR is independent of the shortcut recovery fix in #59. It does not alter shortcut matching, persisted settings, public SDK interfaces, or UI layout. The SDK change is test-only, so no package release or Changeset is needed.

## Verification

```sh
cargo test
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo check --release
git diff --check
cd sdk
bun run --cwd typescript check
bun run --cwd typescript test
bun run --cwd typescript build
```

- Rust: 428 passed, 9 ignored.
- TypeScript SDK: 45 passed; type checking and build pass.
- Formatting, Clippy, and diff whitespace checks pass.
- Release checking passes with the existing unused `call_developer` warning.
- A separate read-only review found no behavioral-equivalence issues.
- Linux compilation/runtime verification is delegated to CI; physical X11/Wayland and microphone smoke tests were not run locally. The installed macOS diagnostic build is unchanged by this cleanup.
