### PR TITLE
fix(transcription): clarify Parakeet v3 language selection

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -48,6 +48,36 @@ Permissions revoked later
 Apple silicon, macOS 15+. Choices come from the compiled model/language catalog;
 Apple Speech is currently excluded from the desktop picker.
 
+```ts
+Choose a supported language              // setup.language-conditioning; macOS + Linux picker
+├── Parakeet v3 -> Detect language from audio; selected language does not constrain output
+└── Whisper -> Use selected language to guide decoding; accuracy is not guaranteed
+```
+
+Parakeet v3 remains available for Portuguese and its other existing language
+choices. Its card explains the limitation and suggests Whisper for
+language-guided transcription. This does not change saved selections or expand
+the Auto picker choices. Multilingual audio support is not language conditioning:
+the pinned v3 GGUF has no `stt.parakeet.prompt.num_prompts` metadata, which gates
+language prompting in `transcribe-cpp-sys` 0.1.3.
+
+Sources: [model catalog](../../src/transcription_models.rs),
+[shared picker](../../src/desktop_transcription_picker.rs), and the runtime
+options in [parakeet.rs](../../src/parakeet.rs) and
+[linux_transcriber.rs](../../src/linux_transcriber.rs). The regression
+`parakeet_v3_supports_portuguese_without_language_conditioning` checks that the
+Portuguese selection remains valid and available, sends no runtime language
+hint, and contrasts Whisper's `pt` hint. It does not run inference.
+The regression was observed failing with the old metadata and passing after the
+correction. The macOS release picker preview built, but screenshot capture was
+blocked by missing Screen Recording access; visual layout remains unverified.
+
+**Unreproduced recognition report:** [#68](https://github.com/anomalyco/hex/issues/68)
+reports Portuguese speech misrecognized as English. Source and pinned-model
+metadata inspection establish the prompting limitation, not the cause or repair
+of those transcripts. No v3 audio reproduction or transcription-quality fix has
+been demonstrated.
+
 Checks start in [onboarding.rs](../../src/onboarding.rs),
 [transcription.rs](../../src/transcription.rs), and
 [transcription_models.rs](../../src/transcription_models.rs). Setup/picker previews

--- a/src/desktop_transcription_picker.rs
+++ b/src/desktop_transcription_picker.rs
@@ -184,6 +184,18 @@ pub(crate) fn render_transcription_picker<T: TranscriptionPickerDelegate>(
                         definition.quality,
                     )),
             )
