### PR TITLE
fix(macos): match mode applications when Finder shows extensions

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -156,6 +156,19 @@ Selection and stage checks start in
 [personal_commands.rs](../../src/personal_commands.rs). They do not prove live
 provider availability or real application/Brave context changes.
 
+Application activations compare the picker's bundle name with the foreground
+application's localized name. When Finder shows all filename extensions, the
+picker name arrives as `Ghostty.app`; [context.rs](../../src/context.rs) strips
+that suffix on both sides and [app_settings.rs](../../src/app_settings.rs)
+rewrites already persisted activations on load, checked by
+`application_matching_ignores_finder_bundle_extensions` and
+`loading_strips_finder_bundle_extensions_from_mode_applications`.
+
+**Released-version defect:** through 2.1.13, a mode saved with that Finder
+preference enabled never activates and every dictation falls back to Global.
+Workaround until the fix ships: quit HEX, remove the `.app` suffix from
+`dictation_processing.modes[].applications` in `settings.json`, relaunch.
+
 ## Use Voice Action
 
 [Voice Action](voice-action.md) maps the separate opt-in, hold-only shortcut,

--- a/src/app_settings.rs
+++ b/src/app_settings.rs
@@ -664,10 +664,13 @@ impl AppSettings {
                 settings.dictation_processing.default_mode.name = "Global".into();
                 settings.normalize_double_tap_settings();
                 settings.migrate_legacy_replacements();
+                let mode_applications_migrated = settings.normalize_mode_application_names();
                 let transcription_migrated = settings.migrate_disabled_transcription_model();
                 crate::transcription_models::validate(&settings.transcription)?;
                 settings.repair_hotkey_conflict();
-                if (transcription_migrated || microphone_policy_migrated)
+                if (transcription_migrated
+                    || microphone_policy_migrated
+                    || mode_applications_migrated)
                     && let Err(error) = settings.write_to(path)
                 {
                     tracing::warn!(%error, "could not persist the replacement transcription model");
@@ -738,6 +741,30 @@ impl AppSettings {
             .get_or_init(Default::default)
             .write()
             .unwrap_or_else(|error| error.into_inner()) = self.voice_action.clone();
+    }
+
+    /// Mode activations saved while Finder showed filename extensions carry a
+    /// `.app` suffix that never matched the foreground application name.
+    fn normalize_mode_application_names(&mut self) -> bool {
+        let mut migrated = false;
+        let modes = std::iter::once(&mut self.dictation_processing.default_mode)
+            .chain(self.dictation_processing.modes.iter_mut());
+        for mode in modes {
+            let mut mode_migrated = false;
+            for application in &mut mode.applications {
+                let normalized = crate::context::strip_bundle_extension(application).to_owned();
+                if normalized != *application {
+                    *application = normalized;
+                    mode_migrated = true;
+                }
+            }
+            if mode_migrated {
+                mode.applications.sort_by_key(|name| name.to_lowercase());
+                mode.applications.dedup();
+                migrated = true;
+            }
+        }
+        migrated
     }
 
     fn migrate_legacy_replacements(&mut self) {
@@ -1063,6 +1090,34 @@ mod tests {
         drop(reloaded);
         AppSettings::load_from(&path).unwrap();
         assert!(completion_recorded_at(&directory));
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn loading_strips_finder_bundle_extensions_from_mode_applications() {
+        let directory = std::env::temp_dir().join(format!(
+            "hex-mode-applications-{}-{}",
+            std::process::id(),
+            SETTINGS_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed),
+        ));
+        fs::create_dir(&directory).unwrap();
+        let path = directory.join("settings.json");
+        fs::write(
+            &path,
+            br#"{"dictation_processing":{"modes":[{"name":"Code","applications":["Zed.app","Ghostty.app","Zed"]}]}}"#,
+        )
+        .unwrap();
+
+        let settings = AppSettings::load_from(&path).unwrap();
+        assert_eq!(
+            settings.dictation_processing.modes[0].applications,
+            vec!["Ghostty".to_string(), "Zed".to_string()]
+        );
+        let persisted: AppSettings = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(
+            persisted.dictation_processing.modes[0].applications,
+            vec!["Ghostty".to_string(), "Zed".to_string()]
+        );
         fs::remove_dir_all(directory).unwrap();
     }
 

--- a/src/application_catalog.rs
+++ b/src/application_catalog.rs
@@ -87,9 +87,10 @@ pub fn metadata(path: &Path) -> Result<InstalledApplication> {
         let path_string = NSString::from_str(&path.to_string_lossy());
         let bundle = NSBundle::bundleWithPath(&path_string)
             .ok_or_else(|| eyre!("{} is not a readable application bundle", path.display()))?;
-        let name = NSFileManager::defaultManager()
+        let display_name = NSFileManager::defaultManager()
             .displayNameAtPath(&path_string)
             .to_string();
+        let name = crate::context::strip_bundle_extension(&display_name).to_owned();
         let bundle_id = bundle
             .bundleIdentifier()
             .map(|identifier| identifier.to_string());

--- a/src/context.rs
+++ b/src/context.rs
@@ -247,7 +247,22 @@ fn normalize_browser_host(host: &str) -> String {
 }
 
 fn application_names_equal(left: &str, right: &str) -> bool {
-    left.eq_ignore_ascii_case(right)
+    strip_bundle_extension(left).eq_ignore_ascii_case(strip_bundle_extension(right))
+}
+
+/// Removes a trailing `.app` from an application name.
+///
+/// `NSFileManager.displayNameAtPath` honors Finder's "Show all filename
+/// extensions" preference and then returns `Ghostty.app`, while the frontmost
+/// application's `localizedName` is always `Ghostty`. Names are normalized
+/// before they are stored and again when compared so settings written by
+/// either form keep matching.
+pub fn strip_bundle_extension(name: &str) -> &str {
+    let bytes = name.as_bytes();
+    match bytes.len().checked_sub(4) {
+        Some(split) if split > 0 && bytes[split..].eq_ignore_ascii_case(b".app") => &name[..split],
+        _ => name,
+    }
 }
 
 fn browser_hosts_equal(left: &str, right: &str) -> bool {
@@ -276,6 +291,29 @@ mod tests {
         };
 
         assert!(ContextSelector::application("Zed").matches(&context));
+    }
+
+    #[test]
+    fn application_matching_ignores_finder_bundle_extensions() {
+        let context = ContextSnapshot {
+            application: Some("Ghostty".into()),
+            ..ContextSnapshot::default()
+        };
+
+        assert!(ContextSelector::application("Ghostty.app").matches(&context));
+        assert!(ContextSelector::application("ghostty.APP").matches(&context));
+    }
+
+    #[test]
+    fn bundle_extension_stripping_only_removes_a_trailing_suffix() {
+        assert_eq!(strip_bundle_extension("Ghostty.app"), "Ghostty");
+        assert_eq!(
+            strip_bundle_extension("T3 Code (Nightly).app"),
+            "T3 Code (Nightly)"
+        );
+        assert_eq!(strip_bundle_extension("Ghostty"), "Ghostty");
+        assert_eq!(strip_bundle_extension("app.application"), "app.application");
+        assert_eq!(strip_bundle_extension(".app"), ".app");
     }
 
     #[test]


### PR DESCRIPTION
Disclaimer : this has been heavily generated by IA, I am not familiar with Rust but I proof read everything and made sure everything passed. 

I found a workaround by closing Hex, removing the ".app" in the settings.json and reopening Hex so this is not urgent.

## Problem

A dictation mode that activates on an application never matches when Finder's "Show all filename extensions" preference is enabled. Every dictation falls back to the Global mode.

The application picker names an app with `NSFileManager.displayNameAtPath`, which honors that Finder preference and returns `Ghostty.app`. Mode selection compares that stored name with the frontmost application's `NSRunningApplication.localizedName`, which is always `Ghostty`. The comparison in `context.rs` is a plain case-insensitive equality, so `Ghostty.app` never equals `Ghostty`.

Observed on 2.1.13 with `AppleShowAllExtensions = 1`: `settings.json` held `"applications": ["Ghostty.app", "Slack.app", ...]`, `live.ndjson` reported `"application": "Ghostty"`, and `process.log` logged `profile="Global"` for every dictation.

The existing `finder_has_native_picker_metadata_and_an_icon` test also fails on such a machine before this change, because `metadata` returns `Finder.app`.

## Fix

- `application_catalog::metadata` strips a trailing `.app` from the picker name, so new activations are stored the way the foreground context reports them.
- `context::application_names_equal` strips the suffix on both sides, so activations written by either form keep matching. The helper is shared.
- `app_settings::load_from` rewrites already persisted `.app` activations on load and persists the migration like the existing microphone and transcription migrations, so affected users are repaired without touching `settings.json` by hand.
- `docs/features/README.md` records the matching rule, the checks, and the released-version defect with its workaround, per `AGENTS.md`.

## Checks

- `cargo fmt --all --check`
- `cargo test --locked --bin voice-control`: 439 passed, 0 failed (macOS 26, Xcode 26.6, Apple M4 Pro)
- `cargo clippy --locked --bin voice-control --tests -- -D warnings`
- `git diff --check`

New tests: `application_matching_ignores_finder_bundle_extensions`, `bundle_extension_stripping_only_removes_a_trailing_suffix`, `loading_strips_finder_bundle_extensions_from_mode_applications`.

Not covered: the picker UI still compares `mode.applications.contains(&name)` with the catalog name; both sides are now suffix-free, but no GPUI test drives the picker.
