### PR TITLE
fix(macos): start quietly when the Dock icon is hidden

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -200,6 +200,36 @@ Menu bar and Settings                    // maintenance
 ```
 
 ```ts
+Launch Hex                               // maintain.startup
+├── Setup incomplete / permissions or model missing -> Open setup or Settings
+├── Show Dock icon on -> Open Settings
+└── Show Dock icon off + usable menu-bar item -> No startup window
+    ├── Dictation starts independently of the Settings window
+    └── Menu-bar Settings / Finder or Spotlight reopen -> Open or focus the window
+
+Menu-bar installation fails -> Show Dock icon and open the window // recovery access
+```
+
+The existing **Show Dock icon** preference controls quiet startup; there is no
+additional launch-window setting. This applies to normal and login launches,
+does not change login registration, and does not hide an already open window
+when the preference changes. Explicit previews always open their requested pane.
+
+Checks in [meeting_watcher.rs](../../src/meeting_watcher.rs):
+`dockless_startup_stays_quiet_only_when_setup_and_menu_bar_are_ready` and
+`dock_visible_startup_always_opens_the_app` cover the startup decision. The
+existing `on_reopen` and status-item `OpenSettings` paths bypass that decision.
+These checks do not establish signed-app login behavior or native Finder/Spotlight
+reopening; those still need an installed-app smoke test. This addresses the
+menu-bar-only case in [#64](https://github.com/anomalyco/hex/issues/64), not an
+independent window preference for users keeping the Dock icon visible.
+
+**Executed September 3, 2026:** 441 Rust tests passed (nine opt-in tests ignored),
+along with all twelve keyboard-layout child scenarios, formatting, and Clippy.
+The release Settings preview built and launched, but window screenshot capture
+failed; no visual or installed-app startup verification is claimed.
+
+```ts
 Update available                         // maintain.updates
 ├── Sidebar Update -> Sparkle update dialog
 └── Menu bar > Check for Updates -> Same dialog