+            .when(definition.id == TranscriptionModelId::ParakeetV3, |card| {
+                card.child(
+                    div()
+                        .pt_3()
+                        .text_size(px(12.0))
+                        .text_color(rgb(MUTED))
+                        .child(
+                            "Detects language from audio, not the selected language. \
+                             For language-guided transcription, try Whisper.",
+                        ),
+                )
+            })
             .when_some(progress, |card, progress| {
                 let indicator = match progress {
                     TranscriptionPickerProgress::Downloading(progress) => div()
@@ -321,6 +333,7 @@ pub(crate) fn render_transcription_picker<T: TranscriptionPickerDelegate>(
                             div()
                                 .id("transcription-model-list")
                                 .flex_1()
+                                .min_w_0()
                                 .h_full()
                                 .p_5()
                                 .overflow_y_scroll()

--- a/src/transcription_models.rs
+++ b/src/transcription_models.rs
@@ -345,7 +345,8 @@ pub const MODELS: &[ModelDefinition] = &[
         timestamps: "Token timestamps",
         runtime: ModelRuntime::Gguf(&PARAKEET_V3_ARTIFACT),
         languages: PARAKEET_V3_LANGUAGES,
-        accepts_language_hint: true,
+        // The pinned v3 artifact detects language from audio and has no prompt input.
+        accepts_language_hint: false,
         supports_language_detection: false,
         supports_recognition_hints: false,
     },
@@ -999,6 +1000,33 @@ mod tests {
         assert_eq!(whisper.runtime_language_hint("fil"), Some("tl"));
         assert_eq!(qwen.runtime_language_hint(AUTO_LANGUAGE), None);
         assert_eq!(qwen.runtime_language_hint("zh"), Some("zh"));
+    }
+
+    #[test]
+    fn parakeet_v3_supports_portuguese_without_language_conditioning() {
+        let selection = TranscriptionSelection {
+            model: TranscriptionModelId::ParakeetV3,
+            language: "pt".into(),
+            recognition_hints: String::new(),
+        };
+        let model = validate(&selection).unwrap();
+        assert_eq!(model.id, TranscriptionModelId::ParakeetV3);
+        assert!(
+            choices_for_runtime("pt")
+                .iter()
+                .any(|choice| choice.model.id == model.id)
+        );
+        assert_eq!(model.runtime_language_hint(&selection.language), None);
+        assert_eq!(
+            definition(TranscriptionModelId::WhisperLargeV3Turbo)
+                .runtime_language_hint(&selection.language),
+            Some("pt")
+        );
+        assert!(
+            !choices_for_runtime(AUTO_LANGUAGE)
+                .iter()
+                .any(|choice| choice.model.id == model.id)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Selecting Portuguese with Parakeet v3 looks like it should guide transcription, but the pinned model identifies language from audio instead. HEX currently marks it as accepting a language hint even though that hint does not condition decoding. Related to #68.

## What Changes

- Mark Parakeet v3 as not accepting a runtime language hint. Portuguese remains a valid, available selection; Whisper still receives `pt`.
- Add a note to its shared macOS/Linux model card: “Detects language from audio, not the selected language. For language-guided transcription, try Whisper.”
- Document the distinction between multilingual support and language conditioning, with a regression covering selection validity, availability, and the runtime hint.

## Language Conditioning

In `transcribe-cpp-sys` 0.1.3, Parakeet reads `params->language` for decoding only when the encoder has a prompt input. That input requires positive `stt.parakeet.prompt.num_prompts` metadata. All 58 metadata entries in the pinned v3 GGUF header were inspected: Portuguese is supported and language detection is advertised, but the prompt key is absent. This agrees with [NVIDIA's model description](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3), which describes transcription without language prompting.

## Demo

Before and after release previews built and launched with the deterministic
Portuguese/installed fixture. Screenshot capture failed with `could not create
image from window`; `CGPreflightScreenCaptureAccess()` returned false. No
screenshots are attached, and visual layout remains unverified. No permissions
were changed.

## Scope

This is a metadata and UI clarification, not a demonstrated transcription-quality repair. #68 remains open: the reported audio failure has not been reproduced. Saved selections and Auto picker eligibility are unchanged; trying Whisper is a suggestion, not an accuracy guarantee.

## Verification

```sh
# Commands SDK prerequisite, from sdk/
bun install --frozen-lockfile
bun run --cwd commands build

# From the repository root
cargo fmt --check
CMAKE=/opt/homebrew/bin/cmake cargo test --locked --bin voice-control transcription_models::tests
CMAKE=/opt/homebrew/bin/cmake cargo test --locked --bin voice-control desktop_transcription_picker::tests
CMAKE=/opt/homebrew/bin/cmake cargo test --locked
CMAKE=/opt/homebrew/bin/cmake cargo clippy --locked --all-targets --all-features -- -D warnings
git diff --check

# Run on the base and changed source, with before/after output paths
CMAKE=/opt/homebrew/bin/cmake ./scripts/capture-preview.sh /private/var/folders/dd/5fz89drs5p9_r0fk7rwqqnbr0000gn/T/opencode/hex-68-before.png transcription-picker --language pt --model-state installed
CMAKE=/opt/homebrew/bin/cmake ./scripts/capture-preview.sh /private/var/folders/dd/5fz89drs5p9_r0fk7rwqqnbr0000gn/T/opencode/hex-68-after.png transcription-picker --language pt --model-state installed
```

- Regression observed red with the old metadata (`Some("pt")` instead of `None`), then green.
- Focused checks: 11 model-catalog tests and 1 existing picker test passed.
- Full suite: 440 passed, 9 ignored; all 12 keyboard-layout child processes passed. The first run failed the commands-workspace test because the fresh worktree lacked generated SDK resources; building the prerequisite above resolved it without source changes.
- Clippy, formatting, and diff whitespace checks passed.
- Release builds succeeded with the existing unused `call_developer` warning. Both capture commands failed at screenshot creation, as described above.
- No v3 inference, live microphone, paste, or Linux-native UI testing was performed.