--- a/src/app_window.rs
+++ b/src/app_window.rs
@@ -3743,7 +3743,7 @@ impl AppWindow {
                                     .child(
                                         settings_row(
                                             "Show Dock icon",
-                                            "Keep HEX visible in the Dock while it is running",
+                                            "When off, HEX starts quietly in the menu bar after setup",
                                             toggle(dock_icon_position),
                                         )
                                         .id("dock-icon-setting")

--- a/src/meeting_watcher.rs
+++ b/src/meeting_watcher.rs
@@ -116,6 +116,15 @@ pub fn preview_shell(
     run_with_shell_preview(shutdown, false, None, false, Some(preview))
 }
 
+fn should_open_app_on_launch(
+    show_dock_icon: bool,
+    setup_ready: bool,
+    onboarding_completed: bool,
+    status_item_available: bool,
+) -> bool {
+    show_dock_icon || !setup_ready || !onboarding_completed || !status_item_available
+}
+
 fn run_with_shell_preview(
     shutdown: &'static AtomicBool,
     preview: bool,
@@ -135,6 +144,7 @@ fn run_with_shell_preview(
     };
     let show_dock_icon = settings.show_dock_icon;
     let setup_ready = crate::onboarding::status(&settings.transcription).ready();
+    let onboarding_completed = shell_preview.is_some() || crate::onboarding::completion_recorded();
     let history = if listener.is_some() {
         match crate::history::History::open_default(settings.history_retention) {
             Ok(history) => Some(history),
@@ -179,8 +189,6 @@ fn run_with_shell_preview(
     let shell_event_path = app_event_path
         .clone()
         .unwrap_or_else(|| meeting_project_root.join("logs/live.ndjson"));
-    let show_app_on_launch =
-        shell_preview.is_some() || app_event_path.is_some() && !dictation_preview;
     let (event_sender, event_receiver) = mpsc::sync_channel(32);
     let (command_sender, command_receiver) = mpsc::sync_channel(8);
     let (meeting_request_sender, meeting_request_receiver) = mpsc::sync_channel(8);
@@ -418,6 +426,12 @@ fn run_with_shell_preview(
             None
         };
         crate::app_settings::set_dock_icon_visible(show_dock_icon || status_actions.is_none());
+        let show_app_on_launch = should_open_app_on_launch(
+            show_dock_icon,
+            setup_ready,
+            onboarding_completed,
+            status_actions.is_some(),
+        );
         let open_result = match shell_preview.clone() {
             Some(preview) => Some(crate::app_window::open_preview(
                 &app_window,
@@ -428,7 +442,7 @@ fn run_with_shell_preview(
                 preview,
                 cx,
             )),
-            None => app_event_path.map(|event_path| {
+            None if show_app_on_launch => app_event_path.map(|event_path| {
                 crate::app_window::open_or_focus(
                     &app_window,
                     event_path,
@@ -440,8 +454,9 @@ fn run_with_shell_preview(
                     cx,
                 )
             }),
+            None => None,
         };
-        if show_app_on_launch && let Some(Err(error)) = open_result {
+        if let Some(Err(error)) = open_result {
             tracing::error!(%error, "could not open HEX");
         }
         let quit_shutdown = shutdown;
@@ -1091,4 +1106,45 @@ pub fn probe() -> Result<()> {
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dockless_startup_stays_quiet_only_when_setup_and_menu_bar_are_ready() {
+        for setup_ready in [false, true] {
+            for onboarding_completed in [false, true] {
+                for status_item_available in [false, true] {
+                    assert_eq!(
+                        should_open_app_on_launch(
+                            false,
+                            setup_ready,
+                            onboarding_completed,
+                            status_item_available,
+                        ),
+                        !(setup_ready && onboarding_completed && status_item_available),
+                        "setup_ready={setup_ready}, onboarding_completed={onboarding_completed}, status_item_available={status_item_available}",
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn dock_visible_startup_always_opens_the_app() {
+        for setup_ready in [false, true] {
+            for onboarding_completed in [false, true] {
+                for status_item_available in [false, true] {
+                    assert!(should_open_app_on_launch(
+                        true,
+                        setup_ready,
+                        onboarding_completed,
+                        status_item_available,
+                    ));
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Why

HEX opens Settings on every app launch, even when the user has hidden its Dock icon. That makes a background voice utility interrupt startup and login unnecessarily.

Addresses the menu-bar-only startup case in #64 by reusing **Show Dock icon**, rather than introducing another preference.

## What Changes

**Before:** a normal app launch opens Settings regardless of Dock visibility.

**After:** with the Dock icon hidden, completed setup, healthy permissions/model, and a successfully installed menu-bar item, HEX starts without opening a window. Dictation startup remains independent of Settings.

```mermaid
flowchart TD
    Launch[Launch HEX] --> Setup{Setup complete and ready?}
    Setup -- No --> Window[Open setup or Settings]
    Setup -- Yes --> Dock{Show Dock icon?}
    Dock -- Yes --> Window
    Dock -- No --> Menu{Menu-bar item installed?}
    Menu -- No --> Fallback[Show Dock icon and open Settings]
    Menu -- Yes --> Quiet[Start without a window]
```

- Menu-bar Settings and explicit Finder/Spotlight reopen still open or focus the window. Those paths are not gated by the startup decision.
- Turning the Dock setting off does not close an already open window.
- The existing setting now explains: “When off, HEX starts quietly in the menu bar after setup”.
- Explicit pane previews remain visible.

## Demo

The release Settings preview built and launched, but screenshot capture failed with `could not create image from window`. No screenshot or native startup/reopen demonstration is claimed.

## Scope

macOS startup-window policy, setting copy, and feature-map documentation. Login registration is unchanged, and there is no separate window preference for users who keep the Dock icon visible. No installed app or live preferences were changed during verification.

## Verification

```sh
cargo fmt --all --check
CMAKE=/opt/homebrew/bin/cmake cargo test --locked --bin voice-control
CMAKE=/opt/homebrew/bin/cmake cargo test --locked --test keyboard_layout
CMAKE=/opt/homebrew/bin/cmake cargo clippy --locked --all-targets --all-features -- -D warnings
git diff --check
CMAKE=/opt/homebrew/bin/cmake ./scripts/capture-preview.sh "$TMPDIR/hex-quiet-startup-settings.png" settings
```

- 441 tests passed, 9 opt-in tests ignored. New tests cover all 16 combinations of Dock visibility, setup readiness, onboarding completion, and menu-bar availability.
- All 12 keyboard-layout child scenarios passed; formatting, Clippy, and whitespace checks passed.
- The release preview build succeeded with an existing unused `call_developer` warning. Screenshot capture failed as noted above.
- Still unverified: signed-app launch at login, native Finder/Spotlight reopening after quiet startup, and physical dictation after quiet startup. Decision tests are not native end-to-end proof.